### PR TITLE
Windows VM assist updates

### DIFF
--- a/vmassist/windows/vmassist.ps1
+++ b/vmassist/windows/vmassist.ps1
@@ -2259,7 +2259,7 @@ else
     Out-Log $machineKeysHasDefaultPermissions -color Cyan -endLine
     $details = "$machineKeysPath folder does not have default NTFS permissions<br>SDDL: $machineKeysSddl<br>$machineKeysAccessString"
     New-Check -name 'MachineKeys folder permissions' -result 'Info' -details $details
-    $mitigation = '<a href="https://learn.microsoft.com/en-us/troubleshoot/azure/virtual-machines/troubleshoot-extension-certificates-issues-windows-vm#solution-2-fix-the-access-control-list-acl-in-the-machinekeys-or-systemkeys-folders">Troubleshoot extension certificates</a>'
+    $mitigation = 'The default permissions on "C:\ProgramData\Microsoft\Crypto\RSA\MachineKeys" have been altered. If incorrect permissions are given on this directory then it may block an extension from decrypting its protected settings. If the Guest Agent status is Ready, but extensions with protected settings are failing to install then <a href="https://learn.microsoft.com/en-us/troubleshoot/azure/virtual-machines/troubleshoot-extension-certificates-issues-windows-vm#solution-2-fix-the-access-control-list-acl-in-the-machinekeys-or-systemkeys-folders">troubleshoot extension certificates</a>'
     New-Finding -type Information -name 'Non-default MachineKeys permissions' -description $details -mitigation $mitigation
 }
 

--- a/vmassist/windows/vmassist.ps1
+++ b/vmassist/windows/vmassist.ps1
@@ -1164,7 +1164,7 @@ function Get-ExtensionHandlers
     return $extensionHandlers
 }
 
-# Tests if the built in System account has Full access to a directory
+# Tests if the built in System account has Full Control to a directory and its subfolders/files
 function Test-SystemFullAccess {
     [CmdletBinding()]
     param(
@@ -2281,7 +2281,7 @@ if ($isVMAgentInstalled)
         Out-Log $windowsAzureAllowsSystemFullAccess -color Cyan -endLine
         $details = "The System account does not have full access to $windowsAzureFolderPath"
         New-Check -name "$windowsAzureFolderPath permissions" -result 'Info' -details $details
-        New-Finding -type Information -name "Non-default $windowsAzureFolderPath permissions" -description $details -mitigation 'The C:\WindowsAzure directory has been changed from its default permissions. Ensure the built-in System account has Full control to this folder, subfolder, and directories in order for the Guest Agent to work properly.'
+        New-Finding -type Information -name "Non-default $windowsAzureFolderPath permissions" -description $details -mitigation 'The built-in System account does not have Full control of the C:\WindowsAzure directory. Ensure the built-in System account has Full control to this folder, subfolder, and directories in order for the Guest Agent to work properly.'
     }
 }
 else
@@ -2308,7 +2308,7 @@ if ($isVMAgentInstalled)
         Out-Log $packagesAllowsSystemFullAccess -color Cyan -endLine
         $details = "The System account does not have full access to $packagesFolderPath"
         New-Check -name "$packagesFolderPath permissions" -result 'Info' -details $details
-        New-Finding -type Information -name "Non-default $packagesFolderPath permissions" -description $details -mitigation 'The C:\Packages directory has been changed from its default permissions. Ensure the built-in System account has Full control to this folder, subfolder, and directories in order for the Guest Agent to work properly.'
+        New-Finding -type Information -name "Non-default $packagesFolderPath permissions" -description $details -mitigation 'The built-in System account does not have Full control of the C:\Packages directory. Ensure the built-in System account has Full control to this folder, subfolder, and directories in order for the Guest Agent to work properly.'
     }
 }
 else

--- a/vmassist/windows/vmassist.ps1
+++ b/vmassist/windows/vmassist.ps1
@@ -1793,7 +1793,7 @@ if ($isVMAgentInstalled)
 # If you are using a proxy, you will get its value under the ProxyServer key.
 # This gets the same settings as running "netsh winhttp show proxy"
 $proxyConfigured = $false
-Out-Log 'Netsh Proxy configured:' -startLine
+Out-Log 'Netsh proxy configured:' -startLine
 $netshWinhttpShowProxyOutput = netsh winhttp show proxy
 Out-Log "`$netshWinhttpShowProxyOutput: $netshWinhttpShowProxyOutput" -verboseOnly
 $proxyServers = $netshWinhttpShowProxyOutput | Select-String -SimpleMatch 'Proxy Server(s)' | Select-Object -ExpandProperty Line

--- a/vmassist/windows/vmassist.ps1
+++ b/vmassist/windows/vmassist.ps1
@@ -387,6 +387,7 @@ function Get-ThirdPartyLoadedModules
         [string]$processName
     )
     $microsoftWindowsProductionPCA2011 = 'CN=Microsoft Windows Production PCA 2011, O=Microsoft Corporation, L=Redmond, S=Washington, C=US'
+    $microsoftCodeSigningPCA2011 = 'CN=Microsoft Code Signing PCA 2011, O=Microsoft Corporation, L=Redmond, S=Washington, C=US'
     Out-Log "Third-party modules in $($processName):" -startLine
     if ($isVMAgentInstalled)
     {
@@ -401,7 +402,7 @@ function Get-ThirdPartyLoadedModules
                     $filePath = $processThirdPartyModule.FileName
                     $signature = Invoke-ExpressionWithLogging "Get-AuthenticodeSignature -FilePath '$filePath' -ErrorAction SilentlyContinue" -verboseOnly
                     $issuer = $signature.SignerCertificate.Issuer
-                    if ($issuer -eq $microsoftWindowsProductionPCA2011)
+                    if ($issuer -eq $microsoftWindowsProductionPCA2011 -or $issuer -eq $microsoftCodeSigningPCA2011)
                     {
                         $processThirdPartyModules = $processThirdPartyModules | Where-Object {$_.FileName -ne $filePath}
                     }

--- a/vmassist/windows/vmassist.ps1
+++ b/vmassist/windows/vmassist.ps1
@@ -1890,14 +1890,14 @@ Out-Log "$machinePoliciesInternetSettingsKeyPath\ProxySettingsPerUser: $proxySet
 
 if ($proxyConfigured)
 {
-    New-Check -name 'Netsh Proxy configured' -result 'Info' -details $proxyServers
+    New-Check -name 'Netsh proxy configured' -result 'Info' -details $proxyServers
     Out-Log $proxyConfigured -color Cyan -endLine
     $mitigation = '<a href="https://learn.microsoft.com/en-us/troubleshoot/azure/virtual-machines/windows-azure-guest-agent#solution-3-enable-dhcp-and-make-sure-that-the-server-isnt-blocked-by-firewalls-proxies-or-other-sources">Ensure the proxy is not blocking connectivity to 168.63.129.16 on ports 80 or 32526</a>'
-    New-Finding -type Information -name 'Netsh Proxy configured' -description $proxyServers -mitigation $mitigation
+    New-Finding -type Information -name 'Netsh proxy configured' -description $proxyServers -mitigation $mitigation
 }
 else
 {
-    New-Check -name 'Netsh Proxy configured' -result 'OK' -details 'No netsh proxy detected'
+    New-Check -name 'Netsh proxy configured' -result 'OK' -details 'No netsh proxy detected'
     Out-Log $proxyConfigured -color Green -endLine
 }
 

--- a/vmassist/windows/vmassist.ps1
+++ b/vmassist/windows/vmassist.ps1
@@ -1173,12 +1173,14 @@ function Test-SystemFullAccess {
 
     try {
         $acl = Get-Acl -Path $Path
+        $fullControl = [System.Security.AccessControl.FileSystemRights]::FullControl
+
         $systemAccess = $acl.Access | Where-Object {
             $_.IdentityReference -eq 'NT AUTHORITY\SYSTEM' -and
-            $_.FileSystemRights -band [System.Security.AccessControl.FileSystemRights]::FullControl -and
+            ($_.FileSystemRights -band $fullControl) -eq $fullControl -and
             $_.AccessControlType -eq 'Allow' -and
-            $_.InheritanceFlags -band ([System.Security.AccessControl.InheritanceFlags]::ContainerInherit) -and
-            $_.InheritanceFlags -band ([System.Security.AccessControl.InheritanceFlags]::ObjectInherit) -and
+            ($_.InheritanceFlags -band [System.Security.AccessControl.InheritanceFlags]::ContainerInherit) -ne 0 -and
+            ($_.InheritanceFlags -band [System.Security.AccessControl.InheritanceFlags]::ObjectInherit) -ne 0 -and
             $_.PropagationFlags -eq [System.Security.AccessControl.PropagationFlags]::None
         }
 

--- a/vmassist/windows/vmassist.ps1
+++ b/vmassist/windows/vmassist.ps1
@@ -200,7 +200,7 @@ function Get-WCFConfig
         $global:dbgMachineConfigStrings = $machineConfigStrings
         $description = "$machineConfigx64FilePath shows WCF debugging is enabled:<p>$matchesString<p>"
         $global:dbgDescription = $description
-        New-Finding -type Critical -name 'WCF debugging enabled' -description $description -mitigation 'We recommend only enabling WCF debugging while debugging a WCF issue. Please disable WCF debugging'
+        New-Finding -type Critical -name 'WCF debugging enabled' -description $description -mitigation 'We recommend only enabling WCF debugging while debugging a WCF issue. Please disable WCF debugging. Please see the following <a href="https://learn.microsoft.com/en-us/azure/virtual-machines/extensions/agent-windows#manual-installation">article for more steps.</a>'
     }
     else
     {
@@ -1611,7 +1611,7 @@ if ($winmgmt.Status -eq 'Running')
         Out-Log $stdRegProvQuerySuccess -color Red -endLine
         New-Check -name 'StdRegProv WMI class' -result 'FAILED' -details 'StdRegProv WMI class query failed'
         $description = "StdRegProv WMI class query failed with error code $stdRegProvReturnValue"
-        New-Finding -type Critical -name 'StdRegProv WMI class query failed' -description $description -mitigation ''
+        New-Finding -type Critical -name 'StdRegProv WMI class query failed' -description $description -mitigation 'The VM agent .msi file uses WMI StdRegProv to access the registry. If this is not working properly then installing the VM Guest Agent via MSI will fail. See this <a href="https://learn.microsoft.com/en-us/azure/virtual-machines/extensions/agent-windows#manual-installation">article for steps on how to fix it</a>'
     }
 }
 else

--- a/vmassist/windows/vmassist.ps1
+++ b/vmassist/windows/vmassist.ps1
@@ -2194,33 +2194,27 @@ if ($showFilters -eq $true)
 }
 
 #Validates permissions on the MachineKeys folder
-$machineKeysDefaultSddl = 'O:SYG:SYD:PAI(A;;0x12019f;;;WD)(A;;FA;;;BA)'
 Out-Log 'MachineKeys folder has default permissions:' -startLine
 $machineKeysPath = 'C:\ProgramData\Microsoft\Crypto\RSA\MachineKeys'
-$machineKeysAcl = Get-Acl -Path $machineKeysPath
-$machineKeysSddl = $machineKeysAcl | Select-Object -ExpandProperty Sddl
-$machineKeysAccess = $machineKeysAcl | Select-Object -ExpandProperty Access
-$machineKeysAccessString = $machineKeysAccess | ForEach-Object {"$($_.IdentityReference) $($_.AccessControlType) $($_.FileSystemRights)"}
-$machineKeysAccessString = $machineKeysAccessString -join '<br>'
 
-if ($machineKeysSddl -eq $machineKeysDefaultSddl)
+$machineKeysAllowsSystemFullAccess = Test-SystemFullAccess($machineKeysPath)
+
+if ($machineKeysAllowsSystemFullAccess)
 {
-    $machineKeysHasDefaultPermissions = $true
-    Out-Log $machineKeysHasDefaultPermissions -color Green -endLine
-    $details = "$machineKeysPath folder has default NTFS permissions" # <br>SDDL: $machineKeysSddl<br>$machineKeysAccessString"
-    New-Check -name 'MachineKeys folder permissions' -result 'OK' -details $details
+    Out-Log $machineKeysAllowsSystemFullAccess -color Green -endLine
+    $details = "The System account has full access to $machineKeysPath" 
+    New-Check -name '$machineKeysPath permissions' -result 'OK' -details $details
 }
 else
 {
-    $machineKeysHasDefaultPermissions = $false
-    Out-Log $machineKeysHasDefaultPermissions -color Cyan -endLine
-    $details = "$machineKeysPath folder does not have default NTFS permissions<br>SDDL: $machineKeysSddl<br>$machineKeysAccessString"
+    Out-Log $machineKeysAllowsSystemFullAccess -color Cyan -endLine
+    $details = "The System account does not have full access to $machineKeysPath"
     New-Check -name 'MachineKeys folder permissions' -result 'Info' -details $details
     $mitigation = '<a href="https://learn.microsoft.com/en-us/troubleshoot/azure/virtual-machines/troubleshoot-extension-certificates-issues-windows-vm#solution-2-fix-the-access-control-list-acl-in-the-machinekeys-or-systemkeys-folders">Troubleshoot extension certificates</a>'
     New-Finding -type Information -name 'Non-default MachineKeys permissions' -description $details -mitigation $mitigation
 }
 
-# Permissions on $env:SystemDrive\WindowsAzure and $env:SystemDrive\Packages folder during startup.
+# Permissions on $env:SystemDriveand $env:SystemDrive\Packages folder during startup.
 # It first removes all user/groups and then sets the following permission
 # (Read & Execute: Everyone, Full Control: SYSTEM & Local Administrators only) to these folders.
 # If GA fails to remove/set the permission, it can't proceed further.

--- a/vmassist/windows/vmassist.ps1
+++ b/vmassist/windows/vmassist.ps1
@@ -1890,14 +1890,14 @@ Out-Log "$machinePoliciesInternetSettingsKeyPath\ProxySettingsPerUser: $proxySet
 
 if ($proxyConfigured)
 {
-    New-Check -name 'Proxy configured' -result 'Info' -details $proxyServers
+    New-Check -name 'Netsh Proxy configured' -result 'Info' -details $proxyServers
     Out-Log $proxyConfigured -color Cyan -endLine
     $mitigation = '<a href="https://learn.microsoft.com/en-us/troubleshoot/azure/virtual-machines/windows-azure-guest-agent#solution-3-enable-dhcp-and-make-sure-that-the-server-isnt-blocked-by-firewalls-proxies-or-other-sources">Ensure the proxy is not blocking connectivity to 168.63.129.16 on ports 80 or 32526</a>'
     New-Finding -type Information -name 'Proxy configured' -description $proxyServers -mitigation $mitigation
 }
 else
 {
-    New-Check -name 'Proxy configured' -result 'OK' -details 'No proxy detected'
+    New-Check -name 'Netsh Proxy configured' -result 'OK' -details 'No netsh proxy detected'
     Out-Log $proxyConfigured -color Green -endLine
 }
 

--- a/vmassist/windows/vmassist.ps1
+++ b/vmassist/windows/vmassist.ps1
@@ -1793,7 +1793,7 @@ if ($isVMAgentInstalled)
 # If you are using a proxy, you will get its value under the ProxyServer key.
 # This gets the same settings as running "netsh winhttp show proxy"
 $proxyConfigured = $false
-Out-Log 'Proxy configured:' -startLine
+Out-Log 'Netsh Proxy configured:' -startLine
 $netshWinhttpShowProxyOutput = netsh winhttp show proxy
 Out-Log "`$netshWinhttpShowProxyOutput: $netshWinhttpShowProxyOutput" -verboseOnly
 $proxyServers = $netshWinhttpShowProxyOutput | Select-String -SimpleMatch 'Proxy Server(s)' | Select-Object -ExpandProperty Line

--- a/vmassist/windows/vmassist.ps1
+++ b/vmassist/windows/vmassist.ps1
@@ -2281,7 +2281,7 @@ if ($isVMAgentInstalled)
         Out-Log $windowsAzureAllowsSystemFullAccess -color Cyan -endLine
         $details = "The System account does not have full access to $windowsAzureFolderPath"
         New-Check -name "$windowsAzureFolderPath permissions" -result 'Info' -details $details
-        New-Finding -type Information -name "Non-default $windowsAzureFolderPath permissions" -description $details -mitigation 'The built-in System account does not have Full control of the C:\WindowsAzure directory. Ensure the built-in System account has Full control to this folder, subfolder, and directories in order for the Guest Agent to work properly.'
+        New-Finding -type Information -name "Non-default $windowsAzureFolderPath permissions" -description $details -mitigation 'The built-in System account does not have Full control of the C:\WindowsAzure directory. If you are unable to install the Guest Agent or the Guest Agent services fail to start due to "Access denied", then ensure that the built-in System account has Full control of C:\WindowsAzure applied to this folder, subfolder, and directories.'
     }
 }
 else
@@ -2308,7 +2308,7 @@ if ($isVMAgentInstalled)
         Out-Log $packagesAllowsSystemFullAccess -color Cyan -endLine
         $details = "The System account does not have full access to $packagesFolderPath"
         New-Check -name "$packagesFolderPath permissions" -result 'Info' -details $details
-        New-Finding -type Information -name "Non-default $packagesFolderPath permissions" -description $details -mitigation 'The built-in System account does not have Full control of the C:\Packages directory. Ensure the built-in System account has Full control to this folder, subfolder, and directories in order for the Guest Agent to work properly.'
+        New-Finding -type Information -name "Non-default $packagesFolderPath permissions" -description $details -mitigation 'The built-in System account does not have Full control of the C:\Packages directory. If you are unable to install the Guest Agent/Extensions or the Guest Agent services fail to start due to "Access denied", then ensure that the built-in System account has Full control of C:\Packages applied to this folder, subfolder, and directories.'
     }
 }
 else

--- a/vmassist/windows/vmassist.ps1
+++ b/vmassist/windows/vmassist.ps1
@@ -1893,7 +1893,7 @@ if ($proxyConfigured)
     New-Check -name 'Netsh Proxy configured' -result 'Info' -details $proxyServers
     Out-Log $proxyConfigured -color Cyan -endLine
     $mitigation = '<a href="https://learn.microsoft.com/en-us/troubleshoot/azure/virtual-machines/windows-azure-guest-agent#solution-3-enable-dhcp-and-make-sure-that-the-server-isnt-blocked-by-firewalls-proxies-or-other-sources">Ensure the proxy is not blocking connectivity to 168.63.129.16 on ports 80 or 32526</a>'
-    New-Finding -type Information -name 'Proxy configured' -description $proxyServers -mitigation $mitigation
+    New-Finding -type Information -name 'Netsh Proxy configured' -description $proxyServers -mitigation $mitigation
 }
 else
 {


### PR DESCRIPTION
- Updated mitigations
- Updated how the permission checks for C:\WindowsAzure and C:\Packages work. Instead of just checking default values it will check if the Systema account has Full control
- Starting with .1172 it appears that the Guest Agent has another Microsoft cert it uses to sign its loaded modules. Added 'CN=Microsoft Code Signing PCA 2011, O=Microsoft Corporation, L=Redmond, S=Washington, C=US' in the 3rd party module check
- Use PowerShell to check for StdRegProv since that should work regardless of Windows version