### PR TITLE
Make rhui-check.py work properly on RHEL 10

### DIFF
--- a/Linux_scripts/rhui-check/rhui-check.py
+++ b/Linux_scripts/rhui-check/rhui-check.py
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/bin/env python
 
 import argparse
 import logging
@@ -45,11 +45,6 @@ class CustomFormatter(logging.Formatter):
 
 
 
-if os.geteuid() != 0:
-   logger.critical('This script needs to execute with root privileges')
-   logger.critical('You could leverage the sudo tool to gain administrative privileges')
-   exit(1)
-
 def start_logging(debug_level = False):
     """This function sets up the logging configuration for the script and writes the log to /var/log/rhuicheck.log"""
 
@@ -86,6 +81,11 @@ parser.add_argument(  '--debug','-d',
 args = parser.parse_args()
 logger = start_logging(args.debug)
 
+if os.geteuid() != 0:
+   logger.critical('This script needs to execute with root privileges')
+   logger.critical('You could leverage the sudo tool to gain administrative privileges')
+   exit(1)
+
 try:
     import requests
 except ImportError:
@@ -118,7 +118,7 @@ class localParser(configparser.ConfigParser):
         return d
 
 def get_host(url):
-    urlregex = '[^:]*://([^/]*)/.*'
+    urlregex = r'[^:]*://([^/]*)/.*'
     host_match = re.match(urlregex, url)
     return host_match.group(1)
 
@@ -172,6 +172,7 @@ def connect_to_host(url, selection, mysection):
     url = url+"/repodata/repomd.xml"
     url = url.replace('$releasever',releasever)
     url = url.replace('$basearch',basearch)
+    url = url.replace('$arch',basearch)
     logger.debug('baseurl for repo {} is {}'.format(mysection, url))
 
     headers = {'content-type': 'application/json'}
@@ -357,7 +358,7 @@ def get_proxies(parser_object, mysection):
     proxy_info = dict()
 
     # proxy_regex = '(^[^:]*)(:(//)(([^:]*)(:([^@]*)){0,1}@){0,1}.*)?'
-    proxy_regex = '(^[^:]*):(//)(([^:]*)(:([^@]*)){0,1}@){0,1}.*'
+    proxy_regex = r'(^[^:]*):(//)(([^:]*)(:([^@]*)){0,1}@){0,1}.*'
 
     for key in ['proxy', 'proxy_user', 'proxy_password']:
         try:
@@ -444,13 +445,13 @@ def check_repos(reposconfig):
     global eus 
 
     logger.debug('Entering microsoft_repo()')
-    rhuirepo = '^(rhui-)?microsoft.*'
-    eusrepo  = '.*-(eus|e4s)-.*'
+    rhuirepo = r'^(rhui-)?microsoft.*'
+    eusrepo  = r'.*-(eus|e4s)-.*'
     microsoft_reponame = ''
     enabled_repos = list()
 
     for repo_name in reposconfig.sections():
-        if re.match('\[*default\]*', repo_name):
+        if re.match(r'\[*default\]*', repo_name):
             continue
 
         try:
@@ -542,7 +543,7 @@ def connect_to_repos(reposconfig, check_repos):
 
     for repo_name in check_repos:
 
-        if re.match('\[*default\]*', repo_name):
+        if re.match(r'\[*default\]*', repo_name):
             continue
 
         try:


### PR DESCRIPTION
This PR fixes a few issues I encountered when testing to ensure it works properly on RHEL 10. In the order that you'll encounter them in the diff:

1. Fix the shebang line to correctly state this is a python script, not a bash script. With this corrected you could also run it by setting the execute bit and running directly: `chmod +x rhui-check.py; ./rhui-check.py`
2. In the "not root" case `logger` was referenced before it was defined.
3. Regexes should always be defined in `r''` raw strings. Otherwise unexpected behavior or (on RHEL 10) syntax warnings can occur, as python will attempt to apply regular string [escape sequences](https://docs.python.org/3/reference/lexical_analysis.html#escape-sequences) before interpreting the regex.
4. [most importantly] The repo baseurls for RHEL 10 contain `$arch`, not `$basearch`, so you must replace that in the url too or this tool will say that every repo returns a 403 (because it's trying a non-existent URL).

Update: Abandoning in favor of https://github.com/Azure/azure-support-scripts/pull/61