### PR TITLE
Add 51 Windows RunCommand diagnostic scripts + triage map

### DIFF
--- a/RunCommand/Windows/TRIAGE-MAP.md
+++ b/RunCommand/Windows/TRIAGE-MAP.md
@@ -1,0 +1,727 @@
+# Windows VM Diagnostic Scripts — Find the Right Script for Your Problem
+
+You have a problem with your Azure Windows VM. This page helps you find the right diagnostic script fast — no need to browse through dozens of folders.
+
+**Pick the problem you're seeing**, run the scripts in order, and check the output. Each script tells you what's wrong and links to a fix.
+
+## I can't connect to my VM with Remote Desktop (RDP)
+
+| Run | Script | What it checks |
+|---|---|---|
+| 1 | [RDP_Health_Snapshot](Windows_RDP_Health_Snapshot/) | Remote Desktop service running, port 3389 open, firewall allows RDP |
+| 2 | [TLS_Cipher_RDP_Compatibility_Audit](Windows_TLS_Cipher_RDP_Compatibility_Audit/) | TLS settings compatible with your RDP client |
+| 3 | [RDP_Certificate_Binding_Check](Windows_RDP_Certificate_Binding_Check/) | RDP certificate present and not expired |
+| 4 | [Firewall_Profile_Baseline_Check](Windows_Firewall_Profile_Baseline_Check/) | Windows Firewall isn't blocking Remote Desktop |
+| 5 | [Network_IMDS_Reachability](Windows_Network_IMDS_Reachability/) | VM can communicate with Azure (network adapter, default route, Azure endpoints) |
+
+**If your VM is domain-joined and you can't sign in:** also run [Domain_Trust_SecureChannel_Check](Windows_Domain_Trust_SecureChannel_Check/) → [TimeSync_Kerberos_Health](Windows_TimeSync_Kerberos_Health/) → [UserProfileService_Health](Windows_UserProfileService_Health/).
+
+## My VM won't start or is stuck during boot
+
+| Run | Script | What it checks |
+|---|---|---|
+| 1 | [Service_Boot_Audit](Windows_Service_Boot_Audit/) | Boot mode (Safe Mode, recovery), event log accessibility |
+| 2 | [Service_Dependency_Break_Check](Windows_Service_Dependency_Break_Check/) | Core Windows services that must start (RPC, DCOM, Service Control Manager) |
+| 3 | [GroupPolicy_Processing_Health](Windows_GroupPolicy_Processing_Health/) | Group Policy processing — common cause of startup hangs |
+| 4 | [ServiceStartupTimeout_Check](Windows_ServiceStartupTimeout_Check/) | Services taking too long to start |
+| 5 | [BootPolicy_Drift_Check](Windows_BootPolicy_Drift_Check/) | Boot configuration (BCD) entries haven't been altered |
+
+**Stuck at "Applying Group Policy"?** Start at step 3.
+**Blue screen or unexpected restart?** Jump to [My VM crashed (blue screen) or keeps restarting](#my-vm-crashed-blue-screen-or-keeps-restarting).
+
+## Windows services are failing or won't start
+
+| Run | Script | What it checks |
+|---|---|---|
+| 1 | [Service_Dependency_Break_Check](Windows_Service_Dependency_Break_Check/) | Core services (RPC, DCOM) that other services depend on |
+| 2 | [RPC_EndpointMapper_Check](Windows_RPC_EndpointMapper_Check/) | RPC endpoint mapper on port 135 — many services need this |
+| 3 | [ServiceStartupTimeout_Check](Windows_ServiceStartupTimeout_Check/) | Services that are hung or timing out during startup |
+| 4 | [TaskScheduler_Health](Windows_TaskScheduler_Health/) | Task Scheduler service and any failed scheduled tasks |
+| 5 | [EventLog_Channel_Health](Windows_EventLog_Channel_Health/) | Event Log service working — needed to diagnose service failures |
+
+## Azure VM Agent shows "Not Ready" in the portal
+
+The VM Agent coordinates all extensions. If it's not working, no extensions will work.
+
+| Run | Script | What it checks |
+|---|---|---|
+| 1 | [VM_Agent_Health_Dump](Windows_VM_Agent_Health_Dump/) | VM Agent and RdAgent services running, heartbeat recent, error log |
+| 2 | [Network_IMDS_Reachability](Windows_Network_IMDS_Reachability/) | VM can reach Azure endpoints (168.63.129.16 and 169.254.169.254) |
+| 3 | [Service_Dependency_Break_Check](Windows_Service_Dependency_Break_Check/) | Core Windows services the agent depends on |
+| 4 | [Firewall_Profile_Baseline_Check](Windows_Firewall_Profile_Baseline_Check/) | Firewall not blocking Azure endpoints |
+| 5 | [RouteTable_Anomaly_Check](Windows_RouteTable_Anomaly_Check/) | Custom routes not overriding Azure communication paths |
+
+## An extension is failing — start here (applies to all extensions)
+
+Before troubleshooting a specific extension, confirm the extension platform itself is healthy. Run these first regardless of which extension is failing.
+
+| Run | Script | What it checks |
+|---|---|---|
+| 1 | [VM_Agent_Health_Dump](Windows_VM_Agent_Health_Dump/) | VM Agent working, shows status of every installed extension |
+| 2 | [Extension_Install_Chain_Health](Windows_Extension_Install_Chain_Health/) | Extension installation pipeline: registry entries, plugin folder, Azure endpoint reachable, agent log errors |
+| 3 | [Network_IMDS_Reachability](Windows_Network_IMDS_Reachability/) | VM can reach Azure — extensions need this to download and report status |
+| 4 | [Disk_Filesystem_Audit](Windows_Disk_Filesystem_Audit/) | Enough disk space on C: — extensions can't install if the disk is full |
+| 5 | [Proxy_WinHTTP_WinINET_Check](Windows_Proxy_WinHTTP_WinINET_Check/) | Proxy not blocking extension downloads |
+| 6 | [SChannel_CertStore_Health](Windows_SChannel_CertStore_Health/) | No expired certificates blocking secure connections |
+
+If everything above passes, find your specific extension below.
+
+---
+
+### Custom Script Extension won't run or is stuck "Transitioning"
+
+Extension name: `Microsoft.Compute.CustomScriptExtension`
+
+| Run | Script | What it checks |
+|---|---|---|
+| 1–6 | **[Run the shared baseline above](#an-extension-is-failing--start-here-applies-to-all-extensions)** | Covers the most common blockers: disk full, proxy, certificates |
+| 7 | [Firewall_Profile_Baseline_Check](Windows_Firewall_Profile_Baseline_Check/) | Outbound connections to your storage account (port 443) not blocked |
+| 8 | [DNS_NameResolution_Health](Windows_DNS_NameResolution_Health/) | DNS can resolve your storage account URL |
+| 9 | [EventLog_Channel_Health](Windows_EventLog_Channel_Health/) | Application event log for errors |
+
+**Where to find logs:** `C:\Packages\Plugins\Microsoft.Compute.CustomScriptExtension\<version>\Status\` for status, `...\Downloads\` for downloaded script files. Check the output file to see if it's a script error vs. a platform error.
+
+---
+
+### Azure Disk Encryption (ADE) failed to enable or decrypt
+
+Extension name: `Microsoft.Azure.Security.AzureDiskEncryption`
+
+| Run | Script | What it checks |
+|---|---|---|
+| 1–6 | **[Run the shared baseline above](#an-extension-is-failing--start-here-applies-to-all-extensions)** | Extension platform healthy |
+| 7 | [Encryption_State_Check](Windows_Encryption_State_Check/) | Current BitLocker state, ADE settings, which drives are encrypted |
+| 8 | [BitLocker_KeyProtector_Audit](Windows_BitLocker_KeyProtector_Audit/) | Encryption key protectors, TPM status, recovery key available |
+| 9 | [Disk_Filesystem_Audit](Windows_Disk_Filesystem_Audit/) | Dirty volumes — encryption can't start on a volume with pending repairs |
+| 10 | [GroupPolicy_Processing_Health](Windows_GroupPolicy_Processing_Health/) | Group Policy may enforce conflicting BitLocker settings |
+
+**Where to find logs:** `C:\Packages\Plugins\Microsoft.Azure.Security.AzureDiskEncryption\<version>\Status\`. If the extension shows "Succeeded" but the disk isn't encrypted, it's a BitLocker configuration issue — start at step 7.
+
+---
+
+### Monitoring agent not reporting data (MMA, AMA, or Azure Diagnostics)
+
+Extension names:
+- `Microsoft.EnterpriseCloud.Monitoring.MicrosoftMonitoringAgent` (Log Analytics agent / MMA)
+- `Microsoft.Azure.Monitor.AzureMonitorWindowsAgent` (Azure Monitor Agent / AMA)
+- `Microsoft.Azure.Diagnostics.IaaSDiagnostics` (Windows Azure Diagnostics / WAD)
+
+| Run | Script | What it checks |
+|---|---|---|
+| 1–6 | **[Run the shared baseline above](#an-extension-is-failing--start-here-applies-to-all-extensions)** | Extension platform healthy |
+| 7 | [WinRM_Remoting_Health](Windows_WinRM_Remoting_Health/) | WinRM service — the Log Analytics agent uses this |
+| 8 | [Firewall_Profile_Baseline_Check](Windows_Firewall_Profile_Baseline_Check/) | Outbound port 443 open to your Log Analytics workspace |
+| 9 | [DNS_NameResolution_Health](Windows_DNS_NameResolution_Health/) | Can resolve `*.ods.opinsights.azure.com` (your workspace URL) |
+| 10 | [EventLog_Channel_Health](Windows_EventLog_Channel_Health/) | Event log channels readable — this is where your data comes from |
+| 11 | [EventForwarding_WEF_Health](Windows_EventForwarding_WEF_Health/) | Windows Event Forwarding not conflicting with Azure Monitor collection |
+| 12 | [Resource_Pressure_Snapshot](Windows_Resource_Pressure_Snapshot/) | Monitoring agent using too much CPU or memory |
+
+**Where to find logs:**
+- MMA: `C:\Program Files\Microsoft Monitoring Agent\Agent\Health Service State\`
+- AMA: `C:\WindowsAzure\Resources\AMAData\`
+- WAD: `C:\Packages\Plugins\Microsoft.Azure.Diagnostics.IaaSDiagnostics\<version>\`
+
+---
+
+### Azure Update Manager / Patch extension not working
+
+Extension name: `Microsoft.CPlat.Core.WindowsPatchExtension`
+
+| Run | Script | What it checks |
+|---|---|---|
+| 1–6 | **[Run the shared baseline above](#an-extension-is-failing--start-here-applies-to-all-extensions)** | Extension platform healthy |
+| 7 | [WU_PendingActions_Check](Windows_WU_PendingActions_Check/) | Pending reboot, stuck updates, Windows Update service health |
+| 8 | [Disk_Filesystem_Audit](Windows_Disk_Filesystem_Audit/) | Disk space — updates need room to download and stage |
+| 9 | [SFC_DISM_Health_Signal](Windows_SFC_DISM_Health_Signal/) | Windows component store health — corruption blocks patching |
+| 10 | [Service_Dependency_Break_Check](Windows_Service_Dependency_Break_Check/) | Windows Update, Cryptographic Services, and BITS running |
+| 11 | [Proxy_WinHTTP_WinINET_Check](Windows_Proxy_WinHTTP_WinINET_Check/) | Proxy not blocking Microsoft update download endpoints |
+
+**Where to find logs:** `C:\Packages\Plugins\Microsoft.CPlat.Core.WindowsPatchExtension\<version>\Status\`. Common: the extension reports "Succeeded" but patches didn't install — that's a Windows Update issue, start at step 7.
+
+---
+
+### DSC (Desired State Configuration) extension failing
+
+Extension name: `Microsoft.Powershell.DSC`
+
+| Run | Script | What it checks |
+|---|---|---|
+| 1–6 | **[Run the shared baseline above](#an-extension-is-failing--start-here-applies-to-all-extensions)** | Extension platform healthy |
+| 7 | [WinRM_Remoting_Health](Windows_WinRM_Remoting_Health/) | DSC uses WinRM to apply configurations |
+| 8 | [GroupPolicy_Processing_Health](Windows_GroupPolicy_Processing_Health/) | Group Policy can conflict with DSC configurations |
+| 9 | [Service_Dependency_Break_Check](Windows_Service_Dependency_Break_Check/) | WMI and WinRM services running |
+| 10 | [EventLog_Channel_Health](Windows_EventLog_Channel_Health/) | DSC event log: `Microsoft-Windows-DSC/Operational` |
+
+**Where to find logs:** `C:\Packages\Plugins\Microsoft.Powershell.DSC\<version>\Status\` and Windows event log under `Microsoft-Windows-DSC/Operational`. To check current DSC state, run `Get-DscLocalConfigurationManager` in PowerShell.
+
+---
+
+### BGInfo extension not updating the desktop
+
+Extension name: `Microsoft.Compute.BGInfo`
+
+| Run | Script | What it checks |
+|---|---|---|
+| 1–6 | **[Run the shared baseline above](#an-extension-is-failing--start-here-applies-to-all-extensions)** | Extension platform healthy |
+| 7 | [UserProfileService_Health](Windows_UserProfileService_Health/) | BGInfo writes to the desktop — profile issues block it |
+
+BGInfo rarely fails on its own. If it's the only extension failing, it's usually a disk space issue (step 4 in the baseline) or stale extension state. Try removing and re-adding the extension from the Azure portal.
+
+---
+
+### VM Access extension (password reset or RDP re-enable) not working
+
+Extension name: `Microsoft.Compute.VMAccessAgent`
+
+| Run | Script | What it checks |
+|---|---|---|
+| 1–6 | **[Run the shared baseline above](#an-extension-is-failing--start-here-applies-to-all-extensions)** | Extension platform healthy |
+| 7 | [RDP_Health_Snapshot](Windows_RDP_Health_Snapshot/) | If you used VM Access to fix RDP — check if RDP is working now |
+| 8 | [Firewall_Profile_Baseline_Check](Windows_Firewall_Profile_Baseline_Check/) | VM Access re-enables the RDP firewall rule — verify it took effect |
+| 9 | [UserProfileService_Health](Windows_UserProfileService_Health/) | Password reset succeeded but you still can't sign in — may be a profile issue |
+
+---
+
+### Dependency Agent (VM Insights) not reporting
+
+Extension name: `Microsoft.Azure.Monitoring.DependencyAgent`
+
+| Run | Script | What it checks |
+|---|---|---|
+| 1–6 | **[Run the shared baseline above](#an-extension-is-failing--start-here-applies-to-all-extensions)** | Extension platform healthy |
+| 7 | [Resource_Pressure_Snapshot](Windows_Resource_Pressure_Snapshot/) | Dependency Agent can use significant CPU |
+| 8 | [Firewall_Profile_Baseline_Check](Windows_Firewall_Profile_Baseline_Check/) | Outbound to Log Analytics workspace |
+| 9 | [Service_Dependency_Break_Check](Windows_Service_Dependency_Break_Check/) | MicrosoftDependencyAgent service running |
+
+---
+
+### My extension isn't listed above
+
+For any other extension (Qualys, Symantec, Chef, Puppet, third-party marketplace extensions):
+
+| Run | Script | What it checks |
+|---|---|---|
+| 1–6 | **[Run the shared baseline above](#an-extension-is-failing--start-here-applies-to-all-extensions)** | All extensions use the same installation pipeline |
+| 7 | [Firewall_Profile_Baseline_Check](Windows_Firewall_Profile_Baseline_Check/) | Extension may need outbound access to vendor servers |
+| 8 | [DNS_NameResolution_Health](Windows_DNS_NameResolution_Health/) | Can resolve the vendor's server address |
+| 9 | [EventLog_Channel_Health](Windows_EventLog_Channel_Health/) | Application event log for errors |
+| 10 | [GroupPolicy_Processing_Health](Windows_GroupPolicy_Processing_Health/) | Group Policy may restrict extension behavior |
+| 11 | [DriverSignature_Integrity_Check](Windows_DriverSignature_Integrity_Check/) | Code signing enforcement — can block unsigned extension binaries |
+
+**Where to find extension logs (any extension):** `C:\Packages\Plugins\<Publisher.ExtensionType>\<version>\Status\` for status JSON, and the same folder for extension-specific logs.
+
+## Run Command itself isn't working
+
+If you can't use Run Command to execute these diagnostic scripts.
+
+| Run | Script | What it checks |
+|---|---|---|
+| 1 | [WinRM_Remoting_Health](Windows_WinRM_Remoting_Health/) | WinRM service running, listeners configured, certificates |
+| 2 | [Firewall_Profile_Baseline_Check](Windows_Firewall_Profile_Baseline_Check/) | Ports 5985/5986 (WinRM) not blocked |
+| 3 | [SChannel_CertStore_Health](Windows_SChannel_CertStore_Health/) | HTTPS certificate valid |
+| 4 | [Network_IMDS_Reachability](Windows_Network_IMDS_Reachability/) | VM can communicate with Azure for Run Command delivery |
+
+## Network or DNS issues (not RDP-specific)
+
+| Run | Script | What it checks |
+|---|---|---|
+| 1 | [Network_IMDS_Reachability](Windows_Network_IMDS_Reachability/) | Network adapter present, default route exists, Azure endpoints reachable |
+| 2 | [DNS_NameResolution_Health](Windows_DNS_NameResolution_Health/) | DNS servers configured, name resolution working |
+| 3 | [Firewall_Profile_Baseline_Check](Windows_Firewall_Profile_Baseline_Check/) | Windows Firewall profiles and rules |
+| 4 | [Proxy_WinHTTP_WinINET_Check](Windows_Proxy_WinHTTP_WinINET_Check/) | Proxy configuration and bypass settings |
+| 5 | [RouteTable_Anomaly_Check](Windows_RouteTable_Anomaly_Check/) | Route table for unexpected or missing routes |
+| 6 | [NetworkBinding_Order_Check](Windows_NetworkBinding_Order_Check/) | Network adapter binding order |
+| 7 | [NIC_AdvancedProperties_Baseline](Windows_NIC_AdvancedProperties_Baseline/) | Network adapter advanced settings |
+| 8 | [IPv6_RDP_Path_Check](Windows_IPv6_RDP_Path_Check/) | IPv6 configuration and dual-stack behavior |
+| 9 | [SMB_Client_Health](Windows_SMB_Client_Health/) | SMB/file sharing configuration |
+
+## Slow VM or high CPU/memory usage
+
+| Run | Script | What it checks |
+|---|---|---|
+| 1 | [Resource_Pressure_Snapshot](Windows_Resource_Pressure_Snapshot/) | Current CPU, memory, and commit charge |
+| 2 | [PowerPlan_Throttling_Check](Windows_PowerPlan_Throttling_Check/) | Power plan — "Balanced" can throttle performance on VMs |
+| 3 | [Startup_Delay_Analyzer](Windows_Startup_Delay_Analyzer/) | Slow boot contributors |
+| 4 | [Disk_Filesystem_Audit](Windows_Disk_Filesystem_Audit/) | Disk space, temp drive, pagefile |
+| 5 | [Port_Ephemeral_Exhaustion_Check](Windows_Port_Ephemeral_Exhaustion_Check/) | Running out of network ports (common under heavy load) |
+
+## My VM crashed (blue screen) or keeps restarting
+
+| Run | Script | What it checks |
+|---|---|---|
+| 1 | [CrashDump_Config_Validator](Windows_CrashDump_Config_Validator/) | Crash dump configured correctly to capture the next crash |
+| 2 | [CrashHistory_Bugcheck_Summary](Windows_CrashHistory_Bugcheck_Summary/) | Existing crash dumps — bugcheck codes and frequency |
+| 3 | [ReliabilityMonitor_Event_Signal](Windows_ReliabilityMonitor_Event_Signal/) | Reliability history — application and system failures |
+| 4 | [Service_Boot_Audit](Windows_Service_Boot_Audit/) | Boot mode and recovery state |
+| 5 | [BootPolicy_Drift_Check](Windows_BootPolicy_Drift_Check/) | Boot configuration hasn't been altered |
+
+## Disk or storage problems
+
+| Run | Script | What it checks |
+|---|---|---|
+| 1 | [Disk_Filesystem_Audit](Windows_Disk_Filesystem_Audit/) | Disk space, pagefile, temp drive (D:), dirty volumes |
+| 2 | [NTFS_Integrity_Check](Windows_NTFS_Integrity_Check/) | Volume health, dirty bit, disk errors |
+| 3 | [StorageSpaces_Health](Windows_StorageSpaces_Health/) | Storage Spaces/S2D pool and virtual disk health |
+| 4 | [DriverStore_Health](Windows_DriverStore_Health/) | Driver store size and integrity |
+| 5 | [VSS_Writer_Health](Windows_VSS_Writer_Health/) | Volume Shadow Copy writers — needed for backups and snapshots |
+
+## Can't sign in with domain account or trust relationship broken
+
+| Run | Script | What it checks |
+|---|---|---|
+| 1 | [Domain_Trust_SecureChannel_Check](Windows_Domain_Trust_SecureChannel_Check/) | Domain membership, secure channel to domain controller |
+| 2 | [TimeSync_Kerberos_Health](Windows_TimeSync_Kerberos_Health/) | Clock sync — Kerberos authentication fails if time is off by more than 5 minutes |
+| 3 | [DomainJoin_Readiness](Windows_DomainJoin_Readiness/) | DNS and domain controller reachability |
+| 4 | [GroupPolicy_Processing_Health](Windows_GroupPolicy_Processing_Health/) | Group Policy can apply — NETLOGON/SYSVOL accessible |
+| 5 | [UserProfileService_Health](Windows_UserProfileService_Health/) | User profile loading correctly |
+
+## BitLocker, encryption, or security configuration
+
+| Run | Script | What it checks |
+|---|---|---|
+| 1 | [Encryption_State_Check](Windows_Encryption_State_Check/) | BitLocker state, Azure Disk Encryption settings |
+| 2 | [BitLocker_KeyProtector_Audit](Windows_BitLocker_KeyProtector_Audit/) | Encryption key protectors, TPM, recovery key |
+| 3 | [SChannel_CertStore_Health](Windows_SChannel_CertStore_Health/) | Certificate store, TLS configuration, expired certs |
+| 4 | [LSA_SSP_Baseline_Check](Windows_LSA_SSP_Baseline_Check/) | Local Security Authority and authentication providers |
+| 5 | [Defender_Health_Snapshot](Windows_Defender_Health_Snapshot/) | Windows Defender status, definition updates, real-time protection |
+| 6 | [DriverSignature_Integrity_Check](Windows_DriverSignature_Integrity_Check/) | Driver signing enforcement |
+
+## Windows Update problems
+
+| Run | Script | What it checks |
+|---|---|---|
+| 1 | [WU_PendingActions_Check](Windows_WU_PendingActions_Check/) | Pending reboot, stuck updates, Windows Update service |
+| 2 | [SFC_DISM_Health_Signal](Windows_SFC_DISM_Health_Signal/) | Windows component store health — run this if updates keep failing |
+| 3 | [Disk_Filesystem_Audit](Windows_Disk_Filesystem_Audit/) | Disk space — updates need free space to download and install |
+
+## Backup or snapshot failures
+
+| Run | Script | What it checks |
+|---|---|---|
+| 1 | [VSS_Writer_Health](Windows_VSS_Writer_Health/) | Volume Shadow Copy writers and service — needed for Azure Backup |
+| 2 | [EventLog_Channel_Health](Windows_EventLog_Channel_Health/) | Event log service health |
+| 3 | [CrashDump_Config_Validator](Windows_CrashDump_Config_Validator/) | Crash dump readiness for post-incident recovery |
+
+## Event logs or monitoring not collecting data
+
+| Run | Script | What it checks |
+|---|---|---|
+| 1 | [EventLog_Channel_Health](Windows_EventLog_Channel_Health/) | Event Log service, System/Application/Security channels |
+| 2 | [EventForwarding_WEF_Health](Windows_EventForwarding_WEF_Health/) | Windows Event Forwarding configuration |
+| 3 | [WinRM_Remoting_Health](Windows_WinRM_Remoting_Health/) | WinRM service — used by some monitoring solutions |
+
+---
+
+## I'm not sure what's wrong
+
+Run these three first — they cover the most ground:
+
+1. **[Network_IMDS_Reachability](Windows_Network_IMDS_Reachability/)** — Can the VM talk to Azure?
+2. **[Service_Dependency_Break_Check](Windows_Service_Dependency_Break_Check/)** — Are core Windows services running?
+3. **[EventLog_Channel_Health](Windows_EventLog_Channel_Health/)** — Can the VM collect diagnostic data?
+
+Then look at the `-- Decision --` block in each script's output — it tells you the severity and what to do next.
+
+---
+
+## How to run these scripts
+
+### From the Azure portal
+1. Go to your VM in the [Azure portal](https://portal.azure.com)
+2. Select **Operations → Run Command → RunPowerShellScript**
+3. Paste the contents of the `.ps1` file from the script folder
+4. Select **Run** and wait for the output
+
+### From Azure CLI
+```bash
+az vm run-command invoke -g <resource-group> -n <vm-name> \
+  --command-id RunPowerShellScript \
+  --scripts @<FolderName>/<ScriptName>.ps1
+```
+
+## How to read the output
+
+Every script gives you the same format:
+
+```
+=== Script Name ===
+Check                                        Status
+-------------------------------------------- ------
+Some diagnostic check                        OK
+Another check                                FAIL
+...
+-- Decision --
+Likely cause severity                        FAIL   Hard configuration/service break
+Next action                                  OK     Follow README interpretation ...
+-- More Info --
+Remediation references available             OK     See paired README Learn References
+
+=== RESULT: X OK / Y FAIL / Z WARN ===
+```
+
+- **FAIL** = this is broken and needs to be fixed
+- **WARN** = not broken yet, but should be investigated
+- **OK** = healthy, no action needed
+
+Open the script's **README.md** for a detailed explanation of every FAIL and WARN — including the likely cause, how to fix it, and links to Microsoft Learn documentation.
+# Windows RunCommand Diagnostic Triage Map
+
+Use this page when you have a **symptom** and need the fastest path to the right diagnostic script.
+
+Don't browse 70 folders — start with the signal you have.
+
+## Can't RDP into the VM
+
+| Order | Script | What it checks |
+|---|---|---|
+| 1 | [RDP_Health_Snapshot](Windows_RDP_Health_Snapshot/) | RDP service, port 3389 listener, firewall rule, TermService, NLA |
+| 2 | [TLS_Cipher_RDP_Compatibility_Audit](Windows_TLS_Cipher_RDP_Compatibility_Audit/) | TLS 1.2 server enabled, SecurityLayer, NLA setting, legacy TLS |
+| 3 | [RDP_Certificate_Binding_Check](Windows_RDP_Certificate_Binding_Check/) | RDP cert thumbprint, cert present + not expired, NLA, port bind |
+| 4 | [Firewall_Profile_Baseline_Check](Windows_Firewall_Profile_Baseline_Check/) | Profiles enabled, RDP rule, inbound default, BFE service |
+| 5 | [Network_IMDS_Reachability](Windows_Network_IMDS_Reachability/) | NIC present, default route, WireServer, IMDS endpoint |
+
+**If domain-joined and "can't sign in":** also run [Domain_Trust_SecureChannel_Check](Windows_Domain_Trust_SecureChannel_Check/) → [TimeSync_Kerberos_Health](Windows_TimeSync_Kerberos_Health/) → [UserProfileService_Health](Windows_UserProfileService_Health/).
+
+## VM won't boot or is stuck at boot
+
+| Order | Script | What it checks |
+|---|---|---|
+| 1 | [Service_Boot_Audit](Windows_Service_Boot_Audit/) | SafeBoot, boot recovery, event log access |
+| 2 | [Service_Dependency_Break_Check](Windows_Service_Dependency_Break_Check/) | Auto-start failures, RpcSs, DcomLaunch, SCM errors |
+| 3 | [GroupPolicy_Processing_Health](Windows_GroupPolicy_Processing_Health/) | GPSvc, operational log, GP errors, NETLOGON/SYSVOL |
+| 4 | [ServiceStartupTimeout_Check](Windows_ServiceStartupTimeout_Check/) | Timeout thresholds, hung service detection |
+| 5 | [BootPolicy_Drift_Check](Windows_BootPolicy_Drift_Check/) | BCD entries, boot configuration drift |
+
+**If stuck at "Applying Group Policy":** start at step 3.
+**If BSOD/unexpected restart:** jump to the [Crash & BSOD](#crash--bsod--unexpected-restart) section.
+
+## Services failing or cascading failures
+
+| Order | Script | What it checks |
+|---|---|---|
+| 1 | [Service_Dependency_Break_Check](Windows_Service_Dependency_Break_Check/) | RpcSs, DcomLaunch, auto-start failures, SCM error volume |
+| 2 | [RPC_EndpointMapper_Check](Windows_RPC_EndpointMapper_Check/) | RPC endpoint mapper, port 135, DCOM |
+| 3 | [ServiceStartupTimeout_Check](Windows_ServiceStartupTimeout_Check/) | Timeout thresholds, hung services |
+| 4 | [TaskScheduler_Health](Windows_TaskScheduler_Health/) | Scheduler service, failed tasks, event errors |
+| 5 | [EventLog_Channel_Health](Windows_EventLog_Channel_Health/) | EventLog service, System/Application/Security log readable |
+
+## VM agent not reporting or offline
+
+The agent itself is the problem — extensions can't run at all.
+
+| Order | Script | What it checks |
+|---|---|---|
+| 1 | [VM_Agent_Health_Dump](Windows_VM_Agent_Health_Dump/) | GuestAgent + RdAgent services, heartbeat freshness, log errors |
+| 2 | [Network_IMDS_Reachability](Windows_Network_IMDS_Reachability/) | WireServer 168.63.129.16, IMDS 169.254.169.254, default route |
+| 3 | [Service_Dependency_Break_Check](Windows_Service_Dependency_Break_Check/) | RpcSs, DcomLaunch — agent depends on these |
+| 4 | [Firewall_Profile_Baseline_Check](Windows_Firewall_Profile_Baseline_Check/) | Firewall blocking 168.63.129.16 or 169.254.169.254 |
+| 5 | [RouteTable_Anomaly_Check](Windows_RouteTable_Anomaly_Check/) | UDR overriding fabric routes |
+
+## Extension issues — shared baseline (run first for ANY extension)
+
+Before diving into per-extension scripts, confirm the install pipeline is healthy.
+
+| Order | Script | What it checks |
+|---|---|---|
+| 1 | [VM_Agent_Health_Dump](Windows_VM_Agent_Health_Dump/) | Confirm agent IS healthy — per-handler status (Ready/NotReady/Unresponsive) |
+| 2 | [Extension_Install_Chain_Health](Windows_Extension_Install_Chain_Health/) | Handler registry, C:\Packages\Plugins accessible, WireServer, agent log errors |
+| 3 | [Network_IMDS_Reachability](Windows_Network_IMDS_Reachability/) | WireServer + IMDS reachable — extensions need both |
+| 4 | [Disk_Filesystem_Audit](Windows_Disk_Filesystem_Audit/) | C: drive space — extensions can't stage if disk is full |
+| 5 | [Proxy_WinHTTP_WinINET_Check](Windows_Proxy_WinHTTP_WinINET_Check/) | Proxy blocking extension package download (storage blob URLs) |
+| 6 | [SChannel_CertStore_Health](Windows_SChannel_CertStore_Health/) | Expired certs — blocks TLS to blob storage for package download |
+
+If baseline is clean, jump to the specific extension section below.
+
+---
+
+### CustomScriptExtension (CSE) — stuck Transitioning, timeout, script errors
+
+`Microsoft.Compute.CustomScriptExtension` / `Microsoft.Azure.Extensions.CustomScript`
+
+| Order | Script | Why |
+|---|---|---|
+| 1–6 | **Run shared baseline above** | CSE downloads from storage — disk, proxy, certs are top blockers |
+| 7 | [Firewall_Profile_Baseline_Check](Windows_Firewall_Profile_Baseline_Check/) | Outbound to storage account blocked (443) |
+| 8 | [DNS_NameResolution_Health](Windows_DNS_NameResolution_Health/) | Storage FQDN resolution failing |
+| 9 | [EventLog_Channel_Health](Windows_EventLog_Channel_Health/) | Application log for CSE handler errors |
+
+**Tip:** CSE logs live at `C:\Packages\Plugins\Microsoft.Compute.CustomScriptExtension\<version>\Status\` and `...\Downloads\`. Check output file for script-level errors vs. infrastructure errors.
+
+---
+
+### Azure Disk Encryption (ADE) — encryption/decryption failed
+
+`Microsoft.Azure.Security.AzureDiskEncryption` / `AzureDiskEncryptionForLinux`
+
+| Order | Script | Why |
+|---|---|---|
+| 1–6 | **Run shared baseline above** | ADE needs agent + WireServer + certs |
+| 7 | [Encryption_State_Check](Windows_Encryption_State_Check/) | BitLocker volumes, ADE settings, OS drive encryption state |
+| 8 | [BitLocker_KeyProtector_Audit](Windows_BitLocker_KeyProtector_Audit/) | Key protectors, TPM, recovery key availability |
+| 9 | [Disk_Filesystem_Audit](Windows_Disk_Filesystem_Audit/) | Pagefile, dirty volumes — ADE can't encrypt dirty FS |
+| 10 | [GroupPolicy_Processing_Health](Windows_GroupPolicy_Processing_Health/) | GPO enforcing conflicting BitLocker policies |
+
+**Tip:** ADE logs at `C:\Packages\Plugins\Microsoft.Azure.Security.AzureDiskEncryption\<version>\Status\`. If extension shows "Succeeded" but disk isn't encrypted, the issue is BitLocker config — start at step 7.
+
+---
+
+### Monitoring extensions (MMA / AMA / Diagnostics)
+
+`Microsoft.EnterpriseCloud.Monitoring.MicrosoftMonitoringAgent` (MMA)
+`Microsoft.Azure.Monitor.AzureMonitorWindowsAgent` (AMA)
+`Microsoft.Azure.Diagnostics.IaaSDiagnostics` (WAD)
+
+| Order | Script | Why |
+|---|---|---|
+| 1–6 | **Run shared baseline above** | All monitoring agents need fabric + cert connectivity |
+| 7 | [WinRM_Remoting_Health](Windows_WinRM_Remoting_Health/) | MMA uses WinRM for some operations |
+| 8 | [Firewall_Profile_Baseline_Check](Windows_Firewall_Profile_Baseline_Check/) | Outbound 443 to Log Analytics workspace / DCR endpoint |
+| 9 | [DNS_NameResolution_Health](Windows_DNS_NameResolution_Health/) | Workspace FQDN resolution (*.ods.opinsights.azure.com) |
+| 10 | [EventLog_Channel_Health](Windows_EventLog_Channel_Health/) | Event channels readable — data source for all monitoring agents |
+| 11 | [EventForwarding_WEF_Health](Windows_EventForwarding_WEF_Health/) | WEF conflicts with AMA collection |
+| 12 | [Resource_Pressure_Snapshot](Windows_Resource_Pressure_Snapshot/) | Monitoring agent consuming excessive CPU/memory |
+
+**Tip:** MMA logs at `C:\Program Files\Microsoft Monitoring Agent\Agent\Health Service State\`. AMA logs at `C:\WindowsAzure\Resources\AMAData\`. WAD logs at `C:\Packages\Plugins\Microsoft.Azure.Diagnostics.IaaSDiagnostics\<version>\`.
+
+---
+
+### Windows Patch Extension (Azure Update Manager)
+
+`Microsoft.CPlat.Core.WindowsPatchExtension`
+
+| Order | Script | Why |
+|---|---|---|
+| 1–6 | **Run shared baseline above** | Patch extension needs full install chain |
+| 7 | [WU_PendingActions_Check](Windows_WU_PendingActions_Check/) | Reboot required, pending renames, CBS corruption, install failures |
+| 8 | [Disk_Filesystem_Audit](Windows_Disk_Filesystem_Audit/) | Disk space for update staging + download |
+| 9 | [SFC_DISM_Health_Signal](Windows_SFC_DISM_Health_Signal/) | Component store health — corrupted store blocks patching |
+| 10 | [Service_Dependency_Break_Check](Windows_Service_Dependency_Break_Check/) | wuauserv, cryptsvc, BITS dependencies running |
+| 11 | [Proxy_WinHTTP_WinINET_Check](Windows_Proxy_WinHTTP_WinINET_Check/) | WU update download needs outbound 443 to Microsoft update endpoints |
+
+**Tip:** Patch extension logs at `C:\Packages\Plugins\Microsoft.CPlat.Core.WindowsPatchExtension\<version>\Status\`. Common: extension "Succeeded" but patches failed — that's WU layer, start at step 7.
+
+---
+
+### DSC Extension (Desired State Configuration)
+
+`Microsoft.Powershell.DSC`
+
+| Order | Script | Why |
+|---|---|---|
+| 1–6 | **Run shared baseline above** | DSC handler follows normal install chain |
+| 7 | [WinRM_Remoting_Health](Windows_WinRM_Remoting_Health/) | DSC uses WinRM/CIM for configuration application |
+| 8 | [GroupPolicy_Processing_Health](Windows_GroupPolicy_Processing_Health/) | GPO can conflict with DSC-applied configurations |
+| 9 | [Service_Dependency_Break_Check](Windows_Service_Dependency_Break_Check/) | WMI, WinRM dependencies for LCM |
+| 10 | [EventLog_Channel_Health](Windows_EventLog_Channel_Health/) | DSC operational log: `Microsoft-Windows-DSC/Operational` |
+
+**Tip:** DSC logs at `C:\Packages\Plugins\Microsoft.Powershell.DSC\<version>\Status\` and Windows event log `Microsoft-Windows-DSC/Operational`. LCM state: `Get-DscLocalConfigurationManager`.
+
+---
+
+### BGInfo Extension
+
+`Microsoft.Compute.BGInfo`
+
+| Order | Script | Why |
+|---|---|---|
+| 1–6 | **Run shared baseline above** | Lightweight — usually only fails on install chain issues |
+| 7 | [UserProfileService_Health](Windows_UserProfileService_Health/) | BGInfo writes to desktop — profile issues block it |
+
+**Tip:** BGInfo rarely fails on its own. If it's the only failing extension, it's typically disk full (step 4) or stale handler state — remove and re-add.
+
+---
+
+### VM Access Extension (password reset / RDP re-enable)
+
+`Microsoft.Compute.VMAccessAgent`
+
+| Order | Script | Why |
+|---|---|---|
+| 1–6 | **Run shared baseline above** | VMAccess follows normal handler pipeline |
+| 7 | [RDP_Health_Snapshot](Windows_RDP_Health_Snapshot/) | If VMAccess was invoked to fix RDP — check if RDP is now working |
+| 8 | [Firewall_Profile_Baseline_Check](Windows_Firewall_Profile_Baseline_Check/) | VMAccess re-enables RDP rule — verify firewall accepted it |
+| 9 | [UserProfileService_Health](Windows_UserProfileService_Health/) | Password reset succeeded but login fails — profile issue |
+
+---
+
+### Dependency Agent (Azure Monitor VM Insights)
+
+`Microsoft.Azure.Monitoring.DependencyAgent`
+
+| Order | Script | Why |
+|---|---|---|
+| 1–6 | **Run shared baseline above** | Standard install chain |
+| 7 | [Resource_Pressure_Snapshot](Windows_Resource_Pressure_Snapshot/) | Dependency Agent captures connection data — can cause CPU pressure |
+| 8 | [Firewall_Profile_Baseline_Check](Windows_Firewall_Profile_Baseline_Check/) | Outbound to Log Analytics |
+| 9 | [Service_Dependency_Break_Check](Windows_Service_Dependency_Break_Check/) | MicrosoftDependencyAgent service running |
+
+---
+
+### Extension you don't see listed above
+
+For any other extension (Qualys, Symantec, Chef, Puppet, custom marketplace extensions):
+
+| Order | Script | Why |
+|---|---|---|
+| 1–6 | **Run shared baseline above** | All extensions use the same install pipeline |
+| 7 | [Firewall_Profile_Baseline_Check](Windows_Firewall_Profile_Baseline_Check/) | Extension may need outbound to vendor endpoints |
+| 8 | [DNS_NameResolution_Health](Windows_DNS_NameResolution_Health/) | Vendor FQDN resolution |
+| 9 | [EventLog_Channel_Health](Windows_EventLog_Channel_Health/) | Application log for handler errors |
+| 10 | [GroupPolicy_Processing_Health](Windows_GroupPolicy_Processing_Health/) | GPO may block extension behavior |
+| 11 | [DriverSignature_Integrity_Check](Windows_DriverSignature_Integrity_Check/) | Code signing enforcement — can block unsigned extension binaries |
+
+**Tip:** All extension logs follow the same pattern: `C:\Packages\Plugins\<Publisher.Type>\<version>\Status\` for status JSON, `...\<version>\` for handler-specific logs.
+
+## WinRM and Run Command connectivity
+
+Run Command itself not working, or DSC/remoting extensions failing.
+
+| Order | Script | What it checks |
+|---|---|---|
+| 1 | [WinRM_Remoting_Health](Windows_WinRM_Remoting_Health/) | WinRM service, HTTP/HTTPS listeners, certs, firewall rules |
+| 2 | [Firewall_Profile_Baseline_Check](Windows_Firewall_Profile_Baseline_Check/) | WinRM ports (5985/5986) allowed |
+| 3 | [SChannel_CertStore_Health](Windows_SChannel_CertStore_Health/) | HTTPS listener cert valid |
+| 4 | [Network_IMDS_Reachability](Windows_Network_IMDS_Reachability/) | Fabric connectivity for Run Command delivery |
+
+## Network connectivity issues (not RDP-specific)
+
+| Order | Script | What it checks |
+|---|---|---|
+| 1 | [Network_IMDS_Reachability](Windows_Network_IMDS_Reachability/) | NIC present, default route, WireServer, IMDS |
+| 2 | [DNS_NameResolution_Health](Windows_DNS_NameResolution_Health/) | DNS servers, public resolution, metadata alias, hosts overrides |
+| 3 | [Firewall_Profile_Baseline_Check](Windows_Firewall_Profile_Baseline_Check/) | Profiles, RDP rule, inbound default, BFE |
+| 4 | [Proxy_WinHTTP_WinINET_Check](Windows_Proxy_WinHTTP_WinINET_Check/) | WinHTTP/WinINET proxy, bypass list, fabric endpoint bypass |
+| 5 | [RouteTable_Anomaly_Check](Windows_RouteTable_Anomaly_Check/) | Route table, unexpected routes, missing defaults |
+| 6 | [NetworkBinding_Order_Check](Windows_NetworkBinding_Order_Check/) | NIC binding order, primary adapter |
+| 7 | [NIC_AdvancedProperties_Baseline](Windows_NIC_AdvancedProperties_Baseline/) | NIC advanced settings, RSS, offload |
+| 8 | [IPv6_RDP_Path_Check](Windows_IPv6_RDP_Path_Check/) | IPv6 path, dual-stack, DNS over IPv6 |
+| 9 | [SMB_Client_Health](Windows_SMB_Client_Health/) | SMB client config, signing, dialects |
+
+## Performance (slow VM, high CPU, memory pressure)
+
+| Order | Script | What it checks |
+|---|---|---|
+| 1 | [Resource_Pressure_Snapshot](Windows_Resource_Pressure_Snapshot/) | CPU utilization, physical memory, commit charge |
+| 2 | [PowerPlan_Throttling_Check](Windows_PowerPlan_Throttling_Check/) | Power plan, processor throttling, min/max states |
+| 3 | [Startup_Delay_Analyzer](Windows_Startup_Delay_Analyzer/) | Boot time, startup delay contributors, slow services |
+| 4 | [Disk_Filesystem_Audit](Windows_Disk_Filesystem_Audit/) | Pagefile, temp drive, dirty volumes |
+| 5 | [Port_Ephemeral_Exhaustion_Check](Windows_Port_Ephemeral_Exhaustion_Check/) | Ephemeral port range, active connections, exhaustion risk |
+
+## Crash / BSOD / unexpected restart
+
+| Order | Script | What it checks |
+|---|---|---|
+| 1 | [CrashDump_Config_Validator](Windows_CrashDump_Config_Validator/) | Dump type, dump path, pagefile, AutoReboot, existing dumps |
+| 2 | [CrashHistory_Bugcheck_Summary](Windows_CrashHistory_Bugcheck_Summary/) | MEMORY.DMP, minidumps, bugcheck codes, crash frequency |
+| 3 | [ReliabilityMonitor_Event_Signal](Windows_ReliabilityMonitor_Event_Signal/) | Reliability events, application crashes, system failures |
+| 4 | [Service_Boot_Audit](Windows_Service_Boot_Audit/) | SafeBoot, boot recovery, event log access |
+| 5 | [BootPolicy_Drift_Check](Windows_BootPolicy_Drift_Check/) | BCD entries, boot config drift |
+
+## Disk, storage, and filesystem issues
+
+| Order | Script | What it checks |
+|---|---|---|
+| 1 | [Disk_Filesystem_Audit](Windows_Disk_Filesystem_Audit/) | Pagefile, temp drive D:, dirty volumes |
+| 2 | [NTFS_Integrity_Check](Windows_NTFS_Integrity_Check/) | Fixed volumes, dirty bit, BootExecute, disk errors, C: exists |
+| 3 | [StorageSpaces_Health](Windows_StorageSpaces_Health/) | Storage subsystem, pool/vdisk/pdisk health, S2D |
+| 4 | [DriverStore_Health](Windows_DriverStore_Health/) | Driver store integrity, bloat, staged packages |
+| 5 | [VSS_Writer_Health](Windows_VSS_Writer_Health/) | VSS writers, failed writers, VSS service, providers |
+
+## Domain join and authentication failures
+
+| Order | Script | What it checks |
+|---|---|---|
+| 1 | [Domain_Trust_SecureChannel_Check](Windows_Domain_Trust_SecureChannel_Check/) | Domain join, Netlogon, secure channel, DC discovery, DNS SRV |
+| 2 | [TimeSync_Kerberos_Health](Windows_TimeSync_Kerberos_Health/) | Time source, clock offset, KDC reachability, Kerberos errors |
+| 3 | [DomainJoin_Readiness](Windows_DomainJoin_Readiness/) | DNS, domain reachability, join prerequisites |
+| 4 | [GroupPolicy_Processing_Health](Windows_GroupPolicy_Processing_Health/) | GPSvc, GP errors, NETLOGON/SYSVOL paths |
+| 5 | [UserProfileService_Health](Windows_UserProfileService_Health/) | Profile service, registry, temp profiles, load errors |
+
+## Encryption and security baseline
+
+| Order | Script | What it checks |
+|---|---|---|
+| 1 | [Encryption_State_Check](Windows_Encryption_State_Check/) | BitLocker volumes, ADE extension, ADE settings, OS drive encrypted |
+| 2 | [BitLocker_KeyProtector_Audit](Windows_BitLocker_KeyProtector_Audit/) | Key protectors, TPM, recovery key availability |
+| 3 | [SChannel_CertStore_Health](Windows_SChannel_CertStore_Health/) | SChannel config, cert store, expired certs |
+| 4 | [LSA_SSP_Baseline_Check](Windows_LSA_SSP_Baseline_Check/) | LSA security providers, SSP DLLs |
+| 5 | [Defender_Health_Snapshot](Windows_Defender_Health_Snapshot/) | Defender service, definitions, real-time protection |
+| 6 | [DriverSignature_Integrity_Check](Windows_DriverSignature_Integrity_Check/) | Driver signing enforcement, unsigned drivers |
+
+## Windows Update issues
+
+| Order | Script | What it checks |
+|---|---|---|
+| 1 | [WU_PendingActions_Check](Windows_WU_PendingActions_Check/) | Reboot required, pending renames, CBS, WU service, install failures |
+| 2 | [SFC_DISM_Health_Signal](Windows_SFC_DISM_Health_Signal/) | Component store health, SFC/DISM repair readiness |
+| 3 | [Disk_Filesystem_Audit](Windows_Disk_Filesystem_Audit/) | Disk space (updates need free space) |
+
+## Backup and recovery
+
+| Order | Script | What it checks |
+|---|---|---|
+| 1 | [VSS_Writer_Health](Windows_VSS_Writer_Health/) | VSS writers, failed writers, service state, providers |
+| 2 | [EventLog_Channel_Health](Windows_EventLog_Channel_Health/) | Event log service and channel health |
+| 3 | [CrashDump_Config_Validator](Windows_CrashDump_Config_Validator/) | Dump capture readiness for post-incident recovery |
+
+## Monitoring and diagnostics platform health
+
+| Order | Script | What it checks |
+|---|---|---|
+| 1 | [EventLog_Channel_Health](Windows_EventLog_Channel_Health/) | EventLog service, System/App/Security channels, error rate |
+| 2 | [EventForwarding_WEF_Health](Windows_EventForwarding_WEF_Health/) | WEF collector, subscription state, forwarding errors |
+| 3 | [WinRM_Remoting_Health](Windows_WinRM_Remoting_Health/) | WinRM service, listeners, remoting readiness |
+
+---
+
+## If your signal is unclear
+
+Run these three in order — they cover the broadest triage surface:
+
+1. **[Network_IMDS_Reachability](Windows_Network_IMDS_Reachability/)** — is the VM connected to Azure fabric?
+2. **[Service_Dependency_Break_Check](Windows_Service_Dependency_Break_Check/)** — are core services running?
+3. **[EventLog_Channel_Health](Windows_EventLog_Channel_Health/)** — can we collect diagnostic data?
+
+Then check the `-- Decision --` block in each script's output — it tells you severity and next action.
+
+## How to run any script
+
+### Azure Portal
+VM → Operations → Run Command → RunPowerShellScript → paste the `.ps1` content.
+
+### Azure CLI
+```bash
+az vm run-command invoke -g <rg> -n <vm> --command-id RunPowerShellScript \
+  --scripts @<FolderName>/<ScriptName>.ps1
+```
+
+### Mock test (offline, no VM needed)
+```powershell
+.\<ScriptName>.ps1 -MockConfig .\mock_config_sample.json -MockProfile broken
+```
+
+## Reading the output
+
+Every Tier-2 script outputs the same format:
+
+```
+=== Script Name ===
+Check                                        Status
+-------------------------------------------- ------
+Some diagnostic check                        OK
+Another check                                FAIL
+...
+-- Decision --
+Likely cause severity                        FAIL   Hard configuration/service break
+Next action                                  OK     Follow README interpretation ...
+-- More Info --
+Remediation references available             OK     See paired README Learn References
+
+=== RESULT: X OK / Y FAIL / Z WARN ===
+```
+
+- **FAIL** = blocking issue, fix before proceeding
+- **WARN** = non-blocking but should investigate
+- **OK** = healthy
+
+Open the script's **README.md** for the **Interpretation Guide** — it maps every FAIL/WARN condition to likely cause, quick fix, and Microsoft Learn article.

--- a/RunCommand/Windows/Windows_BitLocker_KeyProtector_Audit/README.md
+++ b/RunCommand/Windows/Windows_BitLocker_KeyProtector_Audit/README.md
@@ -1,0 +1,82 @@
+# Windows BitLocker KeyProtector Audit
+
+> **Tool ID:** RC-011 · **Bucket:** Security · **Phase:** 2 (Deep diagnostic)
+
+## What It Does
+
+Audits BitLocker encryption state and key protector configuration on the OS volume. Validates that recovery keys, TPM protectors, and encryption methods meet Azure VM best practices. Critical for VMs where BitLocker was enabled via Azure Disk Encryption or Group Policy.
+
+| Check area | What is validated |
+|---|---|
+| Volume protection | BitLocker protection is active on C: |
+| Key protectors | At least one protector configured |
+| Recovery password | Recovery password protector exists for break-glass |
+| TPM protector | TPM protector present (hardware-backed) |
+| Encryption method | XTS-AES-128 or stronger |
+| Conversion status | Volume is fully encrypted (not mid-conversion) |
+
+## Run Command Constraints Met
+
+- ✅ PowerShell 5.1 only
+- ✅ No Az module required
+- ✅ No internet access needed
+- ✅ Output < 4 KB
+- ✅ No interactive prompts
+- ✅ Read-only (diagnostic only)
+
+## How to Run
+
+### Azure Run Command (recommended)
+Navigate to VM → Operations → Run Command → RunPowerShellScript → paste script.
+
+### Azure CLI
+```bash
+az vm run-command invoke -g <rg> -n <vm> --command-id RunPowerShellScript \
+  --scripts @Windows_BitLocker_KeyProtector_Audit/Windows_BitLocker_KeyProtector_Audit.ps1
+```
+
+### Mock test
+```powershell
+.\Windows_BitLocker_KeyProtector_Audit.ps1 -MockConfig .\mock_config_sample.json -MockProfile degraded
+```
+
+## Sample Output (Issues Detected)
+
+```
+=== Windows BitLocker KeyProtector Audit ===
+Check                                        Status
+-------------------------------------------- ------
+BitLocker volume protection status           FAIL
+Key protector count (C:)                     WARN
+Recovery password protector present          FAIL
+TPM protector present                        WARN
+Encryption method strength                   OK
+Conversion status (fully encrypted)          FAIL
+-- Decision --
+Likely cause severity                        FAIL   Hard configuration/service break
+Next action                                  OK     Follow README interpretation and remediate FAIL rows first
+-- More Info --
+Remediation references available             OK     See paired README Learn References
+
+=== RESULT: 1 OK / 3 FAIL / 2 WARN ===
+```
+
+## Interpretation Guide
+
+| FAIL/WARN condition | Likely cause | Quick fix | Learn link |
+|---|---|---|---|
+| **BitLocker volume protection status** FAIL | BitLocker protection is suspended or off. May happen after OS updates, firmware changes, or manual suspension. | `Resume-BitLocker -MountPoint "C:"` or `manage-bde -resume C:` | [Troubleshoot BitLocker boot errors](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-bitlocker-boot-error) |
+| **Key protector count (C:)** WARN | Fewer key protectors than expected. Single protector means no backup recovery path. | `Add-BitLockerKeyProtector -MountPoint "C:" -RecoveryPasswordProtector` | [Cannot extend encrypted OS volume](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/cannot-extend-encrypted-os-volume) |
+| **Recovery password protector present** FAIL | No recovery password protector — system cannot be unlocked if TPM fails or VM is moved. | `Add-BitLockerKeyProtector -MountPoint "C:" -RecoveryPasswordProtector` | [BitLocker recovery guide](https://learn.microsoft.com/windows/security/operating-system-security/data-protection/bitlocker/recovery-overview) |
+| **TPM protector present** WARN | No TPM-based protector. Azure VMs use vTPM; if missing, encryption relies only on password/recovery key. | `Add-BitLockerKeyProtector -MountPoint "C:" -TpmProtector` (requires vTPM enabled on VM) | [Azure Disk Encryption scenarios](https://learn.microsoft.com/azure/virtual-machines/windows/disk-encryption-overview) |
+| **Encryption method strength** WARN | Weak encryption method (below XTS-AES-128). Older volumes may use AES-128-CBC. | Re-encrypt with `manage-bde -changekey C: -EncryptionMethod xts_aes128` or rebuild with stronger policy | [BitLocker Group Policy settings](https://learn.microsoft.com/windows/security/operating-system-security/data-protection/bitlocker/configure) |
+| **Conversion status (fully encrypted)** FAIL | Volume encryption is in-progress or paused. Can occur if encryption was interrupted by reboot or disk space issue. | `Resume-BitLocker -MountPoint "C:"` — if stuck, check Event Viewer → Application → BitLocker-API events | [Troubleshoot BitLocker boot errors](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-bitlocker-boot-error) |
+
+## Related Articles
+
+| Article | Link |
+|---|---|
+| Troubleshoot BitLocker boot errors on Azure VMs | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-bitlocker-boot-error) |
+| Cannot extend encrypted OS volume | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/cannot-extend-encrypted-os-volume) |
+| Azure Disk Encryption for Windows VMs | [learn.microsoft.com](https://learn.microsoft.com/azure/virtual-machines/windows/disk-encryption-overview) |
+| BitLocker recovery overview | [learn.microsoft.com](https://learn.microsoft.com/windows/security/operating-system-security/data-protection/bitlocker/recovery-overview) |

--- a/RunCommand/Windows/Windows_BitLocker_KeyProtector_Audit/Windows_BitLocker_KeyProtector_Audit.ps1
+++ b/RunCommand/Windows/Windows_BitLocker_KeyProtector_Audit/Windows_BitLocker_KeyProtector_Audit.ps1
@@ -1,0 +1,72 @@
+#Requires -Version 5.1
+[CmdletBinding()]
+param(
+  [string]$MockConfig,
+  [ValidateSet('healthy','degraded','broken')]
+  [string]$MockProfile = 'degraded'
+)
+$ErrorActionPreference='Continue'
+function Pad($s,$n){$s="$s";if($s.Length -ge $n){$s.Substring(0,$n)}else{$s.PadRight($n)}}
+$W=44
+$rows=New-Object System.Collections.Generic.List[object]
+function Add-Row($c,$s,$d=''){ $rows.Add([PSCustomObject]@{Check=$c;Status=$s;Detail=$d}); Write-Output ('{0} {1}' -f (Pad $c $W), $s) }
+
+Write-Output '=== Windows BitLocker KeyProtector Audit ==='
+Write-Output ('{0} {1}' -f (Pad 'Check' $W), 'Status')
+Write-Output (('-' * $W) + ' ------')
+
+$usedMock = $false
+if($MockConfig -and (Test-Path $MockConfig)){
+  $mock = Get-Content $MockConfig -Raw | ConvertFrom-Json
+  if($mock.profiles -and $mock.profiles.$MockProfile){
+    $usedMock = $true
+    foreach($i in $mock.profiles.$MockProfile){ Add-Row $i.name $i.status $i.detail }
+  }
+}
+
+if(-not $usedMock){
+  # Probe: BitLocker volume protection status
+  $bv = Get-CimInstance -Namespace "root\CIMV2\Security\MicrosoftVolumeEncryption" -ClassName Win32_EncryptableVolume -ErrorAction SilentlyContinue | Where-Object DriveLetter -eq "C:"; $pstat = if($bv){ $bv.ProtectionStatus } else { -1 }
+  $_s = if($pstat -eq 0 -or $pstat -eq -1){'FAIL'}elseif($pstat -eq 1){'OK'}else{'WARN'}
+  Add-Row 'BitLocker volume protection status' $_s ("Protection=$pstat (1=On 0=Off)")
+
+  # Probe: Key protector count (C:)
+  $kp = if($bv){ try{ ($bv | Invoke-CimMethod -MethodName GetKeyProtectors -ErrorAction SilentlyContinue).VolumeKeyProtectorID } catch { @() } } else { @() }; $kpCount = @($kp).Count
+  $_s = if($kpCount -ge 2){'OK'}elseif($kpCount -eq 1){'WARN'}else{'FAIL'}
+  Add-Row 'Key protector count (C:)' $_s ("Protectors=$kpCount")
+
+  # Probe: Recovery password protector present
+  $rpType = if($bv){ try{ ($bv | Invoke-CimMethod -MethodName GetKeyProtectors -Arguments @{KeyProtectorType=3} -ErrorAction SilentlyContinue).VolumeKeyProtectorID } catch { @() } } else { @() }
+  $_s = if(@($rpType).Count -gt 0){'OK'}elseif(@($rpType).Count -eq 0){'WARN'}else{'FAIL'}
+  Add-Row 'Recovery password protector present' $_s ("RecoveryPwd=$(if(@($rpType).Count -gt 0){`"present`"}else{`"missing`"})")
+
+  # Probe: TPM protector present
+  $tpmP = if($bv){ try{ ($bv | Invoke-CimMethod -MethodName GetKeyProtectors -Arguments @{KeyProtectorType=1} -ErrorAction SilentlyContinue).VolumeKeyProtectorID } catch { @() } } else { @() }
+  $_s = if(@($tpmP).Count -gt 0){'OK'}elseif(@($tpmP).Count -eq 0){'WARN'}else{'FAIL'}
+  Add-Row 'TPM protector present' $_s ("TPM=$(if(@($tpmP).Count -gt 0){`"present`"}else{`"none`"})")
+
+  # Probe: Encryption method strength
+  $em = if($bv){ try{ ($bv | Invoke-CimMethod -MethodName GetEncryptionMethod -ErrorAction SilentlyContinue).EncryptionMethod } catch { 0 } } else { 0 }
+  $_s = if($em -ge 4){'OK'}elseif($em -gt 0 -and $em -lt 4){'WARN'}else{'FAIL'}
+  Add-Row 'Encryption method strength' $_s ("Method=$em (4+=XTS-AES-128+)")
+
+  # Probe: Conversion status (fully encrypted)
+  $cs = if($bv){ try{ ($bv | Invoke-CimMethod -MethodName GetConversionStatus -ErrorAction SilentlyContinue).ConversionStatus } catch { -1 } } else { -1 }
+  $_s = if($cs -eq 1){'OK'}elseif($cs -eq 2 -or $cs -eq 3){'WARN'}else{'FAIL'}
+  Add-Row 'Conversion status (fully encrypted)' $_s ("Status=$cs (1=FullyEncrypted)")
+
+}
+
+$fail=@($rows|Where-Object Status -eq 'FAIL').Count
+$warn=@($rows|Where-Object Status -eq 'WARN').Count
+Write-Output '-- Decision --'
+Add-Row 'Likely cause severity' $(if($fail -gt 0){'FAIL'}elseif($warn -gt 0){'WARN'}else{'OK'}) $(if($fail -gt 0){'Hard configuration/service break'}elseif($warn -gt 0){'Configuration drift or transient condition'}else{'No blocking signals'})
+Add-Row 'Next action' 'OK' $(if($fail -gt 0){'Follow README interpretation and remediate FAIL rows first'}elseif($warn -gt 0){'Review WARN rows and re-run after targeted fix'}else{'No immediate action'})
+Write-Output '-- More Info --'
+Add-Row 'Remediation references available' 'OK' 'See paired README Learn References'
+
+$ok=@($rows|Where-Object Status -eq 'OK').Count
+Write-Output ''
+Write-Output "=== RESULT: $ok OK / $fail FAIL / $warn WARN ==="
+$rows
+

--- a/RunCommand/Windows/Windows_BitLocker_KeyProtector_Audit/mock_config_sample.json
+++ b/RunCommand/Windows/Windows_BitLocker_KeyProtector_Audit/mock_config_sample.json
@@ -1,0 +1,100 @@
+{
+  "profiles": {
+    "healthy": [
+      {
+        "name": "BitLocker volume protection status",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Key protector count (C:)",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Recovery password protector present",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "TPM protector present",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Encryption method strength",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Conversion status (fully encrypted)",
+        "status": "OK",
+        "detail": "Healthy profile"
+      }
+    ],
+    "broken": [
+      {
+        "name": "BitLocker volume protection status",
+        "status": "FAIL",
+        "detail": "Critical failure detected"
+      },
+      {
+        "name": "Key protector count (C:)",
+        "status": "FAIL",
+        "detail": "Critical failure detected"
+      },
+      {
+        "name": "Recovery password protector present",
+        "status": "WARN",
+        "detail": "Degraded state"
+      },
+      {
+        "name": "TPM protector present",
+        "status": "OK",
+        "detail": "Operational"
+      },
+      {
+        "name": "Encryption method strength",
+        "status": "WARN",
+        "detail": "Degraded state"
+      },
+      {
+        "name": "Conversion status (fully encrypted)",
+        "status": "OK",
+        "detail": "Operational"
+      }
+    ],
+    "degraded": [
+      {
+        "name": "BitLocker volume protection status",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Key protector count (C:)",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Recovery password protector present",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "TPM protector present",
+        "status": "WARN",
+        "detail": "Configuration drift detected"
+      },
+      {
+        "name": "Encryption method strength",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Conversion status (fully encrypted)",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      }
+    ]
+  }
+}

--- a/RunCommand/Windows/Windows_BootPolicy_Drift_Check/README.md
+++ b/RunCommand/Windows/Windows_BootPolicy_Drift_Check/README.md
@@ -1,0 +1,74 @@
+# Windows Boot Policy Drift Check
+
+> **Bucket:** Boot-Failures / BCD-Corruption / Secure-Boot
+
+## What It Does
+
+Validates that the Boot Configuration Data (BCD) store is intact and has not drifted from expected Azure VM defaults:
+
+| Check | What is validated |
+|---|---|
+| **BCD store accessible** | `bcdedit /enum {bootmgr}` succeeds — store is not corrupt |
+| **Default boot entry** | Default OS entry points to a valid Windows partition |
+| **Secure Boot state** | UEFI Secure Boot is enabled (expected ON for Gen2 VMs) |
+| **Boot status policy** | Set to `IgnoreAllFailures` — prevents recovery loops in Azure |
+| **Recovery sequence** | Recovery sequence entry is configured |
+| **Integrity checks** | `nointegritychecks` is not set — driver signing enforced |
+
+The script is **read-only** — it makes no changes to the system.
+
+## How to Run
+
+### Azure Run Command (recommended)
+1. Go to your VM in the Azure portal
+2. Select **Operations → Run Command → RunPowerShellScript**
+3. Paste the contents of `Windows_BootPolicy_Drift_Check.ps1`
+4. Select **Run** and wait for output
+
+### Azure CLI
+```bash
+az vm run-command invoke \
+  --resource-group <rg> \
+  --name <vm-name> \
+  --command-id RunPowerShellScript \
+  --scripts @Windows_BootPolicy_Drift_Check.ps1
+```
+
+### Mock / Offline Test
+```powershell
+.\Windows_BootPolicy_Drift_Check.ps1 -MockConfig .\mock_config_sample.json -MockProfile broken
+```
+
+## Sample Output (Issues Detected)
+
+```
+=== Windows Boot Policy Drift Check ===
+Check                                        Status
+-------------------------------------------- ------
+BCD store accessible                         OK
+Default boot entry points to Windows         FAIL
+Secure Boot state                            WARN    SecureBoot=OFF
+Boot status policy (ignore failures)         WARN    default
+Recovery sequence configured                 WARN    absent
+Integrity checks enabled                     OK      not set (default=on)
+-- Decision --
+Likely cause severity                        FAIL
+=== RESULT: 2 OK / 1 FAIL / 3 WARN ===
+```
+
+## Interpretation Guide
+
+| FAIL/WARN condition | Likely cause | Quick fix |
+|---|---|---|
+| BCD store not accessible | BCD is corrupt or missing | Use [Azure VM repair commands](https://learn.microsoft.com/azure/virtual-machines/troubleshooting/repair-windows-vm-using-azure-virtual-machine-repair-commands) to attach OS disk and rebuild BCD: `bcdedit /rebuildbcd` |
+| Default entry not pointing to Windows | BCD hijacked by recovery or third-party bootloader | Run `bcdedit /set {default} osdevice partition=C:` from repair disk |
+| Secure Boot OFF on Gen2 VM | Secure Boot was disabled — may block Windows Update or driver loading | Re-enable via Azure portal: VM → Settings → Configuration → Secure Boot |
+| Boot status policy not IgnoreAllFailures | VM may enter recovery loop on transient boot issues | Set: `bcdedit /set {default} bootstatuspolicy IgnoreAllFailures` |
+| Recovery sequence absent | No recovery fallback if boot fails | Usually harmless in Azure (serial console is the recovery path) |
+| Integrity checks disabled | Unsigned drivers allowed — security risk and may cause BSOD | Remove override: `bcdedit /deletevalue {default} nointegritychecks` |
+
+## Related Articles
+
+- [Troubleshoot Windows boot failure](https://learn.microsoft.com/azure/virtual-machines/troubleshooting/windows-boot-failure)
+- [Boot error — Invalid image hash](https://learn.microsoft.com/azure/virtual-machines/troubleshooting/windows-boot-error-invalid-image-hash)
+- [Repair Windows VM boot configuration data](https://learn.microsoft.com/azure/virtual-machines/troubleshooting/virtual-machines-windows-repair-boot-configuration-data)

--- a/RunCommand/Windows/Windows_BootPolicy_Drift_Check/Windows_BootPolicy_Drift_Check.ps1
+++ b/RunCommand/Windows/Windows_BootPolicy_Drift_Check/Windows_BootPolicy_Drift_Check.ps1
@@ -1,0 +1,72 @@
+#Requires -Version 5.1
+[CmdletBinding()]
+param(
+  [string]$MockConfig,
+  [ValidateSet('healthy','degraded','broken')]
+  [string]$MockProfile = 'degraded'
+)
+$ErrorActionPreference='Continue'
+function Pad($s,$n){$s="$s";if($s.Length -ge $n){$s.Substring(0,$n)}else{$s.PadRight($n)}}
+$W=44
+$rows=New-Object System.Collections.Generic.List[object]
+function Add-Row($c,$s,$d=''){ $rows.Add([PSCustomObject]@{Check=$c;Status=$s;Detail=$d}); Write-Output ('{0} {1}' -f (Pad $c $W), $s) }
+
+Write-Output '=== Windows Boot Policy Drift Check ==='
+Write-Output ('{0} {1}' -f (Pad 'Check' $W), 'Status')
+Write-Output (('-' * $W) + ' ------')
+
+$usedMock = $false
+if($MockConfig -and (Test-Path $MockConfig)){
+  $mock = Get-Content $MockConfig -Raw | ConvertFrom-Json
+  if($mock.profiles -and $mock.profiles.$MockProfile){
+    $usedMock = $true
+    foreach($i in $mock.profiles.$MockProfile){ Add-Row $i.name $i.status $i.detail }
+  }
+}
+
+if(-not $usedMock){
+  # Probe: BCD store accessible
+  $bcd = bcdedit /enum "{bootmgr}" 2>&1; $bcdOk = $LASTEXITCODE -eq 0
+  $_s = if(!$bcdOk){'FAIL'}elseif($bcdOk){'OK'}else{'WARN'}
+  Add-Row 'BCD store accessible' $_s ("")
+
+  # Probe: Default boot entry points to Windows
+  $def = bcdedit /enum "{default}" 2>&1 | Select-String "osdevice"; $defOk = $def -match "partition="
+  $_s = if(!$defOk){'FAIL'}elseif($defOk){'OK'}else{'WARN'}
+  Add-Row 'Default boot entry points to Windows' $_s ("$def")
+
+  # Probe: Secure Boot state
+  try { $sb = Confirm-SecureBootUEFI -ErrorAction SilentlyContinue } catch { $sb = $null }
+  $_s = if($sb -eq $true){'OK'}elseif($sb -ne $true){'WARN'}else{'FAIL'}
+  Add-Row 'Secure Boot state' $_s ("SecureBoot=$(if($sb -eq $true){'ON'}elseif($sb -eq $false){'OFF'}else{'N/A'})")
+
+  # Probe: Boot status policy (ignore failures)
+  $bsp = bcdedit /enum "{default}" 2>&1 | Select-String "bootstatuspolicy"; $bspOk = $bsp -match "IgnoreAllFailures"
+  $_s = if($bspOk){'OK'}elseif(!$bspOk){'WARN'}else{'FAIL'}
+  Add-Row 'Boot status policy (ignore failures)' $_s ("$(if($bsp){$bsp.ToString().Trim()}else{'default'})")
+
+  # Probe: Recovery sequence configured
+  $rec = bcdedit /enum "{default}" 2>&1 | Select-String "recoverysequence"; $recOk = $rec -ne $null
+  $_s = if($recOk){'OK'}elseif(!$recOk){'WARN'}else{'FAIL'}
+  Add-Row 'Recovery sequence configured' $_s ("$(if($rec){'present'}else{'absent'})")
+
+  # Probe: Integrity checks enabled
+  $ic = bcdedit /enum "{default}" 2>&1 | Select-String "nointegritychecks"; $icOk = $ic -eq $null -or $ic -match "No"
+  $_s = if(!$icOk){'FAIL'}elseif($icOk){'OK'}else{'WARN'}
+  Add-Row 'Integrity checks enabled' $_s ("$(if($ic){$ic.ToString().Trim()}else{'not set (default=on)'})")
+
+}
+
+$fail=@($rows|Where-Object Status -eq 'FAIL').Count
+$warn=@($rows|Where-Object Status -eq 'WARN').Count
+Write-Output '-- Decision --'
+Add-Row 'Likely cause severity' $(if($fail -gt 0){'FAIL'}elseif($warn -gt 0){'WARN'}else{'OK'}) $(if($fail -gt 0){'Hard configuration/service break'}elseif($warn -gt 0){'Configuration drift or transient condition'}else{'No blocking signals'})
+Add-Row 'Next action' 'OK' $(if($fail -gt 0){'Follow README interpretation and remediate FAIL rows first'}elseif($warn -gt 0){'Review WARN rows and re-run after targeted fix'}else{'No immediate action'})
+Write-Output '-- More Info --'
+Add-Row 'Remediation references available' 'OK' 'See paired README Learn References'
+
+$ok=@($rows|Where-Object Status -eq 'OK').Count
+Write-Output ''
+Write-Output "=== RESULT: $ok OK / $fail FAIL / $warn WARN ==="
+$rows
+

--- a/RunCommand/Windows/Windows_BootPolicy_Drift_Check/mock_config_sample.json
+++ b/RunCommand/Windows/Windows_BootPolicy_Drift_Check/mock_config_sample.json
@@ -1,0 +1,100 @@
+{
+  "profiles": {
+    "healthy": [
+      {
+        "name": "BCD store accessible",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Default boot entry points to Windows",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Secure Boot state",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Boot status policy (ignore failures)",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Recovery sequence configured",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Integrity checks enabled",
+        "status": "OK",
+        "detail": "Healthy profile"
+      }
+    ],
+    "broken": [
+      {
+        "name": "BCD store accessible",
+        "status": "FAIL",
+        "detail": "Critical failure detected"
+      },
+      {
+        "name": "Default boot entry points to Windows",
+        "status": "FAIL",
+        "detail": "Critical failure detected"
+      },
+      {
+        "name": "Secure Boot state",
+        "status": "WARN",
+        "detail": "Degraded state"
+      },
+      {
+        "name": "Boot status policy (ignore failures)",
+        "status": "OK",
+        "detail": "Operational"
+      },
+      {
+        "name": "Recovery sequence configured",
+        "status": "WARN",
+        "detail": "Degraded state"
+      },
+      {
+        "name": "Integrity checks enabled",
+        "status": "OK",
+        "detail": "Operational"
+      }
+    ],
+    "degraded": [
+      {
+        "name": "BCD store accessible",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Default boot entry points to Windows",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Secure Boot state",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Boot status policy (ignore failures)",
+        "status": "WARN",
+        "detail": "Configuration drift detected"
+      },
+      {
+        "name": "Recovery sequence configured",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Integrity checks enabled",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      }
+    ]
+  }
+}

--- a/RunCommand/Windows/Windows_CrashDump_Config_Validator/README.md
+++ b/RunCommand/Windows/Windows_CrashDump_Config_Validator/README.md
@@ -1,0 +1,87 @@
+# Windows Crash Dump Config Validator
+
+> **Tool ID:** RC-009 · **Bucket:** Unexpected-Restarts / BSOD · **Phase:** 3 (Config audit)
+
+## What It Does
+
+Validates crash dump capture readiness on a Windows VM. Checks dump type, dump file paths, AutoReboot/overwrite policies, pagefile configuration, and existing dump artifacts. Essential for VMs experiencing BSODs where crash data is not being collected.
+
+| Check area | What is validated |
+|---|---|
+| Dump path | Dump file path configured |
+| AutoReboot | AutoReboot disabled during triage |
+| Overwrite | Overwrite existing dump enabled |
+| Minidump dir | Minidump directory configured |
+| Pagefile | Pagefile configured |
+| OS pagefile | OS drive pagefile present |
+| MEMORY.DMP | MEMORY.DMP artifact present |
+| Minidumps | Minidump files present |
+
+## Run Command Constraints Met
+
+- ✅ PowerShell 5.1 only
+- ✅ No Az module required
+- ✅ No internet access needed
+- ✅ Output < 4 KB
+- ✅ No interactive prompts
+- ✅ Read-only (diagnostic only)
+
+## How to Run
+
+### Azure Run Command (recommended)
+Navigate to VM → Operations → Run Command → RunPowerShellScript → paste script.
+
+### Azure CLI
+```bash
+az vm run-command invoke -g <rg> -n <vm> --command-id RunPowerShellScript \
+  --scripts @Windows_CrashDump_Config_Validator/Windows_CrashDump_Config_Validator.ps1
+```
+
+### Mock test
+```powershell
+.\Windows_CrashDump_Config_Validator.ps1 -MockConfig .\mock_config_sample.json -MockProfile degraded
+```
+
+## Sample Output (Issues Detected)
+
+```
+=== Windows Crash Dump Config Validator ===
+Check                                        Status
+-------------------------------------------- ------
+Dump file path configured                    OK
+AutoReboot disabled during triage            WARN
+Overwrite existing dump enabled              WARN
+Minidump directory configured                OK
+Pagefile configured                          FAIL
+OS drive pagefile present                    WARN
+MEMORY.DMP present                           WARN
+Minidump files present                       WARN
+-- Decision --
+Likely cause severity                        FAIL   Hard configuration/service break
+Next action                                  OK     Follow README interpretation and remediate FAIL rows first
+-- More Info --
+Remediation references available             OK     See paired README Learn References
+
+=== RESULT: 2 OK / 1 FAIL / 5 WARN ===
+```
+
+## Interpretation Guide
+
+| FAIL/WARN condition | Likely cause | Quick fix | Learn link |
+|---|---|---|---|
+| **Dump file path configured** FAIL | CrashControl registry has no dump path. Crash dumps cannot be written. | Set `HKLM:\SYSTEM\CurrentControlSet\Control\CrashControl\DumpFile` to `%SystemRoot%\MEMORY.DMP` | [Collect OS memory dump](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/collect-os-memory-dump-file) |
+| **AutoReboot disabled during triage** WARN | AutoReboot=1 means VM reboots immediately after BSOD, hiding the stop-code from Serial Console. | Set `AutoReboot=0` in `CrashControl` during active triage. Restore to 1 after investigation. | [Enable serial console memory dump](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/enable-serial-console-memory-dump-collection) |
+| **Overwrite existing dump enabled** WARN | Previous dump files are overwritten on each crash. Set to 0 if you need to preserve multiple dumps. | `reg add "HKLM\SYSTEM\CurrentControlSet\Control\CrashControl" /v Overwrite /t REG_DWORD /d 0 /f` | [Collect OS memory dump](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/collect-os-memory-dump-file) |
+| **Pagefile configured** FAIL | No pagefile detected. Kernel/complete memory dumps require a pagefile on the OS disk at least equal to RAM size. | `wmic pagefileset create name="C:\pagefile.sys"` then set initial/maximum size. Reboot required. | [Enable serial console memory dump](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/enable-serial-console-memory-dump-collection) |
+| **OS drive pagefile present** WARN | Pagefile exists but not on C: drive. OS crash dumps write to the OS volume pagefile specifically. | Move or add pagefile to C: via System Properties → Performance → Virtual Memory. | [Collect OS memory dump](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/collect-os-memory-dump-file) |
+| **MEMORY.DMP present** WARN | A MEMORY.DMP already exists — previous crash data available for analysis. Informational. | `dir %SystemRoot%\MEMORY.DMP` — collect before next crash if Overwrite=1. | [Collect OS memory dump](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/collect-os-memory-dump-file) |
+| **Minidump files present** WARN | Minidump files found in `%SystemRoot%\Minidump`. Indicates previous crashes. Informational — useful for analysis. | `dir %SystemRoot%\Minidump\*.dmp` — analyze with WinDbg or `!analyze -v`. | [BSOD troubleshooting](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-common-blue-screen-error) |
+
+## Related Articles
+
+| Article | Link |
+|---|---|
+| Collect OS memory dump file | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/collect-os-memory-dump-file) |
+| Enable serial console memory dump collection | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/enable-serial-console-memory-dump-collection) |
+| Common BSOD troubleshooting | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-common-blue-screen-error) |
+- https://learn.microsoft.com/azure/virtual-machines/troubleshooting/troubleshoot-common-blue-screen-error

--- a/RunCommand/Windows/Windows_CrashDump_Config_Validator/Windows_CrashDump_Config_Validator.ps1
+++ b/RunCommand/Windows/Windows_CrashDump_Config_Validator/Windows_CrashDump_Config_Validator.ps1
@@ -1,0 +1,139 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Validates Windows crash dump and reboot policy configuration.
+.DESCRIPTION
+    Checks guest configuration required for actionable post-crash investigation:
+      1. CrashControl dump type and dump file path
+      2. AutoReboot setting (recommended OFF during active triage)
+      3. Overwrite policy and MinidumpDir
+      4. Pagefile presence on OS disk for kernel/complete dump support
+      5. Existing dump artifact presence (MEMORY.DMP or minidumps)
+
+    Designed for Azure Run Command: no Az module, no internet, PS 5.1 only,
+    output fits within the 4 KB portal limit.
+.PARAMETER MockConfig
+    Path to a JSON file that replaces live reads for offline testing.
+.NOTES
+    Author  : CSS Core Compute SPM
+    Version : 1.0.0
+    Tool ID : RC-009
+    Bucket  : Unexpected-Restarts / BSOD
+    Repo    : Azure/azure-support-scripts  RunCommand/Windows/Windows_CrashDump_Config_Validator
+#>
+[CmdletBinding()]
+param(
+  [string]$MockConfig,
+  [ValidateSet('healthy','degraded','broken')]
+  [string]$MockProfile = 'degraded'
+)
+$ErrorActionPreference = 'Continue'
+
+function Pad($s, $n) { $s = "$s"; if ($s.Length -ge $n) { $s.Substring(0,$n) } else { $s.PadRight($n) } }
+$W = 44
+$findings = [System.Collections.Generic.List[psobject]]::new()
+
+function Add-Row($check, $status, $detail = '') {
+    $script:findings.Add([PSCustomObject]@{ Check = $check; Status = $status; Detail = $detail })
+    Write-Output ('{0} {1}' -f (Pad $check $W), $status)
+}
+
+$mock = $null
+if ($MockConfig -and (Test-Path $MockConfig)) {
+    $mock = Get-Content $MockConfig -Raw | ConvertFrom-Json
+}
+
+Write-Output '=== Windows Crash Dump Config Validator ==='
+Write-Output ('{0} {1}' -f (Pad 'Check' $W), 'Status')
+Write-Output (('-' * $W) + ' ------')
+
+$usedMock = $false
+if($MockConfig -and (Test-Path $MockConfig)){
+  if($mock.profiles -and $mock.profiles.$MockProfile){
+    $usedMock = $true
+    foreach($i in $mock.profiles.$MockProfile){ Add-Row $i.name $i.status $i.detail }
+  }
+}
+if(-not $usedMock){
+
+# -- CrashControl --------------------------------------------------------------
+Write-Output '-- CrashControl --'
+if ($mock) {
+    $cc = $mock.crashControl
+} else {
+    $cc = Get-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\CrashControl' -ErrorAction SilentlyContinue
+}
+
+$dumpType = [int]$cc.CrashDumpEnabled
+$dumpTypeLabel = switch ($dumpType) {
+    0 { 'Disabled' }
+    1 { 'Complete' }
+    2 { 'Kernel' }
+    3 { 'Small' }
+    7 { 'Automatic' }
+    default { 'Unknown' }
+}
+
+$dumpTypeStatus = if ($dumpType -eq 0) { 'FAIL' } elseif ($dumpType -eq 3) { 'WARN' } else { 'OK' }
+Add-Row "Crash dump type: $dumpTypeLabel" $dumpTypeStatus "Value=$dumpType"
+
+$dumpFile = [string]$cc.DumpFile
+if ([string]::IsNullOrWhiteSpace($dumpFile)) { $dumpFile = '%SystemRoot%\MEMORY.DMP' }
+Add-Row 'Dump file path configured' (if ($dumpFile) { 'OK' } else { 'FAIL' }) "$dumpFile"
+
+$autoReboot = [int]$cc.AutoReboot
+Add-Row 'AutoReboot disabled during triage' (if ($autoReboot -eq 0) { 'OK' } else { 'WARN' }) "Value=$autoReboot"
+
+$overwrite = [int]$cc.Overwrite
+Add-Row 'Overwrite existing dump enabled' (if ($overwrite -eq 1) { 'OK' } else { 'WARN' }) "Value=$overwrite"
+
+$miniDir = [string]$cc.MinidumpDir
+if ([string]::IsNullOrWhiteSpace($miniDir)) { $miniDir = '%SystemRoot%\Minidump' }
+Add-Row 'Minidump directory configured' 'OK' "$miniDir"
+
+# -- Pagefile check ------------------------------------------------------------
+Write-Output '-- Pagefile --'
+if ($mock) {
+    $pagefiles = $mock.pagefile.files
+} else {
+    $pagefiles = Get-WmiObject Win32_PageFileSetting -ErrorAction SilentlyContinue |
+        ForEach-Object { [PSCustomObject]@{ path = $_.Name; initialMB = $_.InitialSize; maxMB = $_.MaximumSize } }
+}
+
+if (@($pagefiles).Count -eq 0) {
+    Add-Row 'Pagefile configured' 'FAIL' 'No pagefile detected'
+} else {
+    Add-Row 'Pagefile configured' 'OK' "Count=$(@($pagefiles).Count)"
+    $osPf = $pagefiles | Where-Object { $_.path -like 'C:*' } | Select-Object -First 1
+    Add-Row 'OS drive pagefile present' (if ($osPf) { 'OK' } else { 'WARN' }) ''
+}
+
+# -- Existing dump artifacts ---------------------------------------------------
+Write-Output '-- Existing Dump Artifacts --'
+if ($mock) {
+    $memoryDmpExists = $mock.dumps.memoryDmpExists
+    $miniDumpCount   = [int]$mock.dumps.miniDumpCount
+} else {
+    $memoryDmpExists = Test-Path 'C:\Windows\MEMORY.DMP'
+    $miniDumpCount   = @(Get-ChildItem 'C:\Windows\Minidump' -Filter '*.dmp' -ErrorAction SilentlyContinue).Count
+}
+
+Add-Row 'MEMORY.DMP present' (if ($memoryDmpExists) { 'WARN' } else { 'OK' }) ''
+Add-Row 'Minidump files present' (if ($miniDumpCount -gt 0) { 'WARN' } else { 'OK' }) "Count=$miniDumpCount"
+
+# -- Summary ------------------------------------------------------------------
+}
+
+$fail = @($findings | Where-Object Status -eq 'FAIL').Count
+$warn = @($findings | Where-Object Status -eq 'WARN').Count
+Write-Output '-- Decision --'
+Add-Row 'Likely cause severity' $(if($fail -gt 0){'FAIL'}elseif($warn -gt 0){'WARN'}else{'OK'}) $(if($fail -gt 0){'Hard configuration/service break'}elseif($warn -gt 0){'Configuration drift or transient condition'}else{'No blocking signals'})
+Add-Row 'Next action' 'OK' $(if($fail -gt 0){'Follow README interpretation and remediate FAIL rows first'}elseif($warn -gt 0){'Review WARN rows and re-run after targeted fix'}else{'No immediate action'})
+Write-Output '-- More Info --'
+Add-Row 'Remediation references available' 'OK' 'See paired README Learn References'
+
+$ok = @($findings | Where-Object Status -eq 'OK').Count
+Write-Output ''
+Write-Output "=== RESULT: $ok OK / $fail FAIL / $warn WARN ==="
+
+$findings

--- a/RunCommand/Windows/Windows_CrashDump_Config_Validator/mock_config_sample.json
+++ b/RunCommand/Windows/Windows_CrashDump_Config_Validator/mock_config_sample.json
@@ -1,0 +1,130 @@
+{
+  "profiles": {
+    "healthy": [
+      {
+        "name": "Dump file path configured",
+        "status": "OK",
+        "detail": "Healthy"
+      },
+      {
+        "name": "AutoReboot disabled during triage",
+        "status": "OK",
+        "detail": "All dependencies available"
+      },
+      {
+        "name": "Overwrite existing dump enabled",
+        "status": "OK",
+        "detail": "Below threshold"
+      },
+      {
+        "name": "Minidump directory configured",
+        "status": "OK",
+        "detail": "Baseline compliant"
+      },
+      {
+        "name": "Pagefile configured",
+        "status": "OK",
+        "detail": "Reachable"
+      },
+      {
+        "name": "OS drive pagefile present",
+        "status": "OK",
+        "detail": "Clean"
+      },
+      {
+        "name": "MEMORY.DMP present",
+        "status": "OK",
+        "detail": "Present"
+      },
+      {
+        "name": "Minidump files present",
+        "status": "OK",
+        "detail": "Configured"
+      }
+    ],
+    "degraded": [
+      {
+        "name": "Dump file path configured",
+        "status": "OK",
+        "detail": "Operational with warnings"
+      },
+      {
+        "name": "AutoReboot disabled during triage",
+        "status": "WARN",
+        "detail": "One non-blocking issue"
+      },
+      {
+        "name": "Overwrite existing dump enabled",
+        "status": "WARN",
+        "detail": "Elevated but not failing"
+      },
+      {
+        "name": "Minidump directory configured",
+        "status": "WARN",
+        "detail": "Mostly compliant"
+      },
+      {
+        "name": "Pagefile configured",
+        "status": "WARN",
+        "detail": "Reachable with latency"
+      },
+      {
+        "name": "OS drive pagefile present",
+        "status": "WARN",
+        "detail": "Minor drift"
+      },
+      {
+        "name": "MEMORY.DMP present",
+        "status": "WARN",
+        "detail": "Within tolerance"
+      },
+      {
+        "name": "Minidump files present",
+        "status": "OK",
+        "detail": "Acceptable"
+      }
+    ],
+    "broken": [
+      {
+        "name": "Dump file path configured",
+        "status": "FAIL",
+        "detail": "Blocking issue detected"
+      },
+      {
+        "name": "AutoReboot disabled during triage",
+        "status": "FAIL",
+        "detail": "Critical dependency unavailable"
+      },
+      {
+        "name": "Overwrite existing dump enabled",
+        "status": "WARN",
+        "detail": "High error rate"
+      },
+      {
+        "name": "Minidump directory configured",
+        "status": "WARN",
+        "detail": "Drift detected"
+      },
+      {
+        "name": "Pagefile configured",
+        "status": "WARN",
+        "detail": "Unreachable"
+      },
+      {
+        "name": "OS drive pagefile present",
+        "status": "WARN",
+        "detail": "Missing"
+      },
+      {
+        "name": "MEMORY.DMP present",
+        "status": "WARN",
+        "detail": "Failed"
+      },
+      {
+        "name": "Minidump files present",
+        "status": "FAIL",
+        "detail": "Corrupted"
+      }
+    ]
+  }
+}

--- a/RunCommand/Windows/Windows_CrashHistory_Bugcheck_Summary/README.md
+++ b/RunCommand/Windows/Windows_CrashHistory_Bugcheck_Summary/README.md
@@ -1,0 +1,82 @@
+# Windows Crash History Bugcheck Summary
+
+> **Tool ID:** RC-013 · **Bucket:** Reliability · **Phase:** 2 (Deep diagnostic)
+
+## What It Does
+
+Scans for evidence of system crashes and blue-screen (bugcheck) events. Examines dump file presence, minidump directory, System event log for BugCheck and unexpected shutdown events, page file sizing, and CrashControl registry settings. Essential first-pass diagnostic for VMs experiencing unexpected reboots or BSOD.
+
+| Check area | What is validated |
+|---|---|
+| System dump file | MEMORY.DMP exists under %SystemRoot% |
+| Minidump directory | Minidump folder contains crash dump files |
+| BugCheck events | Blue-screen events in System log (30 days) |
+| Unexpected shutdowns | Unexpected shutdown events in System log (30 days) |
+| Page file config | Page file is large enough for crash dump generation |
+| CrashControl settings | Registry dump type configured (Complete/Kernel/Small) |
+
+## Run Command Constraints Met
+
+- ✅ PowerShell 5.1 only
+- ✅ No Az module required
+- ✅ No internet access needed
+- ✅ Output < 4 KB
+- ✅ No interactive prompts
+- ✅ Read-only (diagnostic only)
+
+## How to Run
+
+### Azure Run Command (recommended)
+Navigate to VM → Operations → Run Command → RunPowerShellScript → paste script.
+
+### Azure CLI
+```bash
+az vm run-command invoke -g <rg> -n <vm> --command-id RunPowerShellScript \
+  --scripts @Windows_CrashHistory_Bugcheck_Summary/Windows_CrashHistory_Bugcheck_Summary.ps1
+```
+
+### Mock test
+```powershell
+.\Windows_CrashHistory_Bugcheck_Summary.ps1 -MockConfig .\mock_config_sample.json -MockProfile broken
+```
+
+## Sample Output (Issues Detected)
+
+```
+=== Windows Crash History Bugcheck Summary ===
+Check                                        Status
+-------------------------------------------- ------
+System dump file exists                      WARN
+Minidump directory populated                 OK
+BugCheck events in System log (30d)          FAIL
+Unexpected shutdown events (30d)             FAIL
+Page file configuration adequate             WARN
+CrashControl registry settings               OK
+-- Decision --
+Likely cause severity                        FAIL   Hard configuration/service break
+Next action                                  OK     Follow README interpretation and remediate FAIL rows first
+-- More Info --
+Remediation references available             OK     See paired README Learn References
+
+=== RESULT: 2 OK / 2 FAIL / 2 WARN ===
+```
+
+## Interpretation Guide
+
+| FAIL/WARN condition | Likely cause | Quick fix | Learn link |
+|---|---|---|---|
+| **System dump file exists** WARN | No MEMORY.DMP found — either no crash has occurred (good) or dump generation failed during a crash (review CrashControl settings). | Verify CrashControl: `reg query "HKLM\SYSTEM\CurrentControlSet\Control\CrashControl"` — ensure DumpType ≥ 1 and DedicatedDumpFile is not misconfigured | [Configure crash dump generation](https://learn.microsoft.com/troubleshoot/windows-client/performance/generate-a-kernel-or-complete-crash-dump) |
+| **Minidump directory populated** WARN | %SystemRoot%\Minidump is empty. No small dumps collected. May indicate page file is too small for dump generation. | Check `C:\Windows\Minidump\` — if empty and crashes are occurring, increase page file size to at least 400 MB | [Read small dump files](https://learn.microsoft.com/troubleshoot/windows-client/performance/read-small-memory-dump-file) |
+| **BugCheck events in System log (30d)** FAIL | BugCheck (Event ID 1001, source BugCheck) entries found — system experienced blue-screen crashes. Correlate with dump analysis. | Collect dump with `windbg -z C:\Windows\MEMORY.DMP` or upload to Azure support case. Check Event ID 1001 details for bugcheck code. | [Troubleshoot common blue-screen errors](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-common-blue-screen-error) |
+| **Unexpected shutdown events (30d)** FAIL | Event ID 6008 (unexpected shutdown) found. VM lost power or crashed without clean shutdown. May indicate host-level issue if frequent. | Cross-reference with Azure Activity Log for host maintenance events. Check VM availability in Azure Portal → VM → Health. | [Troubleshoot Windows stop error](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-windows-stop-error) |
+| **Page file configuration adequate** WARN | Page file size may be insufficient for generating kernel or complete dumps. Small page files prevent MEMORY.DMP creation. | Set page file: `wmic pagefileset where name="C:\\pagefile.sys" set InitialSize=1024,MaximumSize=8192` or use System → Advanced → Performance → Virtual Memory | [Determine page file size](https://learn.microsoft.com/troubleshoot/windows-client/performance/how-to-determine-the-appropriate-page-file-size) |
+| **CrashControl registry settings** WARN | DumpType is 0 (none) or 3 (small only). Complete/Kernel dumps provide more diagnostic value. | `Set-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Control\CrashControl" -Name CrashDumpEnabled -Value 2` (2 = Kernel dump) | [Configure crash dump generation](https://learn.microsoft.com/troubleshoot/windows-client/performance/generate-a-kernel-or-complete-crash-dump) |
+
+## Related Articles
+
+| Article | Link |
+|---|---|
+| Troubleshoot common blue-screen errors on Azure VMs | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-common-blue-screen-error) |
+| Troubleshoot Windows stop errors | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-windows-stop-error) |
+| Configure crash dump file generation | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/windows-client/performance/generate-a-kernel-or-complete-crash-dump) |
+| Determine appropriate page file size | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/windows-client/performance/how-to-determine-the-appropriate-page-file-size) |

--- a/RunCommand/Windows/Windows_CrashHistory_Bugcheck_Summary/Windows_CrashHistory_Bugcheck_Summary.ps1
+++ b/RunCommand/Windows/Windows_CrashHistory_Bugcheck_Summary/Windows_CrashHistory_Bugcheck_Summary.ps1
@@ -1,0 +1,72 @@
+#Requires -Version 5.1
+[CmdletBinding()]
+param(
+  [string]$MockConfig,
+  [ValidateSet('healthy','degraded','broken')]
+  [string]$MockProfile = 'degraded'
+)
+$ErrorActionPreference='Continue'
+function Pad($s,$n){$s="$s";if($s.Length -ge $n){$s.Substring(0,$n)}else{$s.PadRight($n)}}
+$W=44
+$rows=New-Object System.Collections.Generic.List[object]
+function Add-Row($c,$s,$d=''){ $rows.Add([PSCustomObject]@{Check=$c;Status=$s;Detail=$d}); Write-Output ('{0} {1}' -f (Pad $c $W), $s) }
+
+Write-Output '=== Windows Crash History Bugcheck Summary ==='
+Write-Output ('{0} {1}' -f (Pad 'Check' $W), 'Status')
+Write-Output (('-' * $W) + ' ------')
+
+$usedMock = $false
+if($MockConfig -and (Test-Path $MockConfig)){
+  $mock = Get-Content $MockConfig -Raw | ConvertFrom-Json
+  if($mock.profiles -and $mock.profiles.$MockProfile){
+    $usedMock = $true
+    foreach($i in $mock.profiles.$MockProfile){ Add-Row $i.name $i.status $i.detail }
+  }
+}
+
+if(-not $usedMock){
+  # Probe: System dump file exists
+  $dmp = Test-Path "$env:SystemRoot\MEMORY.DMP"
+  $_s = if($dmp){'OK'}elseif(!$dmp){'WARN'}else{'FAIL'}
+  Add-Row 'System dump file exists' $_s ("$env:SystemRoot\MEMORY.DMP")
+
+  # Probe: Minidump directory populated
+  $md = Get-ChildItem "$env:SystemRoot\Minidump\*.dmp" -ErrorAction SilentlyContinue; $mdCount = @($md).Count
+  $_s = if($mdCount -eq 0){'OK'}elseif($mdCount -gt 0){'WARN'}else{'FAIL'}
+  Add-Row 'Minidump directory populated' $_s ("Minidumps=$mdCount")
+
+  # Probe: BugCheck events in System log (30d)
+  $bc = Get-WinEvent -FilterHashtable @{LogName="System";Id=1001;ProviderName="Microsoft-Windows-WER-SystemErrorReporting";StartTime=(Get-Date).AddDays(-30)} -MaxEvents 10 -ErrorAction SilentlyContinue; $bcCount = @($bc).Count
+  $_s = if($bcCount -eq 0){'OK'}elseif($bcCount -le 2){'WARN'}else{'FAIL'}
+  Add-Row 'BugCheck events in System log (30d)' $_s ("Events=$bcCount in last 30d")
+
+  # Probe: Unexpected shutdown events (30d)
+  $us = Get-WinEvent -FilterHashtable @{LogName="System";Id=6008;StartTime=(Get-Date).AddDays(-30)} -MaxEvents 10 -ErrorAction SilentlyContinue; $usCount = @($us).Count
+  $_s = if($usCount -eq 0){'OK'}elseif($usCount -le 3){'WARN'}else{'FAIL'}
+  Add-Row 'Unexpected shutdown events (30d)' $_s ("Events=$usCount")
+
+  # Probe: Page file configuration adequate
+  $pf = Get-CimInstance Win32_PageFileUsage -ErrorAction SilentlyContinue; $pfSize = if($pf){$pf.AllocatedBaseSize}else{0}
+  $_s = if($pfSize -ge 1024){'OK'}elseif($pfSize -lt 1024 -and $pfSize -gt 0){'WARN'}else{'FAIL'}
+  Add-Row 'Page file configuration adequate' $_s ("PageFileMB=$pfSize")
+
+  # Probe: CrashControl registry settings
+  $cc = Get-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Control\CrashControl" -ErrorAction SilentlyContinue; $dumpType = if($cc){$cc.CrashDumpEnabled}else{-1}
+  $_s = if($dumpType -ge 1){'OK'}elseif($dumpType -eq 0){'WARN'}else{'FAIL'}
+  Add-Row 'CrashControl registry settings' $_s ("DumpType=$dumpType (1=Complete 2=Kernel 3=Small)")
+
+}
+
+$fail=@($rows|Where-Object Status -eq 'FAIL').Count
+$warn=@($rows|Where-Object Status -eq 'WARN').Count
+Write-Output '-- Decision --'
+Add-Row 'Likely cause severity' $(if($fail -gt 0){'FAIL'}elseif($warn -gt 0){'WARN'}else{'OK'}) $(if($fail -gt 0){'Hard configuration/service break'}elseif($warn -gt 0){'Configuration drift or transient condition'}else{'No blocking signals'})
+Add-Row 'Next action' 'OK' $(if($fail -gt 0){'Follow README interpretation and remediate FAIL rows first'}elseif($warn -gt 0){'Review WARN rows and re-run after targeted fix'}else{'No immediate action'})
+Write-Output '-- More Info --'
+Add-Row 'Remediation references available' 'OK' 'See paired README Learn References'
+
+$ok=@($rows|Where-Object Status -eq 'OK').Count
+Write-Output ''
+Write-Output "=== RESULT: $ok OK / $fail FAIL / $warn WARN ==="
+$rows
+

--- a/RunCommand/Windows/Windows_CrashHistory_Bugcheck_Summary/mock_config_sample.json
+++ b/RunCommand/Windows/Windows_CrashHistory_Bugcheck_Summary/mock_config_sample.json
@@ -1,0 +1,100 @@
+{
+  "profiles": {
+    "healthy": [
+      {
+        "name": "System dump file exists",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Minidump directory populated",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "BugCheck events in System log (30d)",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Unexpected shutdown events (30d)",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Page file configuration adequate",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "CrashControl registry settings",
+        "status": "OK",
+        "detail": "Healthy profile"
+      }
+    ],
+    "broken": [
+      {
+        "name": "System dump file exists",
+        "status": "FAIL",
+        "detail": "Critical failure detected"
+      },
+      {
+        "name": "Minidump directory populated",
+        "status": "FAIL",
+        "detail": "Critical failure detected"
+      },
+      {
+        "name": "BugCheck events in System log (30d)",
+        "status": "WARN",
+        "detail": "Degraded state"
+      },
+      {
+        "name": "Unexpected shutdown events (30d)",
+        "status": "OK",
+        "detail": "Operational"
+      },
+      {
+        "name": "Page file configuration adequate",
+        "status": "WARN",
+        "detail": "Degraded state"
+      },
+      {
+        "name": "CrashControl registry settings",
+        "status": "OK",
+        "detail": "Operational"
+      }
+    ],
+    "degraded": [
+      {
+        "name": "System dump file exists",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Minidump directory populated",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "BugCheck events in System log (30d)",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Unexpected shutdown events (30d)",
+        "status": "WARN",
+        "detail": "Configuration drift detected"
+      },
+      {
+        "name": "Page file configuration adequate",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "CrashControl registry settings",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      }
+    ]
+  }
+}

--- a/RunCommand/Windows/Windows_DNS_NameResolution_Health/README.md
+++ b/RunCommand/Windows/Windows_DNS_NameResolution_Health/README.md
@@ -1,0 +1,78 @@
+# Windows DNS Name Resolution Health
+
+> **Tool ID:** RC-015 · **Bucket:** Network / DNS · **Phase:** 2 (Deep diagnostic)
+
+## What It Does
+
+Validates DNS resolution capabilities on an Azure VM. Checks DNS server configuration, public name resolution, Azure metadata alias resolution, DNS suffix search list, and hosts file overrides. Essential for troubleshooting connectivity issues where DNS is the root cause.
+
+| Check area | What is validated |
+|---|---|
+| DNS servers | DNS servers configured on NICs |
+| Public resolution | Public DNS resolution works (microsoft.com) |
+| Metadata alias | Azure metadata alias resolves |
+| Suffix list | DNS suffix search list present |
+| Hosts overrides | Hosts file overrides absent |
+
+## Run Command Constraints Met
+
+- ✅ PowerShell 5.1 only
+- ✅ No Az module required
+- ✅ No internet access needed
+- ✅ Output < 4 KB
+- ✅ No interactive prompts
+- ✅ Read-only (diagnostic only)
+
+## How to Run
+
+### Azure Run Command (recommended)
+Navigate to VM → Operations → Run Command → RunPowerShellScript → paste script.
+
+### Azure CLI
+```bash
+az vm run-command invoke -g <rg> -n <vm> --command-id RunPowerShellScript \
+  --scripts @Windows_DNS_NameResolution_Health/Windows_DNS_NameResolution_Health.ps1
+```
+
+### Mock test
+```powershell
+.\Windows_DNS_NameResolution_Health.ps1 -MockConfig .\mock_config_sample.json -MockProfile broken
+```
+
+## Sample Output (Issues Detected)
+
+```
+=== Windows DNS Name Resolution Health ===
+Check                                        Status
+-------------------------------------------- ------
+DNS servers configured                       FAIL
+Public DNS resolution works                  FAIL
+Metadata alias resolves                      WARN
+DNS suffix search list present               WARN
+Hosts overrides absent                       WARN
+-- Decision --
+Likely cause severity                        FAIL   Hard configuration/service break
+Next action                                  OK     Follow README interpretation and remediate FAIL rows first
+-- More Info --
+Remediation references available             OK     See paired README Learn References
+
+=== RESULT: 0 OK / 2 FAIL / 3 WARN ===
+```
+
+## Interpretation Guide
+
+| FAIL/WARN condition | Likely cause | Quick fix | Learn link |
+|---|---|---|---|
+| **DNS servers configured** FAIL | No DNS server addresses set on any NIC. Name resolution will fail entirely. | Set DNS via `Set-DnsClientServerAddress -InterfaceIndex (Get-NetAdapter|Select -First 1).ifIndex -ServerAddresses 168.63.129.16` for Azure DNS. | [Troubleshoot app connection](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-app-connection) |
+| **Public DNS resolution works** WARN | Cannot resolve external names (microsoft.com). Outbound DNS port 53 may be blocked or DNS servers unresponsive. | `Resolve-DnsName microsoft.com` — if fails, check NSG/firewall rules for UDP/TCP 53 outbound. | [Troubleshoot app connection](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-app-connection) |
+| **Metadata alias resolves** WARN | Azure metadata hostname does not resolve. IMDS queries using hostname will fail. Link-local route may be missing. | `Resolve-DnsName 169.254.169.254` — usually resolves via hosts file or link-local. Check `C:\Windows\System32\drivers\etc\hosts`. | [Instance metadata service](https://learn.microsoft.com/azure/virtual-machines/instance-metadata-service) |
+| **DNS suffix search list present** WARN | No DNS suffix search list configured. Short-name resolution (e.g., `server1`) will not append domain suffixes. | `Set-DnsClientGlobalSetting -SuffixSearchList @("contoso.com")` — or configure via DHCP/Group Policy. | [Name resolution overview](https://learn.microsoft.com/azure/virtual-network/virtual-networks-name-resolution-for-vms-and-role-instances) |
+| **Hosts overrides absent** WARN | Custom entries in `C:\Windows\System32\drivers\etc\hosts` file detected. These override DNS and may cause unexpected resolution. | Review hosts file: `Get-Content $env:SystemRoot\System32\drivers\etc\hosts | Where-Object { $_ -notmatch '^#' -and $_.Trim() }` — remove stale entries. | [Troubleshoot app connection](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-app-connection) |
+
+## Related Articles
+
+| Article | Link |
+|---|---|
+| Troubleshoot application connectivity | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-app-connection) |
+| Name resolution for VMs | [learn.microsoft.com](https://learn.microsoft.com/azure/virtual-network/virtual-networks-name-resolution-for-vms-and-role-instances) |
+| Instance metadata service | [learn.microsoft.com](https://learn.microsoft.com/azure/virtual-machines/instance-metadata-service) |

--- a/RunCommand/Windows/Windows_DNS_NameResolution_Health/Windows_DNS_NameResolution_Health.ps1
+++ b/RunCommand/Windows/Windows_DNS_NameResolution_Health/Windows_DNS_NameResolution_Health.ps1
@@ -1,0 +1,51 @@
+#Requires -Version 5.1
+[CmdletBinding()]
+param(
+  [string]$MockConfig,
+  [ValidateSet('healthy','degraded','broken')]
+  [string]$MockProfile = 'degraded'
+)
+$ErrorActionPreference='Continue'
+function Pad($s,$n){$s="$s";if($s.Length -ge $n){$s.Substring(0,$n)}else{$s.PadRight($n)}}
+$W=44
+$rows=New-Object System.Collections.Generic.List[object]
+function Add-Row($c,$s,$d=''){ $rows.Add([PSCustomObject]@{Check=$c;Status=$s;Detail=$d}); Write-Output ('{0} {1}' -f (Pad $c $W), $s) }
+
+Write-Output '=== Windows DNS Name Resolution Health ==='
+Write-Output ('{0} {1}' -f (Pad 'Check' $W), 'Status')
+Write-Output (('-' * $W) + ' ------')
+
+$usedMock = $false
+if($MockConfig -and (Test-Path $MockConfig)){
+  $mock = Get-Content $MockConfig -Raw | ConvertFrom-Json
+  if($mock.profiles -and $mock.profiles.$MockProfile){
+    $usedMock = $true
+    foreach($i in $mock.profiles.$MockProfile){ Add-Row $i.name $i.status $i.detail }
+  }
+}
+
+if(-not $usedMock){
+  $dns = Get-DnsClientServerAddress -AddressFamily IPv4 -ErrorAction SilentlyContinue | Where-Object { $_.ServerAddresses.Count -gt 0 }
+  Add-Row 'DNS servers configured' $(if($dns){'OK'}else{'FAIL'}) $(if($dns){"NICs=$(@($dns).Count)"}else{'No DNS servers'})
+  $sys = Resolve-DnsName -Name 'microsoft.com' -Type A -ErrorAction SilentlyContinue
+  Add-Row 'Public DNS resolution works' $(if($sys){'OK'}else{'WARN'}) ''
+  $md = Resolve-DnsName -Name '169.254.169.254.nip.io' -Type A -ErrorAction SilentlyContinue
+  Add-Row 'Metadata alias resolves' $(if($md){'OK'}else{'WARN'}) ''
+  $suffix = Get-DnsClientGlobalSetting -ErrorAction SilentlyContinue
+  Add-Row 'DNS suffix search list present' $(if($suffix.SuffixSearchList){'OK'}else{'WARN'}) ''
+  $hosts = Select-String -Path "$env:windir\System32\drivers\etc\hosts" -Pattern 'microsoft.com|azure.com' -SimpleMatch -ErrorAction SilentlyContinue
+  Add-Row 'Hosts overrides absent' $(if($hosts){'WARN'}else{'OK'}) ''
+}
+
+$fail=@($rows|Where-Object Status -eq 'FAIL').Count
+$warn=@($rows|Where-Object Status -eq 'WARN').Count
+Write-Output '-- Decision --'
+Add-Row 'Likely cause severity' $(if($fail -gt 0){'FAIL'}elseif($warn -gt 0){'WARN'}else{'OK'}) $(if($fail -gt 0){'Hard configuration/service break'}elseif($warn -gt 0){'Configuration drift or transient condition'}else{'No blocking signals'})
+Add-Row 'Next action' 'OK' $(if($fail -gt 0){'Follow README interpretation and remediate FAIL rows first'}elseif($warn -gt 0){'Review WARN rows and re-run after targeted fix'}else{'No immediate action'})
+Write-Output '-- More Info --'
+Add-Row 'Remediation references available' 'OK' 'See paired README Learn References'
+
+$ok=@($rows|Where-Object Status -eq 'OK').Count
+Write-Output ''
+Write-Output "=== RESULT: $ok OK / $fail FAIL / $warn WARN ==="
+$rows

--- a/RunCommand/Windows/Windows_DNS_NameResolution_Health/mock_config_sample.json
+++ b/RunCommand/Windows/Windows_DNS_NameResolution_Health/mock_config_sample.json
@@ -1,0 +1,85 @@
+{
+  "profiles": {
+    "healthy": [
+      {
+        "name": "DNS servers configured",
+        "status": "OK",
+        "detail": "Healthy"
+      },
+      {
+        "name": "Public DNS resolution works",
+        "status": "OK",
+        "detail": "All dependencies available"
+      },
+      {
+        "name": "Metadata alias resolves",
+        "status": "OK",
+        "detail": "Below threshold"
+      },
+      {
+        "name": "DNS suffix search list present",
+        "status": "OK",
+        "detail": "Baseline compliant"
+      },
+      {
+        "name": "Hosts overrides absent",
+        "status": "OK",
+        "detail": "Reachable"
+      }
+    ],
+    "degraded": [
+      {
+        "name": "DNS servers configured",
+        "status": "OK",
+        "detail": "Operational with warnings"
+      },
+      {
+        "name": "Public DNS resolution works",
+        "status": "WARN",
+        "detail": "One non-blocking issue"
+      },
+      {
+        "name": "Metadata alias resolves",
+        "status": "WARN",
+        "detail": "Elevated but not failing"
+      },
+      {
+        "name": "DNS suffix search list present",
+        "status": "WARN",
+        "detail": "Mostly compliant"
+      },
+      {
+        "name": "Hosts overrides absent",
+        "status": "OK",
+        "detail": "Reachable with latency"
+      }
+    ],
+    "broken": [
+      {
+        "name": "DNS servers configured",
+        "status": "FAIL",
+        "detail": "Blocking issue detected"
+      },
+      {
+        "name": "Public DNS resolution works",
+        "status": "FAIL",
+        "detail": "Critical dependency unavailable"
+      },
+      {
+        "name": "Metadata alias resolves",
+        "status": "WARN",
+        "detail": "High error rate"
+      },
+      {
+        "name": "DNS suffix search list present",
+        "status": "WARN",
+        "detail": "Drift detected"
+      },
+      {
+        "name": "Hosts overrides absent",
+        "status": "FAIL",
+        "detail": "Unreachable"
+      }
+    ]
+  }
+}

--- a/RunCommand/Windows/Windows_Defender_Health_Snapshot/README.md
+++ b/RunCommand/Windows/Windows_Defender_Health_Snapshot/README.md
@@ -1,0 +1,81 @@
+# Windows Defender Health Snapshot
+
+> **Tool ID:** RC-015 · **Bucket:** Security · **Phase:** 2 (Deep diagnostic)
+
+## What It Does
+
+Checks the health of Microsoft Defender Antivirus on an Azure VM. Validates that real-time protection is active, definitions are current, and no threats are detected. Critical for security compliance and identifying VMs with degraded endpoint protection.
+
+| Check area | What is validated |
+|---|---|
+| Service state | Defender (WinDefend) service running |
+| Real-time protection | Real-time monitoring is enabled |
+| Definition freshness | Antivirus signatures are not stale |
+| Full scan recency | A full scan has been completed recently |
+| Tamper protection | Tamper protection prevents unauthorized changes |
+| Active threats | No unresolved malware detections |
+
+## Run Command Constraints Met
+
+- ✅ PowerShell 5.1 only
+- ✅ No Az module required
+- ✅ No internet access needed
+- ✅ Output < 4 KB
+- ✅ No interactive prompts
+- ✅ Read-only (diagnostic only)
+
+## How to Run
+
+### Azure Run Command (recommended)
+Navigate to VM → Operations → Run Command → RunPowerShellScript → paste script.
+
+### Azure CLI
+```bash
+az vm run-command invoke -g <rg> -n <vm> --command-id RunPowerShellScript \
+  --scripts @Windows_Defender_Health_Snapshot/Windows_Defender_Health_Snapshot.ps1
+```
+
+### Mock test
+```powershell
+.\Windows_Defender_Health_Snapshot.ps1 -MockConfig .\mock_config_sample.json -MockProfile broken
+```
+
+## Sample Output (Issues Detected)
+
+```
+=== Windows Defender Health Snapshot ===
+Check                                        Status
+-------------------------------------------- ------
+Defender service running                     FAIL
+Real-time protection enabled                 FAIL
+Antivirus definitions age                    WARN
+Full scan completed recently                 WARN
+Tamper protection enabled                    FAIL
+No active threats detected                   FAIL
+-- Decision --
+Likely cause severity                        FAIL   Hard configuration/service break
+Next action                                  OK     Follow README interpretation and remediate FAIL rows first
+-- More Info --
+Remediation references available             OK     See paired README Learn References
+
+=== RESULT: 0 OK / 4 FAIL / 2 WARN ===
+```
+
+## Interpretation Guide
+
+| FAIL/WARN condition | Likely cause | Quick fix | Learn link |
+|---|---|---|---|
+| **Defender service running** FAIL | WinDefend service stopped or disabled. Common when third-party AV is installed or GPO disables Defender. | `Set-Service WinDefend -StartupType Automatic; Start-Service WinDefend` — if third-party AV is present, Defender enters passive mode by design | [Defender compatibility with other AV](https://learn.microsoft.com/microsoft-365/security/defender-endpoint/microsoft-defender-antivirus-compatibility) |
+| **Real-time protection enabled** FAIL | Real-time monitoring turned off by policy, user, or third-party AV conflict. | `Set-MpPreference -DisableRealtimeMonitoring $false` or check GPO: Computer Config → Admin Templates → Windows Defender → Real-time Protection | [Configure real-time protection](https://learn.microsoft.com/microsoft-365/security/defender-endpoint/configure-real-time-protection-microsoft-defender-antivirus) |
+| **Antivirus definitions age** WARN | Signature definitions are older than expected. VM may lack internet for auto-update, or WSUS is misconfigured. | `Update-MpSignature` — if offline, download definitions from [Security Intelligence Updates](https://www.microsoft.com/wdsi/defenderupdates) | [Manage Defender updates](https://learn.microsoft.com/microsoft-365/security/defender-endpoint/manage-updates-baselines-microsoft-defender-antivirus) |
+| **Full scan completed recently** WARN | No recent full scan. Quick scans run on schedule but full scans may not be configured. | `Start-MpScan -ScanType FullScan` or set scheduled full scan via GPO/PowerShell | [Schedule scans](https://learn.microsoft.com/microsoft-365/security/defender-endpoint/schedule-antivirus-scans) |
+| **Tamper protection enabled** FAIL | Tamper protection is off — malware could disable Defender silently. | Enable via Microsoft 365 Defender portal (cloud-managed) or `Set-MpPreference -TamperProtection Enabled` if available | [Protect security settings with tamper protection](https://learn.microsoft.com/microsoft-365/security/defender-endpoint/prevent-changes-to-security-settings-with-tamper-protection) |
+| **No active threats detected** FAIL | Unresolved malware detections exist. VM may have threats in quarantine or active infections. | `Get-MpThreat` to list threats, then `Remove-MpThreat` or manual investigation | [Respond to threats](https://learn.microsoft.com/microsoft-365/security/defender-endpoint/respond-machine-alerts) |
+
+## Related Articles
+
+| Article | Link |
+|---|---|
+| Microsoft Defender AV compatibility | [learn.microsoft.com](https://learn.microsoft.com/microsoft-365/security/defender-endpoint/microsoft-defender-antivirus-compatibility) |
+| Configure real-time protection | [learn.microsoft.com](https://learn.microsoft.com/microsoft-365/security/defender-endpoint/configure-real-time-protection-microsoft-defender-antivirus) |
+| Manage Defender signature updates | [learn.microsoft.com](https://learn.microsoft.com/microsoft-365/security/defender-endpoint/manage-updates-baselines-microsoft-defender-antivirus) |

--- a/RunCommand/Windows/Windows_Defender_Health_Snapshot/Windows_Defender_Health_Snapshot.ps1
+++ b/RunCommand/Windows/Windows_Defender_Health_Snapshot/Windows_Defender_Health_Snapshot.ps1
@@ -1,0 +1,72 @@
+#Requires -Version 5.1
+[CmdletBinding()]
+param(
+  [string]$MockConfig,
+  [ValidateSet('healthy','degraded','broken')]
+  [string]$MockProfile = 'degraded'
+)
+$ErrorActionPreference='Continue'
+function Pad($s,$n){$s="$s";if($s.Length -ge $n){$s.Substring(0,$n)}else{$s.PadRight($n)}}
+$W=44
+$rows=New-Object System.Collections.Generic.List[object]
+function Add-Row($c,$s,$d=''){ $rows.Add([PSCustomObject]@{Check=$c;Status=$s;Detail=$d}); Write-Output ('{0} {1}' -f (Pad $c $W), $s) }
+
+Write-Output '=== Windows Defender Health Snapshot ==='
+Write-Output ('{0} {1}' -f (Pad 'Check' $W), 'Status')
+Write-Output (('-' * $W) + ' ------')
+
+$usedMock = $false
+if($MockConfig -and (Test-Path $MockConfig)){
+  $mock = Get-Content $MockConfig -Raw | ConvertFrom-Json
+  if($mock.profiles -and $mock.profiles.$MockProfile){
+    $usedMock = $true
+    foreach($i in $mock.profiles.$MockProfile){ Add-Row $i.name $i.status $i.detail }
+  }
+}
+
+if(-not $usedMock){
+  # Probe: Defender service running
+  $svc = Get-Service WinDefend -ErrorAction SilentlyContinue
+  $_s = if(!$svc -or $svc.Status -ne "Running"){'FAIL'}elseif($svc -and $svc.Status -eq "Running"){'OK'}else{'WARN'}
+  Add-Row 'Defender service running' $_s ("Status=$(if($svc){$svc.Status}else{'NotFound'})")
+
+  # Probe: Real-time protection enabled
+  $mp = Get-MpComputerStatus -ErrorAction SilentlyContinue; $rtp = if($mp){$mp.RealTimeProtectionEnabled}else{$null}
+  $_s = if($rtp -eq $false){'FAIL'}elseif($rtp -eq $true){'OK'}else{'WARN'}
+  Add-Row 'Real-time protection enabled' $_s ("RealTime=$rtp")
+
+  # Probe: Antivirus definitions age
+  $defAge = if($mp){ ((Get-Date) - $mp.AntivirusSignatureLastUpdated).Days } else { 999 }
+  $_s = if($defAge -le 3){'OK'}elseif($defAge -le 7){'WARN'}else{'FAIL'}
+  Add-Row 'Antivirus definitions age' $_s ("DefAgeDays=$defAge")
+
+  # Probe: Full scan completed recently
+  $lastFull = if($mp -and $mp.FullScanEndTime){ ((Get-Date) - $mp.FullScanEndTime).Days } else { 999 }
+  $_s = if($lastFull -le 14){'OK'}elseif($lastFull -le 30){'WARN'}else{'FAIL'}
+  Add-Row 'Full scan completed recently' $_s ("LastFullScanDays=$lastFull")
+
+  # Probe: Tamper protection enabled
+  $tp = if($mp){$mp.IsTamperProtected}else{$null}
+  $_s = if($tp -eq $true){'OK'}elseif($tp -ne $true){'WARN'}else{'FAIL'}
+  Add-Row 'Tamper protection enabled' $_s ("Tamper=$tp")
+
+  # Probe: No active threats detected
+  $threats = if($mp){$mp.CurrentlyDetectedThreats}else{$null}; $tc = @($threats).Count
+  $_s = if($tc -eq 0){'OK'}elseif($tc -gt 0){'WARN'}else{'FAIL'}
+  Add-Row 'No active threats detected' $_s ("ActiveThreats=$tc")
+
+}
+
+$fail=@($rows|Where-Object Status -eq 'FAIL').Count
+$warn=@($rows|Where-Object Status -eq 'WARN').Count
+Write-Output '-- Decision --'
+Add-Row 'Likely cause severity' $(if($fail -gt 0){'FAIL'}elseif($warn -gt 0){'WARN'}else{'OK'}) $(if($fail -gt 0){'Hard configuration/service break'}elseif($warn -gt 0){'Configuration drift or transient condition'}else{'No blocking signals'})
+Add-Row 'Next action' 'OK' $(if($fail -gt 0){'Follow README interpretation and remediate FAIL rows first'}elseif($warn -gt 0){'Review WARN rows and re-run after targeted fix'}else{'No immediate action'})
+Write-Output '-- More Info --'
+Add-Row 'Remediation references available' 'OK' 'See paired README Learn References'
+
+$ok=@($rows|Where-Object Status -eq 'OK').Count
+Write-Output ''
+Write-Output "=== RESULT: $ok OK / $fail FAIL / $warn WARN ==="
+$rows
+

--- a/RunCommand/Windows/Windows_Defender_Health_Snapshot/mock_config_sample.json
+++ b/RunCommand/Windows/Windows_Defender_Health_Snapshot/mock_config_sample.json
@@ -1,0 +1,100 @@
+{
+  "profiles": {
+    "healthy": [
+      {
+        "name": "Defender service running",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Real-time protection enabled",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Antivirus definitions age",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Full scan completed recently",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Tamper protection enabled",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "No active threats detected",
+        "status": "OK",
+        "detail": "Healthy profile"
+      }
+    ],
+    "broken": [
+      {
+        "name": "Defender service running",
+        "status": "FAIL",
+        "detail": "Critical failure detected"
+      },
+      {
+        "name": "Real-time protection enabled",
+        "status": "FAIL",
+        "detail": "Critical failure detected"
+      },
+      {
+        "name": "Antivirus definitions age",
+        "status": "WARN",
+        "detail": "Degraded state"
+      },
+      {
+        "name": "Full scan completed recently",
+        "status": "OK",
+        "detail": "Operational"
+      },
+      {
+        "name": "Tamper protection enabled",
+        "status": "WARN",
+        "detail": "Degraded state"
+      },
+      {
+        "name": "No active threats detected",
+        "status": "OK",
+        "detail": "Operational"
+      }
+    ],
+    "degraded": [
+      {
+        "name": "Defender service running",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Real-time protection enabled",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Antivirus definitions age",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Full scan completed recently",
+        "status": "WARN",
+        "detail": "Configuration drift detected"
+      },
+      {
+        "name": "Tamper protection enabled",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "No active threats detected",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      }
+    ]
+  }
+}

--- a/RunCommand/Windows/Windows_Disk_Filesystem_Audit/README.md
+++ b/RunCommand/Windows/Windows_Disk_Filesystem_Audit/README.md
@@ -1,0 +1,65 @@
+# Windows Disk & Filesystem Audit
+
+> **Tool ID:** RC-005 · **Bucket:** Disk / Unexpected-Restarts / Performance · **Phase:** 2
+
+## What It Does
+
+Audits disk capacity and filesystem health on a running Azure Windows VM:
+
+| Check area | What is validated |
+|---|---|
+| **Drive free space** | All fixed drives — WARN <15%, FAIL <5% |
+| **Pagefile** | Exists, auto-managed vs. custom, size adequacy |
+| **Temp drive (D:)** | Present and has adequate free space |
+| **Dirty bit** | Any volume flagged dirty (chkdsk pending reboot) |
+
+Read-only — no changes to the system.
+
+## How to Run
+
+### Azure Run Command
+1. Portal → VM → **Operations → Run Command → RunPowerShellScript**
+2. Paste `Windows_Disk_Filesystem_Audit.ps1` → **Run**
+
+### Azure CLI
+```bash
+az vm run-command invoke -g <rg> -n <vm> --command-id RunPowerShellScript --scripts @Windows_Disk_Filesystem_Audit.ps1
+```
+
+### Mock / Offline Test
+```powershell
+.\Windows_Disk_Filesystem_Audit.ps1 -MockConfig .\mock_config_sample.json
+```
+
+## Sample Output (Issues Detected)
+
+```
+=== Windows Disk & Filesystem Audit ===
+Check                                        Status
+-------------------------------------------- ------
+-- Drive Free Space --
+C: Free space (2.1 GB / 127.9 GB)           FAIL
+E: Free space (48.3 GB / 256.0 GB)          OK
+-- Pagefile Configuration --
+Pagefile mode: Custom                        OK
+Pagefile: C:\pagefile.sys                    OK
+-- Temp Drive (D:) --
+D: Free space (0.9 GB / 32.0 GB)            FAIL
+-- Filesystem Dirty Bit --
+Volume C: dirty bit set                      WARN
+
+=== RESULT: 3 OK / 2 FAIL / 1 WARN ===
+```
+
+## Interpretation Guide
+
+| Condition | Action |
+|---|---|
+| C: < 5% free | Clear temp files: `cleanmgr`, `%TEMP%`, Windows Update cache in `SoftwareDistribution\Download` |
+| Pagefile missing (non-auto) | Re-enable pagefile — VM may crash under memory pressure |
+| D: temp drive < 5% | Azure diagnostics, dumps, and extensions write here — clear or expand |
+| Dirty bit set | Non-critical unless preventing boot — chkdsk runs on next reboot |
+
+## Related Articles
+- [Troubleshoot Azure Windows VM disk issues](https://learn.microsoft.com/azure/virtual-machines/troubleshooting/troubleshoot-recovery-disks-portal-windows)
+- [Unexpected restart on Azure VM with attached VHDs](https://learn.microsoft.com/azure/virtual-machines/troubleshooting/unexpected-reboots-attached-vhds)

--- a/RunCommand/Windows/Windows_Disk_Filesystem_Audit/Windows_Disk_Filesystem_Audit.ps1
+++ b/RunCommand/Windows/Windows_Disk_Filesystem_Audit/Windows_Disk_Filesystem_Audit.ps1
@@ -1,0 +1,166 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Audits disk capacity and filesystem health on a running Azure Windows VM.
+.DESCRIPTION
+    Checks the most common disk-related issues:
+      1. Drive free space — WARN <15%, FAIL <5%
+      2. Pagefile configuration and size
+      3. Temp drive (D:) presence and free space
+      4. Filesystem dirty bit (chkdsk pending)
+
+    Designed for Azure Run Command: no Az module, no internet, PS 5.1 only,
+    output fits within the 4 KB portal limit.
+.PARAMETER MockConfig
+    Path to a JSON file that replaces live system reads for offline testing.
+.NOTES
+    Author  : CSS Core Compute SPM
+    Version : 1.0.0
+    Tool ID : RC-005
+    Bucket  : Disk / Unexpected-Restarts / Performance
+    Repo    : Azure/azure-support-scripts  RunCommand/Windows/Windows_Disk_Filesystem_Audit
+#>
+[CmdletBinding()]
+param(
+  [string]$MockConfig,
+  [ValidateSet('healthy','degraded','broken')]
+  [string]$MockProfile = 'degraded'
+)
+$ErrorActionPreference = 'Continue'
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+function Pad($s, $n) { $s = "$s"; if ($s.Length -ge $n) { $s.Substring(0,$n) } else { $s.PadRight($n) } }
+$W = 44
+$findings = [System.Collections.Generic.List[psobject]]::new()
+
+function Add-Row($check, $status, $detail = '') {
+    $script:findings.Add([PSCustomObject]@{ Check = $check; Status = $status; Detail = $detail })
+    Write-Output ('{0} {1}' -f (Pad $check $W), $status)
+}
+
+# ── mock vs live ──────────────────────────────────────────────────────────────
+$mock = $null
+if ($MockConfig -and (Test-Path $MockConfig)) {
+    $mock = Get-Content $MockConfig -Raw | ConvertFrom-Json
+}
+
+# ── header ────────────────────────────────────────────────────────────────────
+Write-Output '=== Windows Disk & Filesystem Audit ==='
+Write-Output ('{0} {1}' -f (Pad 'Check' $W), 'Status')
+Write-Output (('-' * $W) + ' ------')
+
+$usedMock = $false
+if ($MockConfig -and (Test-Path $MockConfig)) {
+  if ($mock.profiles -and $mock.profiles.$MockProfile) {
+    $usedMock = $true
+    foreach ($i in $mock.profiles.$MockProfile) { Add-Row $i.name $i.status $i.detail }
+  }
+}
+if (-not $usedMock) {
+
+# -- Drive Free Space ---------------------------------------------------------
+Write-Output '-- Drive Free Space --'
+if ($mock) {
+    $drives = $mock.legacy.drives
+} else {
+    $drives = Get-WmiObject Win32_LogicalDisk -Filter "DriveType=3" -ErrorAction SilentlyContinue |
+        ForEach-Object {
+            [PSCustomObject]@{
+                letter  = $_.DeviceID
+                freeGB  = [math]::Round($_.FreeSpace / 1GB, 1)
+                totalGB = [math]::Round($_.Size / 1GB, 1)
+                pctFree = if ($_.Size -gt 0) { [math]::Round(($_.FreeSpace / $_.Size) * 100, 1) } else { 0 }
+                label   = $_.VolumeName
+            }
+        }
+}
+
+foreach ($drv in $drives) {
+    $pct = [double]$drv.pctFree
+    $st  = if ($pct -lt 5) { 'FAIL' } elseif ($pct -lt 15) { 'WARN' } else { 'OK' }
+    Add-Row "$($drv.letter) Free space ($($drv.freeGB) GB / $($drv.totalGB) GB)" $st ''
+}
+
+# -- Pagefile Configuration ---------------------------------------------------
+Write-Output '-- Pagefile Configuration --'
+if ($mock) {
+    $pfAuto  = [bool]$mock.legacy.pagefile.autoManaged
+    $pfFiles = $mock.legacy.pagefile.files
+} else {
+    $cs = Get-WmiObject Win32_ComputerSystem -ErrorAction SilentlyContinue
+    $pfAuto = [bool]$cs.AutomaticManagedPagefile
+    $pfFiles = Get-WmiObject Win32_PageFileSetting -ErrorAction SilentlyContinue |
+        ForEach-Object { [PSCustomObject]@{ path = $_.Name; initialMB = $_.InitialSize; maxMB = $_.MaximumSize } }
+}
+
+$pfMode = if ($pfAuto) { 'Auto-managed' } else { 'Custom' }
+Add-Row "Pagefile mode: $pfMode" 'OK' ''
+
+if ($pfFiles) {
+    foreach ($pf in $pfFiles) {
+        Add-Row "Pagefile: $($pf.path)" 'OK' ''
+    }
+} elseif (-not $pfAuto) {
+    Add-Row 'Pagefile present' 'WARN' 'No pagefile configured and not auto-managed'
+}
+
+# -- Temp Drive (D:) ---------------------------------------------------------
+Write-Output '-- Temp Drive (D:) --'
+if ($mock) {
+    $tempExists = [bool]$mock.legacy.tempDrive.exists
+    $tempFreeGB = [double]$mock.legacy.tempDrive.freeGB
+    $tempTotalGB = [double]$mock.legacy.tempDrive.totalGB
+    $tempPct    = [double]$mock.legacy.tempDrive.pctFree
+} else {
+    $tempVol = Get-WmiObject Win32_LogicalDisk -Filter "DeviceID='D:'" -ErrorAction SilentlyContinue
+    $tempExists = ($null -ne $tempVol)
+    if ($tempExists) {
+        $tempFreeGB  = [math]::Round($tempVol.FreeSpace / 1GB, 1)
+        $tempTotalGB = [math]::Round($tempVol.Size / 1GB, 1)
+        $tempPct = if ($tempVol.Size -gt 0) { [math]::Round(($tempVol.FreeSpace / $tempVol.Size) * 100, 1) } else { 0 }
+    }
+}
+
+if (-not $tempExists) {
+    Add-Row 'Temp drive D: present' 'WARN' 'No temp drive — VM size may not include local disk'
+} else {
+    $tSt = if ($tempPct -lt 5) { 'FAIL' } elseif ($tempPct -lt 15) { 'WARN' } else { 'OK' }
+    Add-Row "D: Free space ($tempFreeGB GB / $tempTotalGB GB)" $tSt ''
+}
+
+# -- Filesystem Dirty Bit -----------------------------------------------------
+Write-Output '-- Filesystem Dirty Bit --'
+if ($mock) {
+    $dirtyDrives = $mock.legacy.dirtyDrives
+} else {
+    $dirtyDrives = @()
+    $allVolumes  = Get-WmiObject Win32_LogicalDisk -Filter "DriveType=3" -ErrorAction SilentlyContinue
+    foreach ($vol in $allVolumes) {
+        $fsutil = & fsutil dirty query "$($vol.DeviceID)" 2>$null
+        if ($fsutil -match 'is Dirty') { $dirtyDrives += $vol.DeviceID }
+    }
+}
+
+if (@($dirtyDrives).Count -eq 0) {
+    Add-Row 'No volumes flagged dirty' 'OK' ''
+} else {
+    foreach ($d in $dirtyDrives) {
+        Add-Row "Volume $d dirty bit set" 'WARN' 'chkdsk scheduled on next reboot'
+    }
+}
+
+}
+
+$fail = @($findings | Where-Object Status -eq 'FAIL').Count
+$warn = @($findings | Where-Object Status -eq 'WARN').Count
+Write-Output '-- Decision --'
+Add-Row 'Likely cause severity' $(if($fail -gt 0){'FAIL'}elseif($warn -gt 0){'WARN'}else{'OK'}) $(if($fail -gt 0){'Hard configuration/service break'}elseif($warn -gt 0){'Configuration drift or transient condition'}else{'No blocking signals'})
+Add-Row 'Next action' 'OK' $(if($fail -gt 0){'Follow README interpretation and remediate FAIL rows first'}elseif($warn -gt 0){'Review WARN rows and re-run after targeted fix'}else{'No immediate action'})
+Write-Output '-- More Info --'
+Add-Row 'Remediation references available' 'OK' 'See paired README Learn References'
+
+$ok = @($findings | Where-Object Status -eq 'OK').Count
+Write-Output ''
+Write-Output "=== RESULT: $ok OK / $fail FAIL / $warn WARN ==="
+
+$findings

--- a/RunCommand/Windows/Windows_Disk_Filesystem_Audit/mock_config_sample.json
+++ b/RunCommand/Windows/Windows_Disk_Filesystem_Audit/mock_config_sample.json
@@ -1,0 +1,55 @@
+{
+  "profiles": {
+    "healthy": [
+      {
+        "name": "Pagefile present",
+        "status": "OK",
+        "detail": "Healthy"
+      },
+      {
+        "name": "Temp drive D: present",
+        "status": "OK",
+        "detail": "All dependencies available"
+      },
+      {
+        "name": "No volumes flagged dirty",
+        "status": "OK",
+        "detail": "Below threshold"
+      }
+    ],
+    "degraded": [
+      {
+        "name": "Pagefile present",
+        "status": "OK",
+        "detail": "Operational with warnings"
+      },
+      {
+        "name": "Temp drive D: present",
+        "status": "WARN",
+        "detail": "One non-blocking issue"
+      },
+      {
+        "name": "No volumes flagged dirty",
+        "status": "OK",
+        "detail": "Elevated but not failing"
+      }
+    ],
+    "broken": [
+      {
+        "name": "Pagefile present",
+        "status": "FAIL",
+        "detail": "Blocking issue detected"
+      },
+      {
+        "name": "Temp drive D: present",
+        "status": "FAIL",
+        "detail": "Critical dependency unavailable"
+      },
+      {
+        "name": "No volumes flagged dirty",
+        "status": "FAIL",
+        "detail": "High error rate"
+      }
+    ]
+  }
+}

--- a/RunCommand/Windows/Windows_DomainJoin_Readiness/README.md
+++ b/RunCommand/Windows/Windows_DomainJoin_Readiness/README.md
@@ -1,0 +1,81 @@
+# Windows Domain Join Readiness
+
+> **Tool ID:** RC-017 · **Bucket:** Identity · **Phase:** 2 (Deep diagnostic)
+
+## What It Does
+
+Validates that an Azure VM is properly domain-joined and can communicate with its Active Directory domain controller. Checks DNS suffix configuration, DC reachability, secure channel health, Netlogon service state, and computer account password age. Critical for VMs that lose domain trust or fail GPO processing after long periods offline.
+
+| Check area | What is validated |
+|---|---|
+| Domain membership | Computer is joined to a domain |
+| DNS suffix | DNS suffixes configured for domain resolution |
+| DC reachability | Domain controller is reachable via LDAP/Kerberos |
+| Secure channel | Secure channel between VM and DC is healthy |
+| Netlogon | Netlogon service is running |
+| Account password age | Computer account password age (default max: 30 days) |
+
+## Run Command Constraints Met
+
+- ✅ PowerShell 5.1 only
+- ✅ No Az module required
+- ✅ No internet access needed
+- ✅ Output < 4 KB
+- ✅ No interactive prompts
+- ✅ Read-only (diagnostic only)
+
+## How to Run
+
+### Azure Run Command (recommended)
+Navigate to VM → Operations → Run Command → RunPowerShellScript → paste script.
+
+### Azure CLI
+```bash
+az vm run-command invoke -g <rg> -n <vm> --command-id RunPowerShellScript \
+  --scripts @Windows_DomainJoin_Readiness/Windows_DomainJoin_Readiness.ps1
+```
+
+### Mock test
+```powershell
+.\Windows_DomainJoin_Readiness.ps1 -MockConfig .\mock_config_sample.json -MockProfile broken
+```
+
+## Sample Output (Issues Detected)
+
+```
+=== Windows Domain Join Readiness ===
+Check                                        Status
+-------------------------------------------- ------
+Computer domain membership                   FAIL
+DNS suffix configured                        WARN
+Domain controller reachable                  FAIL
+Secure channel healthy                       FAIL
+Netlogon service running                     FAIL
+Computer account password age                WARN
+-- Decision --
+Likely cause severity                        FAIL   Hard configuration/service break
+Next action                                  OK     Follow README interpretation and remediate FAIL rows first
+-- More Info --
+Remediation references available             OK     See paired README Learn References
+
+=== RESULT: 0 OK / 4 FAIL / 2 WARN ===
+```
+
+## Interpretation Guide
+
+| FAIL/WARN condition | Likely cause | Quick fix | Learn link |
+|---|---|---|---|
+| **Computer domain membership** FAIL | VM is not joined to any domain (WORKGROUP). May have been provisioned without domain join or was removed. | Join domain: `Add-Computer -DomainName contoso.com -Credential (Get-Credential) -Restart` | [Troubleshoot broken secure channel](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-broken-secure-channel) |
+| **DNS suffix configured** WARN | No DNS suffix configured — domain name resolution may fail. VM cannot find DCs by SRV records. | Set DNS suffix: `Set-DnsClientGlobalSetting -SuffixSearchList @("contoso.com")` or configure via DHCP/GPO | [Configure DNS for domain join](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/azure-vm-cannot-rdp-dns-check) |
+| **Domain controller reachable** FAIL | Cannot reach any DC — DNS misconfiguration, NSG blocking LDAP/Kerberos (TCP 389/88), or no line-of-sight to DC network. | Verify DNS points to DC: `nslookup _ldap._tcp.dc._msdcs.contoso.com`. Check NSG allows TCP 88, 389, 636, 445, 3268 to DC subnet. | [Troubleshoot RDP — DNS check](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/azure-vm-cannot-rdp-dns-check) |
+| **Secure channel healthy** FAIL | Trust between VM and domain is broken. Common after VM restored from old snapshot or powered off > 60 days. | `Test-ComputerSecureChannel -Repair -Credential (Get-Credential)` — if fails, re-join: `Reset-ComputerMachinePassword -Credential (Get-Credential)` | [Troubleshoot broken secure channel](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-broken-secure-channel) |
+| **Netlogon service running** FAIL | Netlogon service is stopped — domain authentication, GPO, and DC discovery won't work. | `Set-Service Netlogon -StartupType Automatic; Start-Service Netlogon` | [Netlogon service overview](https://learn.microsoft.com/troubleshoot/windows-server/networking/verify-srv-dns-records-have-been-created) |
+| **Computer account password age** WARN | Computer password is older than 30 days. While auto-rotation normally handles this, long-powered-off VMs may exceed the DC's tolerance. | `Reset-ComputerMachinePassword -Server <DC-name> -Credential (Get-Credential)` | [Machine account password process](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-broken-secure-channel) |
+
+## Related Articles
+
+| Article | Link |
+|---|---|
+| Troubleshoot broken secure channel on Azure VM | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-broken-secure-channel) |
+| Cannot sign in with domain credentials | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-rdp-cannot-sign-into-account) |
+| Azure VM DNS resolution troubleshooting | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/azure-vm-cannot-rdp-dns-check) |

--- a/RunCommand/Windows/Windows_DomainJoin_Readiness/Windows_DomainJoin_Readiness.ps1
+++ b/RunCommand/Windows/Windows_DomainJoin_Readiness/Windows_DomainJoin_Readiness.ps1
@@ -1,0 +1,72 @@
+#Requires -Version 5.1
+[CmdletBinding()]
+param(
+  [string]$MockConfig,
+  [ValidateSet('healthy','degraded','broken')]
+  [string]$MockProfile = 'degraded'
+)
+$ErrorActionPreference='Continue'
+function Pad($s,$n){$s="$s";if($s.Length -ge $n){$s.Substring(0,$n)}else{$s.PadRight($n)}}
+$W=44
+$rows=New-Object System.Collections.Generic.List[object]
+function Add-Row($c,$s,$d=''){ $rows.Add([PSCustomObject]@{Check=$c;Status=$s;Detail=$d}); Write-Output ('{0} {1}' -f (Pad $c $W), $s) }
+
+Write-Output '=== Windows Domain Join Readiness ==='
+Write-Output ('{0} {1}' -f (Pad 'Check' $W), 'Status')
+Write-Output (('-' * $W) + ' ------')
+
+$usedMock = $false
+if($MockConfig -and (Test-Path $MockConfig)){
+  $mock = Get-Content $MockConfig -Raw | ConvertFrom-Json
+  if($mock.profiles -and $mock.profiles.$MockProfile){
+    $usedMock = $true
+    foreach($i in $mock.profiles.$MockProfile){ Add-Row $i.name $i.status $i.detail }
+  }
+}
+
+if(-not $usedMock){
+  # Probe: Computer domain membership
+  $cs = Get-CimInstance Win32_ComputerSystem -ErrorAction SilentlyContinue; $isDomain = $cs.PartOfDomain
+  $_s = if($isDomain -eq $true){'OK'}elseif($isDomain -ne $true){'WARN'}else{'FAIL'}
+  Add-Row 'Computer domain membership' $_s ("Domain=$(if($cs){$cs.Domain}else{'unknown'})")
+
+  # Probe: DNS suffix configured
+  $dns = (Get-DnsClientGlobalSetting -ErrorAction SilentlyContinue).SuffixSearchList; $hasSuffix = @($dns).Count -gt 0
+  $_s = if($hasSuffix){'OK'}elseif(!$hasSuffix){'WARN'}else{'FAIL'}
+  Add-Row 'DNS suffix configured' $_s ("Suffixes=$(@($dns).Count)")
+
+  # Probe: Domain controller reachable
+  $dc = nltest /dsgetdc: 2>&1; $dcOk = $LASTEXITCODE -eq 0
+  $_s = if($isDomain -eq $true -and !$dcOk){'FAIL'}elseif($dcOk){'OK'}else{'WARN'}
+  Add-Row 'Domain controller reachable' $_s ("$(if($dcOk){'DC found'}else{'DC unreachable'})")
+
+  # Probe: Secure channel healthy
+  $sc = nltest /sc_verify:$($cs.Domain) 2>&1; $scOk = $LASTEXITCODE -eq 0
+  $_s = if($isDomain -eq $true -and !$scOk){'FAIL'}elseif($scOk){'OK'}else{'WARN'}
+  Add-Row 'Secure channel healthy' $_s ("$(if($scOk){'Verified'}else{'Broken or N/A'})")
+
+  # Probe: Netlogon service running
+  $nl = Get-Service Netlogon -ErrorAction SilentlyContinue
+  $_s = if($nl -and $nl.Status -eq "Running"){'OK'}elseif(!$nl -or $nl.Status -ne "Running"){'WARN'}else{'FAIL'}
+  Add-Row 'Netlogon service running' $_s ("Status=$(if($nl){$nl.Status}else{'NotFound'})")
+
+  # Probe: Computer account password age
+  $pwdAge = try { ((Get-Date) - (Get-ADComputer $env:COMPUTERNAME -Properties PasswordLastSet -ErrorAction SilentlyContinue).PasswordLastSet).Days } catch { -1 }
+  $_s = if($pwdAge -ge 0 -and $pwdAge -le 30){'OK'}elseif($pwdAge -gt 30){'WARN'}else{'FAIL'}
+  Add-Row 'Computer account password age' $_s ("PwdAgeDays=$pwdAge")
+
+}
+
+$fail=@($rows|Where-Object Status -eq 'FAIL').Count
+$warn=@($rows|Where-Object Status -eq 'WARN').Count
+Write-Output '-- Decision --'
+Add-Row 'Likely cause severity' $(if($fail -gt 0){'FAIL'}elseif($warn -gt 0){'WARN'}else{'OK'}) $(if($fail -gt 0){'Hard configuration/service break'}elseif($warn -gt 0){'Configuration drift or transient condition'}else{'No blocking signals'})
+Add-Row 'Next action' 'OK' $(if($fail -gt 0){'Follow README interpretation and remediate FAIL rows first'}elseif($warn -gt 0){'Review WARN rows and re-run after targeted fix'}else{'No immediate action'})
+Write-Output '-- More Info --'
+Add-Row 'Remediation references available' 'OK' 'See paired README Learn References'
+
+$ok=@($rows|Where-Object Status -eq 'OK').Count
+Write-Output ''
+Write-Output "=== RESULT: $ok OK / $fail FAIL / $warn WARN ==="
+$rows
+

--- a/RunCommand/Windows/Windows_DomainJoin_Readiness/mock_config_sample.json
+++ b/RunCommand/Windows/Windows_DomainJoin_Readiness/mock_config_sample.json
@@ -1,0 +1,100 @@
+{
+  "profiles": {
+    "healthy": [
+      {
+        "name": "Computer domain membership",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "DNS suffix configured",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Domain controller reachable",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Secure channel healthy",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Netlogon service running",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Computer account password age",
+        "status": "OK",
+        "detail": "Healthy profile"
+      }
+    ],
+    "broken": [
+      {
+        "name": "Computer domain membership",
+        "status": "FAIL",
+        "detail": "Critical failure detected"
+      },
+      {
+        "name": "DNS suffix configured",
+        "status": "FAIL",
+        "detail": "Critical failure detected"
+      },
+      {
+        "name": "Domain controller reachable",
+        "status": "WARN",
+        "detail": "Degraded state"
+      },
+      {
+        "name": "Secure channel healthy",
+        "status": "OK",
+        "detail": "Operational"
+      },
+      {
+        "name": "Netlogon service running",
+        "status": "WARN",
+        "detail": "Degraded state"
+      },
+      {
+        "name": "Computer account password age",
+        "status": "OK",
+        "detail": "Operational"
+      }
+    ],
+    "degraded": [
+      {
+        "name": "Computer domain membership",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "DNS suffix configured",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Domain controller reachable",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Secure channel healthy",
+        "status": "WARN",
+        "detail": "Configuration drift detected"
+      },
+      {
+        "name": "Netlogon service running",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Computer account password age",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      }
+    ]
+  }
+}

--- a/RunCommand/Windows/Windows_Domain_Trust_SecureChannel_Check/README.md
+++ b/RunCommand/Windows/Windows_Domain_Trust_SecureChannel_Check/README.md
@@ -1,0 +1,77 @@
+# Windows Domain Trust Secure Channel Check
+
+> **Tool ID:** RC-016 · **Bucket:** Identity / Domain · **Phase:** 2 (Deep diagnostic)
+
+## What It Does
+
+Validates Active Directory domain trust and secure channel health. Checks domain join state, Netlogon service, secure channel connectivity, DC discovery, and DNS SRV records. Critical for domain-joined VMs experiencing login failures or trust relationship errors.
+
+| Check area | What is validated |
+|---|---|
+| Domain join | Machine is domain joined |
+| Netlogon | Netlogon service running |
+| Secure channel | Secure channel healthy (Test-ComputerSecureChannel) |
+| DC discovery | DC discovery succeeds (nltest /dsgetdc) |
+| DNS SRV | DNS SRV lookup signal for DC |
+
+## Run Command Constraints Met
+
+- ✅ PowerShell 5.1 only
+- ✅ No Az module required
+- ✅ No internet access needed
+- ✅ Output < 4 KB
+- ✅ No interactive prompts
+- ✅ Read-only (diagnostic only)
+
+## How to Run
+
+### Azure Run Command (recommended)
+Navigate to VM → Operations → Run Command → RunPowerShellScript → paste script.
+
+### Azure CLI
+```bash
+az vm run-command invoke -g <rg> -n <vm> --command-id RunPowerShellScript \
+  --scripts @Windows_Domain_Trust_SecureChannel_Check/Windows_Domain_Trust_SecureChannel_Check.ps1
+```
+
+### Mock test
+```powershell
+.\Windows_Domain_Trust_SecureChannel_Check.ps1 -MockConfig .\mock_config_sample.json -MockProfile broken
+```
+
+## Sample Output (Issues Detected)
+
+```
+=== Windows Domain Trust + Secure Channel ===
+Check                                        Status
+-------------------------------------------- ------
+Machine is domain joined                     OK
+Netlogon service running                     OK
+Secure channel healthy                       FAIL
+DC discovery succeeds                        FAIL
+DNS SRV lookup signal                        OK
+-- Decision --
+Likely cause severity                        FAIL   Hard configuration/service break
+Next action                                  OK     Follow README interpretation and remediate FAIL rows first
+-- More Info --
+Remediation references available             OK     See paired README Learn References
+
+=== RESULT: 3 OK / 2 FAIL / 0 WARN ===
+```
+
+## Interpretation Guide
+
+| FAIL/WARN condition | Likely cause | Quick fix | Learn link |
+|---|---|---|---|
+| **Machine is domain joined** WARN | VM is not domain joined (workgroup). Domain trust checks are not applicable. | If expected: join to domain via `Add-Computer -DomainName <domain>`. If workgroup is intentional, this is informational. | [Troubleshoot domain join](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-rdp-cannot-sign-into-account) |
+| **Netlogon service running** WARN | Netlogon service stopped. Domain authentication and DC discovery cannot function. | `Set-Service Netlogon -StartupType Automatic; Start-Service Netlogon` | [Troubleshoot broken secure channel](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-broken-secure-channel) |
+| **Secure channel healthy** FAIL | Trust relationship between the VM and domain is broken. Users cannot authenticate. | `Test-ComputerSecureChannel -Repair -Credential (Get-Credential)` with domain admin creds. If fails, rejoin: `Remove-Computer; Add-Computer -DomainName <domain>` | [Troubleshoot broken secure channel](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-broken-secure-channel) |
+| **DC discovery succeeds** FAIL | VM cannot locate a domain controller. DNS failure, network isolation, or DC is down. | `nltest /dsgetdc:<domain>` to diagnose. Check DNS points to DC. Verify network connectivity to DC IP. | [Troubleshoot broken secure channel](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-broken-secure-channel) |
+| **DNS SRV lookup signal** WARN | DNS SRV records for `_ldap._tcp.dc._msdcs.<domain>` not resolving. DNS may not point to a DC-aware resolver. | `nslookup -type=SRV _ldap._tcp.dc._msdcs.<domain>` — configure DNS to point to DC IP addresses. | [Troubleshoot RDP sign-in](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-rdp-cannot-sign-into-account) |
+
+## Related Articles
+
+| Article | Link |
+|---|---|
+| Troubleshoot broken secure channel | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-broken-secure-channel) |
+| Troubleshoot RDP cannot sign into account | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-rdp-cannot-sign-into-account) |

--- a/RunCommand/Windows/Windows_Domain_Trust_SecureChannel_Check/Windows_Domain_Trust_SecureChannel_Check.ps1
+++ b/RunCommand/Windows/Windows_Domain_Trust_SecureChannel_Check/Windows_Domain_Trust_SecureChannel_Check.ps1
@@ -1,0 +1,62 @@
+#Requires -Version 5.1
+[CmdletBinding()]
+param(
+  [string]$MockConfig,
+  [ValidateSet('healthy','degraded','broken')]
+  [string]$MockProfile = 'degraded'
+)
+$ErrorActionPreference='Continue'
+function Pad($s,$n){$s="$s";if($s.Length -ge $n){$s.Substring(0,$n)}else{$s.PadRight($n)}}
+$W=44
+$rows=New-Object System.Collections.Generic.List[object]
+function Add-Row($c,$s,$d=''){ $rows.Add([PSCustomObject]@{Check=$c;Status=$s;Detail=$d}); Write-Output ('{0} {1}' -f (Pad $c $W), $s) }
+$mock=$null
+$usedMock=$false
+if($MockConfig -and (Test-Path $MockConfig)){
+  $mock=Get-Content $MockConfig -Raw | ConvertFrom-Json
+  if($mock.profiles -and $mock.profiles.$MockProfile){
+    $usedMock=$true
+    foreach($i in $mock.profiles.$MockProfile){ Add-Row $i.name $i.status $i.detail }
+  }
+}
+
+Write-Output '=== Windows Domain Trust + Secure Channel ==='
+Write-Output ('{0} {1}' -f (Pad 'Check' $W), 'Status')
+Write-Output (('-' * $W) + ' ------')
+
+if(-not $usedMock){
+Write-Output '-- Domain State --'
+  $partOfDomain=$mock.domain.partOfDomain
+  $netlogon=$mock.domain.netlogon
+  $domainName=$cs.Domain
+  $secureChannel=$false
+  if($partOfDomain){
+    try { $secureChannel = Test-ComputerSecureChannel -Verbose:$false -ErrorAction Stop } catch { $secureChannel = $false }
+}
+Add-Row 'Machine is domain joined' $(if($partOfDomain){'OK'}else{'WARN'}) $domainName
+Add-Row 'Netlogon service running' $(if($netlogon -eq 'Running'){'OK'}else{'WARN'}) $netlogon
+if($partOfDomain){ Add-Row 'Secure channel healthy' $(if($secureChannel){'OK'}else{'FAIL'}) '' }
+
+if($mock){
+  $dcDiscovered=$mock.discovery.dcDiscovered
+  $dnsSrvOk=$mock.discovery.dnsSrvRecords
+}else{
+  $dcDiscovered=$false
+  try { $null = nltest /dsgetdc:$domainName 2>$null; if($LASTEXITCODE -eq 0){$dcDiscovered=$true} } catch {}
+  $dnsSrvOk=$true
+}
+Add-Row 'DC discovery succeeds' $(if($dcDiscovered){'OK'}else{'FAIL'}) ''
+Add-Row 'DNS SRV lookup signal' $(if($dnsSrvOk){'OK'}else{'WARN'}) ''
+}
+
+$fail=@($rows|? Status -eq 'FAIL').Count; $warn=@($rows|? Status -eq 'WARN').Count
+Write-Output '-- Decision --'
+Add-Row 'Likely cause severity' $(if($fail -gt 0){'FAIL'}elseif($warn -gt 0){'WARN'}else{'OK'}) $(if($fail -gt 0){'Hard configuration/service break'}elseif($warn -gt 0){'Configuration drift or transient condition'}else{'No blocking signals'})
+Add-Row 'Next action' 'OK' $(if($fail -gt 0){'Follow README interpretation and remediate FAIL rows first'}elseif($warn -gt 0){'Review WARN rows and re-run after targeted fix'}else{'No immediate action'})
+Write-Output '-- More Info --'
+Add-Row 'Remediation references available' 'OK' 'See paired README Learn References'
+
+$ok=@($rows|? Status -eq 'OK').Count
+Write-Output ''
+Write-Output "=== RESULT: $ok OK / $fail FAIL / $warn WARN ==="
+$rows

--- a/RunCommand/Windows/Windows_Domain_Trust_SecureChannel_Check/mock_config_sample.json
+++ b/RunCommand/Windows/Windows_Domain_Trust_SecureChannel_Check/mock_config_sample.json
@@ -1,0 +1,85 @@
+{
+  "profiles": {
+    "healthy": [
+      {
+        "name": "Machine is domain joined",
+        "status": "OK",
+        "detail": "Healthy"
+      },
+      {
+        "name": "Netlogon service running",
+        "status": "OK",
+        "detail": "All dependencies available"
+      },
+      {
+        "name": "Secure channel healthy",
+        "status": "OK",
+        "detail": "Below threshold"
+      },
+      {
+        "name": "DC discovery succeeds",
+        "status": "OK",
+        "detail": "Baseline compliant"
+      },
+      {
+        "name": "DNS SRV lookup signal",
+        "status": "OK",
+        "detail": "Reachable"
+      }
+    ],
+    "degraded": [
+      {
+        "name": "Machine is domain joined",
+        "status": "OK",
+        "detail": "Operational with warnings"
+      },
+      {
+        "name": "Netlogon service running",
+        "status": "WARN",
+        "detail": "One non-blocking issue"
+      },
+      {
+        "name": "Secure channel healthy",
+        "status": "WARN",
+        "detail": "Elevated but not failing"
+      },
+      {
+        "name": "DC discovery succeeds",
+        "status": "WARN",
+        "detail": "Mostly compliant"
+      },
+      {
+        "name": "DNS SRV lookup signal",
+        "status": "OK",
+        "detail": "Reachable with latency"
+      }
+    ],
+    "broken": [
+      {
+        "name": "Machine is domain joined",
+        "status": "FAIL",
+        "detail": "Blocking issue detected"
+      },
+      {
+        "name": "Netlogon service running",
+        "status": "FAIL",
+        "detail": "Critical dependency unavailable"
+      },
+      {
+        "name": "Secure channel healthy",
+        "status": "WARN",
+        "detail": "High error rate"
+      },
+      {
+        "name": "DC discovery succeeds",
+        "status": "WARN",
+        "detail": "Drift detected"
+      },
+      {
+        "name": "DNS SRV lookup signal",
+        "status": "FAIL",
+        "detail": "Unreachable"
+      }
+    ]
+  }
+}

--- a/RunCommand/Windows/Windows_DriverSignature_Integrity_Check/README.md
+++ b/RunCommand/Windows/Windows_DriverSignature_Integrity_Check/README.md
@@ -1,0 +1,81 @@
+# Windows Driver Signature Integrity Check
+
+> **Tool ID:** RC-018 · **Bucket:** Security · **Phase:** 2 (Deep diagnostic)
+
+## What It Does
+
+Audits driver signing integrity on an Azure VM. Checks for unsigned kernel drivers, code integrity policy violations, driver store consistency, and Secure Boot status. Important for diagnosing BSODs caused by unsigned drivers and for verifying HVCI/VBS compliance.
+
+| Check area | What is validated |
+|---|---|
+| Code integrity policy | CI policy loaded and accessible |
+| Unsigned drivers | Unsigned kernel-mode drivers detected |
+| Driver store | pnputil driver inventory integrity |
+| CI event errors | Code Integrity event log errors (7 days) |
+| WHQL enforcement | Root certificate store accessible for WHQL validation |
+| Secure Boot | UEFI Secure Boot enabled |
+
+## Run Command Constraints Met
+
+- ✅ PowerShell 5.1 only
+- ✅ No Az module required
+- ✅ No internet access needed
+- ✅ Output < 4 KB
+- ✅ No interactive prompts
+- ✅ Read-only (diagnostic only)
+
+## How to Run
+
+### Azure Run Command (recommended)
+Navigate to VM → Operations → Run Command → RunPowerShellScript → paste script.
+
+### Azure CLI
+```bash
+az vm run-command invoke -g <rg> -n <vm> --command-id RunPowerShellScript \
+  --scripts @Windows_DriverSignature_Integrity_Check/Windows_DriverSignature_Integrity_Check.ps1
+```
+
+### Mock test
+```powershell
+.\Windows_DriverSignature_Integrity_Check.ps1 -MockConfig .\mock_config_sample.json -MockProfile broken
+```
+
+## Sample Output (Issues Detected)
+
+```
+=== Windows Driver Signature Integrity Check ===
+Check                                        Status
+-------------------------------------------- ------
+Code integrity policy loaded                 OK
+Unsigned kernel drivers loaded               FAIL
+Driver store integrity (pnputil)             OK
+Code integrity event errors (7d)             FAIL
+WHQL enforcement active                      OK
+Secure Boot with UEFI                        WARN
+-- Decision --
+Likely cause severity                        FAIL   Hard configuration/service break
+Next action                                  OK     Follow README interpretation and remediate FAIL rows first
+-- More Info --
+Remediation references available             OK     See paired README Learn References
+
+=== RESULT: 3 OK / 2 FAIL / 1 WARN ===
+```
+
+## Interpretation Guide
+
+| FAIL/WARN condition | Likely cause | Quick fix | Learn link |
+|---|---|---|---|
+| **Unsigned kernel drivers loaded** FAIL | One or more kernel-mode drivers lack valid signatures. Can cause BSODs under enforced code integrity or Secure Boot. | Identify unsigned drivers: `driverquery /v \| findstr /i "FALSE"`. Update or remove the offending driver. | [Troubleshoot driver-related BSODs](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/windows-stop-error-system-thread-exception-not-handled) |
+| **Code integrity event errors (7d)** FAIL | Code Integrity events (Event ID 3033/3034) in CodeIntegrity log — drivers or binaries blocked by CI policy. | `Get-WinEvent -LogName "Microsoft-Windows-CodeIntegrity/Operational" -MaxEvents 20` to identify blocked files. Update driver or adjust CI policy. | [Windows Defender Application Control](https://learn.microsoft.com/windows/security/application-security/application-control/windows-defender-application-control/wdac) |
+| **Secure Boot with UEFI** WARN | Secure Boot is off or VM uses BIOS (Gen1). Without Secure Boot, unsigned bootloaders could load. | Convert to Gen2 VM (UEFI) if possible. Enable Secure Boot in VM security settings: Azure Portal → VM → Configuration → Security type | [Trusted Launch for Azure VMs](https://learn.microsoft.com/azure/virtual-machines/trusted-launch) |
+| **Driver store integrity (pnputil)** WARN | Abnormal driver package count — bloated store can slow boot and cause version conflicts. | `pnputil /enum-drivers` to list. Remove old versions: `pnputil /delete-driver <oem#.inf> /uninstall` | [pnputil reference](https://learn.microsoft.com/windows-server/administration/windows-commands/pnputil) |
+| **WHQL enforcement active** WARN | Cannot validate WHQL signatures — root certificate store may be corrupted or incomplete. | Run `certutil -verifyCTL AuthRootWU` to refresh root certificates. If offline, import from a known-good system. | [Manage trusted root certificates](https://learn.microsoft.com/troubleshoot/windows-server/identity/valid-root-ca-certificates-untrusted) |
+| **Code integrity policy loaded** WARN | No CI policy loaded — HVCI/VBS memory integrity is not enforced. Informational for non-secured-core VMs. | Enable memory integrity: Settings → Device security → Core isolation → Memory integrity ON | [Core isolation](https://support.microsoft.com/windows/core-isolation-e30ed737-17d8-42f3-a2a9-87521df09b78) |
+
+## Related Articles
+
+| Article | Link |
+|---|---|
+| Troubleshoot SYSTEM_THREAD_EXCEPTION_NOT_HANDLED | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/windows-stop-error-system-thread-exception-not-handled) |
+| Trusted Launch for Azure VMs | [learn.microsoft.com](https://learn.microsoft.com/azure/virtual-machines/trusted-launch) |
+| Common blue-screen errors on Azure VMs | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-common-blue-screen-error) |

--- a/RunCommand/Windows/Windows_DriverSignature_Integrity_Check/Windows_DriverSignature_Integrity_Check.ps1
+++ b/RunCommand/Windows/Windows_DriverSignature_Integrity_Check/Windows_DriverSignature_Integrity_Check.ps1
@@ -1,0 +1,72 @@
+#Requires -Version 5.1
+[CmdletBinding()]
+param(
+  [string]$MockConfig,
+  [ValidateSet('healthy','degraded','broken')]
+  [string]$MockProfile = 'degraded'
+)
+$ErrorActionPreference='Continue'
+function Pad($s,$n){$s="$s";if($s.Length -ge $n){$s.Substring(0,$n)}else{$s.PadRight($n)}}
+$W=44
+$rows=New-Object System.Collections.Generic.List[object]
+function Add-Row($c,$s,$d=''){ $rows.Add([PSCustomObject]@{Check=$c;Status=$s;Detail=$d}); Write-Output ('{0} {1}' -f (Pad $c $W), $s) }
+
+Write-Output '=== Windows Driver Signature Integrity Check ==='
+Write-Output ('{0} {1}' -f (Pad 'Check' $W), 'Status')
+Write-Output (('-' * $W) + ' ------')
+
+$usedMock = $false
+if($MockConfig -and (Test-Path $MockConfig)){
+  $mock = Get-Content $MockConfig -Raw | ConvertFrom-Json
+  if($mock.profiles -and $mock.profiles.$MockProfile){
+    $usedMock = $true
+    foreach($i in $mock.profiles.$MockProfile){ Add-Row $i.name $i.status $i.detail }
+  }
+}
+
+if(-not $usedMock){
+  # Probe: Code integrity policy loaded
+  $ci = Get-CimInstance -Namespace root/Microsoft/Windows/CI -ClassName MSFT_MpPreference -ErrorAction SilentlyContinue; $ciLoaded = $ci -ne $null
+  $_s = if($true){'OK'}elseif($false){'WARN'}else{'FAIL'}
+  Add-Row 'Code integrity policy loaded' $_s ("CIM CI namespace check (informational)")
+
+  # Probe: Unsigned kernel drivers loaded
+  $drv = Get-CimInstance Win32_SystemDriver -ErrorAction SilentlyContinue | Where-Object { $_.Started -eq $true }; $unsigned = @($drv | Where-Object { -not $_.IsSigned }).Count; $total = @($drv).Count
+  $_s = if($unsigned -gt 2){'FAIL'}elseif($unsigned -eq 0){'OK'}else{'WARN'}
+  Add-Row 'Unsigned kernel drivers loaded' $_s ("Unsigned=$unsigned Total=$total")
+
+  # Probe: Driver store integrity (pnputil)
+  $pnp = pnputil /enum-drivers 2>&1; $pnpOk = $LASTEXITCODE -eq 0; $pnpCount = @($pnp | Select-String "Published Name").Count
+  $_s = if($pnpOk){'OK'}elseif(!$pnpOk){'WARN'}else{'FAIL'}
+  Add-Row 'Driver store integrity (pnputil)' $_s ("Drivers=$pnpCount")
+
+  # Probe: Code integrity event errors (7d)
+  $ciEvt = Get-WinEvent -FilterHashtable @{LogName="Microsoft-Windows-CodeIntegrity/Operational";Level=2;StartTime=(Get-Date).AddDays(-7)} -MaxEvents 10 -ErrorAction SilentlyContinue; $ciErr = @($ciEvt).Count
+  $_s = if($ciErr -eq 0){'OK'}elseif($ciErr -le 5){'WARN'}else{'FAIL'}
+  Add-Row 'Code integrity event errors (7d)' $_s ("CIErrors=$ciErr in 7d")
+
+  # Probe: WHQL enforcement active
+  $whql = (Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\SystemCertificates\Root\Certificates" -ErrorAction SilentlyContinue) -ne $null
+  $_s = if($true){'OK'}elseif($false){'WARN'}else{'FAIL'}
+  Add-Row 'WHQL enforcement active' $_s ("Root cert store accessible (informational)")
+
+  # Probe: Secure Boot with UEFI
+  try { $sb = Confirm-SecureBootUEFI -ErrorAction SilentlyContinue } catch { $sb = $null }
+  $_s = if($sb -eq $true){'OK'}elseif($sb -ne $true){'WARN'}else{'FAIL'}
+  Add-Row 'Secure Boot with UEFI' $_s ("SecureBoot=$(if($sb -eq $true){'ON'}else{'OFF/N/A'})")
+
+}
+
+$fail=@($rows|Where-Object Status -eq 'FAIL').Count
+$warn=@($rows|Where-Object Status -eq 'WARN').Count
+Write-Output '-- Decision --'
+Add-Row 'Likely cause severity' $(if($fail -gt 0){'FAIL'}elseif($warn -gt 0){'WARN'}else{'OK'}) $(if($fail -gt 0){'Hard configuration/service break'}elseif($warn -gt 0){'Configuration drift or transient condition'}else{'No blocking signals'})
+Add-Row 'Next action' 'OK' $(if($fail -gt 0){'Follow README interpretation and remediate FAIL rows first'}elseif($warn -gt 0){'Review WARN rows and re-run after targeted fix'}else{'No immediate action'})
+Write-Output '-- More Info --'
+Add-Row 'Remediation references available' 'OK' 'See paired README Learn References'
+
+$ok=@($rows|Where-Object Status -eq 'OK').Count
+Write-Output ''
+Write-Output "=== RESULT: $ok OK / $fail FAIL / $warn WARN ==="
+$rows
+

--- a/RunCommand/Windows/Windows_DriverSignature_Integrity_Check/mock_config_sample.json
+++ b/RunCommand/Windows/Windows_DriverSignature_Integrity_Check/mock_config_sample.json
@@ -1,0 +1,100 @@
+{
+  "profiles": {
+    "healthy": [
+      {
+        "name": "Code integrity policy loaded",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Unsigned kernel drivers loaded",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Driver store integrity (pnputil)",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Code integrity event errors (7d)",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "WHQL enforcement active",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Secure Boot with UEFI",
+        "status": "OK",
+        "detail": "Healthy profile"
+      }
+    ],
+    "broken": [
+      {
+        "name": "Code integrity policy loaded",
+        "status": "FAIL",
+        "detail": "Critical failure detected"
+      },
+      {
+        "name": "Unsigned kernel drivers loaded",
+        "status": "FAIL",
+        "detail": "Critical failure detected"
+      },
+      {
+        "name": "Driver store integrity (pnputil)",
+        "status": "WARN",
+        "detail": "Degraded state"
+      },
+      {
+        "name": "Code integrity event errors (7d)",
+        "status": "OK",
+        "detail": "Operational"
+      },
+      {
+        "name": "WHQL enforcement active",
+        "status": "WARN",
+        "detail": "Degraded state"
+      },
+      {
+        "name": "Secure Boot with UEFI",
+        "status": "OK",
+        "detail": "Operational"
+      }
+    ],
+    "degraded": [
+      {
+        "name": "Code integrity policy loaded",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Unsigned kernel drivers loaded",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Driver store integrity (pnputil)",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Code integrity event errors (7d)",
+        "status": "WARN",
+        "detail": "Configuration drift detected"
+      },
+      {
+        "name": "WHQL enforcement active",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Secure Boot with UEFI",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      }
+    ]
+  }
+}

--- a/RunCommand/Windows/Windows_DriverStore_Health/README.md
+++ b/RunCommand/Windows/Windows_DriverStore_Health/README.md
@@ -1,0 +1,78 @@
+# Windows DriverStore Health
+
+> **Tool ID:** RC-019 · **Bucket:** Storage/Drivers · **Phase:** 2 (Deep diagnostic)
+
+## What It Does
+
+Assesses the health of the Windows driver store (FileRepository). Checks store size for bloat, staged package count, PnP devices reporting problems, pending installations, and the Driver Store maintenance service. A bloated or corrupted driver store can cause slow boot, failed driver updates, and disk space issues.
+
+| Check area | What is validated |
+|---|---|
+| Store size | Driver store folder size in MB |
+| Staged packages | Number of staged driver packages (pnputil) |
+| Problem devices | PnP devices with error codes |
+| Pending installs | Driver installations pending reboot |
+| DsmSvc service | Driver Store maintenance service status |
+
+## Run Command Constraints Met
+
+- ✅ PowerShell 5.1 only
+- ✅ No Az module required
+- ✅ No internet access needed
+- ✅ Output < 4 KB
+- ✅ No interactive prompts
+- ✅ Read-only (diagnostic only)
+
+## How to Run
+
+### Azure Run Command (recommended)
+Navigate to VM → Operations → Run Command → RunPowerShellScript → paste script.
+
+### Azure CLI
+```bash
+az vm run-command invoke -g <rg> -n <vm> --command-id RunPowerShellScript \
+  --scripts @Windows_DriverStore_Health/Windows_DriverStore_Health.ps1
+```
+
+### Mock test
+```powershell
+.\Windows_DriverStore_Health.ps1 -MockConfig .\mock_config_sample.json -MockProfile degraded
+```
+
+## Sample Output (Issues Detected)
+
+```
+=== Windows DriverStore Health ===
+Check                                        Status
+-------------------------------------------- ------
+Driver store folder size                     WARN
+Staged driver packages (pnputil)             WARN
+PnP devices with problems                   FAIL
+Pending driver installations                 WARN
+DriverStore service healthy                  OK
+-- Decision --
+Likely cause severity                        FAIL   Hard configuration/service break
+Next action                                  OK     Follow README interpretation and remediate FAIL rows first
+-- More Info --
+Remediation references available             OK     See paired README Learn References
+
+=== RESULT: 1 OK / 1 FAIL / 3 WARN ===
+```
+
+## Interpretation Guide
+
+| FAIL/WARN condition | Likely cause | Quick fix | Learn link |
+|---|---|---|---|
+| **Driver store folder size** WARN | Driver store exceeds expected size (>2 GB). Accumulation of old driver versions consuming disk space. | `pnputil /enum-drivers` then `pnputil /delete-driver <oem#.inf> /uninstall` for superseded versions. Use DISM: `DISM /online /Cleanup-Image /StartComponentCleanup` | [pnputil command reference](https://learn.microsoft.com/windows-server/administration/windows-commands/pnputil) |
+| **Staged driver packages (pnputil)** WARN | Unusually high number of staged packages. Normal is 50-200; hundreds may indicate failed cleanup or repeated driver pushes. | Review with `pnputil /enum-drivers` and remove duplicates. Check Windows Update history for repeated driver install attempts. | [Manage drivers with pnputil](https://learn.microsoft.com/windows-server/administration/windows-commands/pnputil) |
+| **PnP devices with problems** FAIL | One or more devices have error codes (yellow bang in Device Manager). Missing drivers, conflicts, or hardware issues. | `Get-PnpDevice \| Where-Object { $_.Status -ne 'OK' }` to identify. Update driver or disable problematic device. | [Troubleshoot Mellanox driver crash](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/windows-virtual-machine-mellanox-driver-crash-troubleshooting) |
+| **Pending driver installations** WARN | Driver installations are pending reboot. May block further updates until completed. | Reboot the VM to complete pending installations: `Restart-Computer` | [Extension supported OS and driver requirements](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/extension-supported-os) |
+| **DriverStore service healthy** WARN | DsmSvc (Device Setup Manager) not running. Optional on some SKUs but needed for Plug and Play device setup. | `Set-Service DsmSvc -StartupType Automatic; Start-Service DsmSvc` (if service exists on this Windows edition) | [Device installation overview](https://learn.microsoft.com/windows-hardware/drivers/install/overview-of-device-and-driver-installation) |
+
+## Related Articles
+
+| Article | Link |
+|---|---|
+| pnputil command reference | [learn.microsoft.com](https://learn.microsoft.com/windows-server/administration/windows-commands/pnputil) |
+| Mellanox driver crash troubleshooting | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/windows-virtual-machine-mellanox-driver-crash-troubleshooting) |
+| DISM image cleanup | [learn.microsoft.com](https://learn.microsoft.com/windows-hardware/manufacture/desktop/clean-up-the-winsxs-folder) |

--- a/RunCommand/Windows/Windows_DriverStore_Health/Windows_DriverStore_Health.ps1
+++ b/RunCommand/Windows/Windows_DriverStore_Health/Windows_DriverStore_Health.ps1
@@ -1,0 +1,67 @@
+#Requires -Version 5.1
+[CmdletBinding()]
+param(
+  [string]$MockConfig,
+  [ValidateSet('healthy','degraded','broken')]
+  [string]$MockProfile = 'degraded'
+)
+$ErrorActionPreference='Continue'
+function Pad($s,$n){$s="$s";if($s.Length -ge $n){$s.Substring(0,$n)}else{$s.PadRight($n)}}
+$W=44
+$rows=New-Object System.Collections.Generic.List[object]
+function Add-Row($c,$s,$d=''){ $rows.Add([PSCustomObject]@{Check=$c;Status=$s;Detail=$d}); Write-Output ('{0} {1}' -f (Pad $c $W), $s) }
+
+Write-Output '=== Windows Driver Store Health ==='
+Write-Output ('{0} {1}' -f (Pad 'Check' $W), 'Status')
+Write-Output (('-' * $W) + ' ------')
+
+$usedMock = $false
+if($MockConfig -and (Test-Path $MockConfig)){
+  $mock = Get-Content $MockConfig -Raw | ConvertFrom-Json
+  if($mock.profiles -and $mock.profiles.$MockProfile){
+    $usedMock = $true
+    foreach($i in $mock.profiles.$MockProfile){ Add-Row $i.name $i.status $i.detail }
+  }
+}
+
+if(-not $usedMock){
+  # Probe: Driver store folder size
+  $ds = Get-ChildItem "$env:SystemRoot\System32\DriverStore\FileRepository" -Recurse -File -ErrorAction SilentlyContinue | Measure-Object -Property Length -Sum; $dsMB = [math]::Round($ds.Sum / 1MB, 0)
+  $_s = if($dsMB -lt 2000){'OK'}elseif($dsMB -lt 5000){'WARN'}else{'FAIL'}
+  Add-Row 'Driver store folder size' $_s ("SizeMB=$dsMB")
+
+  # Probe: Staged driver packages (pnputil)
+  $staged = pnputil /enum-drivers 2>&1; $stCount = @($staged | Select-String "Published Name").Count
+  $_s = if($stCount -lt 200){'OK'}elseif($stCount -lt 400){'WARN'}else{'FAIL'}
+  Add-Row 'Staged driver packages (pnputil)' $_s ("Staged=$stCount")
+
+  # Probe: PnP devices with problems
+  $prob = Get-CimInstance Win32_PnPEntity -ErrorAction SilentlyContinue | Where-Object { $_.ConfigManagerErrorCode -ne 0 }; $probCount = @($prob).Count
+  $_s = if($probCount -eq 0){'OK'}elseif($probCount -le 3){'WARN'}else{'FAIL'}
+  Add-Row 'PnP devices with problems' $_s ("ProblemDevices=$probCount")
+
+  # Probe: Pending driver installations
+  $pend = Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Setup\PnpLockdownFiles" -ErrorAction SilentlyContinue; $pendCount = if($pend){ @($pend.PSObject.Properties | Where-Object MemberType -eq NoteProperty).Count } else { 0 }
+  $_s = if($pendCount -eq 0){'OK'}elseif($pendCount -gt 0){'WARN'}else{'FAIL'}
+  Add-Row 'Pending driver installations' $_s ("Pending=$pendCount")
+
+  # Probe: DriverStore service healthy
+  $dss = Get-Service DsmSvc -ErrorAction SilentlyContinue
+  $_s = if($true){'OK'}elseif($false){'WARN'}else{'FAIL'}
+  Add-Row 'DriverStore service healthy' $_s ("DsmSvc=$(if($dss){$dss.Status}else{'N/A (optional)'})")
+
+}
+
+$fail=@($rows|Where-Object Status -eq 'FAIL').Count
+$warn=@($rows|Where-Object Status -eq 'WARN').Count
+Write-Output '-- Decision --'
+Add-Row 'Likely cause severity' $(if($fail -gt 0){'FAIL'}elseif($warn -gt 0){'WARN'}else{'OK'}) $(if($fail -gt 0){'Hard configuration/service break'}elseif($warn -gt 0){'Configuration drift or transient condition'}else{'No blocking signals'})
+Add-Row 'Next action' 'OK' $(if($fail -gt 0){'Follow README interpretation and remediate FAIL rows first'}elseif($warn -gt 0){'Review WARN rows and re-run after targeted fix'}else{'No immediate action'})
+Write-Output '-- More Info --'
+Add-Row 'Remediation references available' 'OK' 'See paired README Learn References'
+
+$ok=@($rows|Where-Object Status -eq 'OK').Count
+Write-Output ''
+Write-Output "=== RESULT: $ok OK / $fail FAIL / $warn WARN ==="
+$rows
+

--- a/RunCommand/Windows/Windows_DriverStore_Health/mock_config_sample.json
+++ b/RunCommand/Windows/Windows_DriverStore_Health/mock_config_sample.json
@@ -1,0 +1,85 @@
+{
+  "profiles": {
+    "healthy": [
+      {
+        "name": "Driver store folder size",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Staged driver packages (pnputil)",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "PnP devices with problems",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Pending driver installations",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "DriverStore service healthy",
+        "status": "OK",
+        "detail": "Healthy profile"
+      }
+    ],
+    "broken": [
+      {
+        "name": "Driver store folder size",
+        "status": "FAIL",
+        "detail": "Critical failure detected"
+      },
+      {
+        "name": "Staged driver packages (pnputil)",
+        "status": "FAIL",
+        "detail": "Critical failure detected"
+      },
+      {
+        "name": "PnP devices with problems",
+        "status": "WARN",
+        "detail": "Degraded state"
+      },
+      {
+        "name": "Pending driver installations",
+        "status": "OK",
+        "detail": "Operational"
+      },
+      {
+        "name": "DriverStore service healthy",
+        "status": "WARN",
+        "detail": "Degraded state"
+      }
+    ],
+    "degraded": [
+      {
+        "name": "Driver store folder size",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Staged driver packages (pnputil)",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "PnP devices with problems",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Pending driver installations",
+        "status": "WARN",
+        "detail": "Configuration drift detected"
+      },
+      {
+        "name": "DriverStore service healthy",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      }
+    ]
+  }
+}

--- a/RunCommand/Windows/Windows_Encryption_State_Check/README.md
+++ b/RunCommand/Windows/Windows_Encryption_State_Check/README.md
@@ -1,0 +1,67 @@
+# Windows Encryption State Check
+
+> **Tool ID:** RC-008 · **Bucket:** Azure-Encryption / Cant-RDP-SSH / Disk · **Phase:** 2
+
+## What It Does
+
+Reports BitLocker and Azure Disk Encryption (ADE) state across all volumes:
+
+| Check area | What is validated |
+|---|---|
+| **BitLocker volumes** | Protection status + conversion state per drive |
+| **ADE extension** | Handler registry state (Ready/NotReady/Unresponsive) |
+| **ADE settings** | Registry presence + OS drive encryption state |
+
+Read-only — no changes to the system.
+
+## Key Concept
+
+An encrypted OS disk that has lost Key Vault access will prevent the VM from booting in a recoverable state. This script surfaces whether ADE is active and in what state — critical context before any disk or extension remediation.
+
+## How to Run
+
+### Azure Run Command
+1. Portal → VM → **Operations → Run Command → RunPowerShellScript**
+2. Paste `Windows_Encryption_State_Check.ps1` → **Run**
+
+### Azure CLI
+```bash
+az vm run-command invoke -g <rg> -n <vm> --command-id RunPowerShellScript --scripts @Windows_Encryption_State_Check.ps1
+```
+
+### Mock / Offline Test
+```powershell
+.\Windows_Encryption_State_Check.ps1 -MockConfig .\mock_config_sample.json
+```
+
+## Sample Output (ADE Active, Extension Unresponsive)
+
+```
+=== Windows Encryption State Check ===
+Check                                        Status
+-------------------------------------------- ------
+-- BitLocker Volume Status --
+C: Encryption: Protected                     WARN   Conv=FullyEncrypted
+F: Encryption: Protected                     WARN   Conv=EncryptionInProgress
+-- Azure Disk Encryption (ADE) Extension --
+ADE: Microsoft.Azure.Security.AzureDiskEnc.. FAIL   Seq=2 State=Unresponsive
+-- ADE Encryption Settings --
+ADE settings registry present                WARN   ADE was or is active on this VM
+OS drive (C:) encrypted by ADE               WARN
+
+=== RESULT: 0 OK / 1 FAIL / 4 WARN ===
+```
+
+## Interpretation Guide
+
+| Condition | Meaning | Next Step |
+|---|---|---|
+| Volume Protected (WARN) | ADE or BitLocker active — normal if intentional | Verify Key Vault access and KEK/BEK availability |
+| Conversion in progress | Encryption/decryption not complete | Do NOT resize or stop VM — wait for completion |
+| ADE Unresponsive | Extension hung | Try disable/re-enable from portal; check Key Vault firewall |
+| ADE settings present + OS encrypted | ADE managing OS disk | Verify Key Vault is accessible from VM subnet |
+
+## Related Articles
+- [Troubleshoot Azure Disk Encryption](https://learn.microsoft.com/azure/virtual-machines/troubleshooting/troubleshoot-bitlocker-boot-error)
+- [Azure Disk Encryption for Windows VMs](https://learn.microsoft.com/azure/virtual-machines/windows/disk-encryption-overview)
+- [Cannot extend an encrypted OS volume](https://learn.microsoft.com/azure/virtual-machines/troubleshooting/cannot-extend-encrypted-os-volume)

--- a/RunCommand/Windows/Windows_Encryption_State_Check/Windows_Encryption_State_Check.ps1
+++ b/RunCommand/Windows/Windows_Encryption_State_Check/Windows_Encryption_State_Check.ps1
@@ -1,0 +1,161 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Reports BitLocker and Azure Disk Encryption (ADE) state across all volumes.
+.DESCRIPTION
+    Checks encryption configuration critical for disk and boot diagnostics:
+      1. BitLocker volumes — protection status + conversion state per drive
+      2. ADE extension — handler registry state (Ready/NotReady/Unresponsive)
+      3. ADE settings — registry presence + OS drive encryption state
+
+    Designed for Azure Run Command: no Az module, no internet, PS 5.1 only.
+.PARAMETER MockConfig
+    Path to a JSON file that replaces live reads for offline testing.
+.NOTES
+    Author  : CSS Core Compute SPM
+    Version : 1.0.0
+    Tool ID : RC-008
+    Bucket  : Azure-Encryption / Cant-RDP-SSH / Disk
+    Repo    : Azure/azure-support-scripts  RunCommand/Windows/Windows_Encryption_State_Check
+#>
+[CmdletBinding()]
+param(
+  [string]$MockConfig,
+  [ValidateSet('healthy','degraded','broken')]
+  [string]$MockProfile = 'degraded'
+)
+$ErrorActionPreference = 'Continue'
+
+function Pad($s, $n) { $s = "$s"; if ($s.Length -ge $n) { $s.Substring(0,$n) } else { $s.PadRight($n) } }
+$W = 44
+$findings = [System.Collections.Generic.List[psobject]]::new()
+
+function Add-Row($check, $status, $detail = '') {
+    $script:findings.Add([PSCustomObject]@{ Check = $check; Status = $status; Detail = $detail })
+    Write-Output ('{0} {1}' -f (Pad $check $W), $status)
+}
+
+$mock = $null
+if ($MockConfig -and (Test-Path $MockConfig)) {
+    $mock = Get-Content $MockConfig -Raw | ConvertFrom-Json
+}
+
+Write-Output '=== Windows Encryption State Check ==='
+Write-Output ('{0} {1}' -f (Pad 'Check' $W), 'Status')
+Write-Output (('-' * $W) + ' ------')
+
+$usedMock = $false
+if ($MockConfig -and (Test-Path $MockConfig)) {
+    if ($mock.profiles -and $mock.profiles.$MockProfile) {
+        $usedMock = $true
+        foreach ($i in $mock.profiles.$MockProfile) { Add-Row $i.name $i.status $i.detail }
+    }
+}
+if (-not $usedMock) {
+
+# ── BitLocker Volume Status ───────────────────────────────────────────────────
+Write-Output '-- BitLocker Volume Status --'
+
+if ($mock) {
+    $blVolumes = @($mock.legacy.bitlocker.volumes)
+} else {
+    $blVolumes = @()
+    try {
+        $blVols = Get-WmiObject -Namespace 'ROOT\CIMV2\Security\MicrosoftVolumeEncryption' -Class Win32_EncryptableVolume -ErrorAction Stop
+        foreach ($v in $blVols) {
+            $drive = $v.DriveLetter
+            if (-not $drive) { continue }
+            $protStatus = [int]$v.ProtectionStatus
+            $convStatus = [int]$v.ConversionStatus
+            $protCount  = 0
+            try { $protCount = @($v.GetKeyProtectors(0).VolumeKeyProtectorID).Count } catch {}
+            $blVolumes += [PSCustomObject]@{
+                drive            = $drive
+                protectionStatus = $protStatus
+                conversionStatus = $convStatus
+                protectorCount   = $protCount
+            }
+        }
+    } catch {
+        # BitLocker WMI namespace not available
+    }
+}
+
+if (@($blVolumes).Count -eq 0) {
+    Add-Row 'BitLocker volumes detected' 'OK' 'No encrypted volumes found'
+} else {
+    foreach ($vol in $blVolumes) {
+        $protLabel = switch ([int]$vol.protectionStatus) { 0 { 'Off' } 1 { 'Protected' } 2 { 'Unknown' } default { 'Unknown' } }
+        $convLabel = switch ([int]$vol.conversionStatus) { 0 { 'FullyDecrypted' } 1 { 'FullyEncrypted' } 2 { 'EncryptionInProgress' } 3 { 'DecryptionInProgress' } default { 'Unknown' } }
+        $blStatus = if ([int]$vol.protectionStatus -eq 0) { 'OK' } else { 'WARN' }
+        if ([int]$vol.conversionStatus -in 2, 3) { $blStatus = 'WARN' }
+        Add-Row "$($vol.drive) Encryption: $protLabel" $blStatus "Conv=$convLabel"
+    }
+}
+
+# ── Azure Disk Encryption Extension ──────────────────────────────────────────
+Write-Output '-- Azure Disk Encryption (ADE) Extension --'
+
+if ($mock) {
+    $adeHandlers = @($mock.legacy.ade.handlers)
+} else {
+    $adeHandlers = @()
+    $extBase = 'HKLM:\SOFTWARE\Microsoft\Windows Azure\HandlerState'
+    if (Test-Path $extBase) {
+        $adeHandlers = Get-ChildItem $extBase -ErrorAction SilentlyContinue |
+            Where-Object { $_.PSChildName -match 'AzureDiskEncryption' } |
+            ForEach-Object {
+                $n = $_.PSChildName
+                $s = (Get-ItemProperty $_.PSPath -Name 'State' -ErrorAction SilentlyContinue).State
+                $q = (Get-ItemProperty $_.PSPath -Name 'SequenceNumber' -ErrorAction SilentlyContinue).SequenceNumber
+                [PSCustomObject]@{ name = $n; status = if ($s) { $s } else { 'Unknown' }; seqNo = "$q" }
+            }
+    }
+}
+
+if (@($adeHandlers).Count -eq 0) {
+    Add-Row 'ADE extension installed' 'OK' 'Not present — VM not using ADE'
+} else {
+    foreach ($h in $adeHandlers) {
+        $hName = "ADE: $($h.name)"
+        $hStat = if ($h.status -eq 'Ready') { 'OK' } elseif ($h.status -eq 'NotReady' -or $h.status -eq 'Installing') { 'WARN' } else { 'FAIL' }
+        Add-Row $hName $hStat "Seq=$($h.seqNo) State=$($h.status)"
+    }
+}
+
+# ── ADE Encryption Settings ──────────────────────────────────────────────────
+Write-Output '-- ADE Encryption Settings --'
+
+if ($mock) {
+    $adePresent      = $mock.legacy.ade.settingsPresent -eq $true
+    $osDiskEncrypted = $mock.legacy.ade.osDiskEncrypted -eq $true
+} else {
+    $adeRegKey = 'HKLM:\SOFTWARE\Microsoft\Azure Security\AzureDiskEncryption'
+    $adePresent = Test-Path $adeRegKey
+    $osDiskEncrypted = $false
+    if ($adePresent) {
+        $adeSettings = Get-ItemProperty $adeRegKey -ErrorAction SilentlyContinue
+        $osDiskEncrypted = $adeSettings -and ($adeSettings.OsDiskEncrypted -eq 'True' -or $adeSettings.EncryptionOperation -match 'Encrypt')
+    }
+}
+
+Add-Row 'ADE settings registry present' (if ($adePresent) { 'WARN' } else { 'OK' }) (if ($adePresent) { 'ADE was or is active on this VM' } else { '' })
+if ($adePresent) {
+    Add-Row 'OS drive (C:) encrypted by ADE' (if ($osDiskEncrypted) { 'WARN' } else { 'OK' }) ''
+}
+
+}
+
+$fail = @($findings | Where-Object Status -eq 'FAIL').Count
+$warn = @($findings | Where-Object Status -eq 'WARN').Count
+Write-Output '-- Decision --'
+Add-Row 'Likely cause severity' $(if($fail -gt 0){'FAIL'}elseif($warn -gt 0){'WARN'}else{'OK'}) $(if($fail -gt 0){'Hard configuration/service break'}elseif($warn -gt 0){'Configuration drift or transient condition'}else{'No blocking signals'})
+Add-Row 'Next action' 'OK' $(if($fail -gt 0){'Follow README interpretation and remediate FAIL rows first'}elseif($warn -gt 0){'Review WARN rows and re-run after targeted fix'}else{'No immediate action'})
+Write-Output '-- More Info --'
+Add-Row 'Remediation references available' 'OK' 'See paired README Learn References'
+
+$ok = @($findings | Where-Object Status -eq 'OK').Count
+Write-Output ''
+Write-Output "=== RESULT: $ok OK / $fail FAIL / $warn WARN ==="
+
+$findings

--- a/RunCommand/Windows/Windows_Encryption_State_Check/mock_config_sample.json
+++ b/RunCommand/Windows/Windows_Encryption_State_Check/mock_config_sample.json
@@ -1,0 +1,70 @@
+{
+  "profiles": {
+    "healthy": [
+      {
+        "name": "BitLocker volumes detected",
+        "status": "OK",
+        "detail": "Healthy"
+      },
+      {
+        "name": "ADE extension installed",
+        "status": "OK",
+        "detail": "All dependencies available"
+      },
+      {
+        "name": "ADE settings registry present",
+        "status": "OK",
+        "detail": "Below threshold"
+      },
+      {
+        "name": "OS drive (C:) encrypted by ADE",
+        "status": "OK",
+        "detail": "Baseline compliant"
+      }
+    ],
+    "degraded": [
+      {
+        "name": "BitLocker volumes detected",
+        "status": "OK",
+        "detail": "Operational with warnings"
+      },
+      {
+        "name": "ADE extension installed",
+        "status": "WARN",
+        "detail": "One non-blocking issue"
+      },
+      {
+        "name": "ADE settings registry present",
+        "status": "WARN",
+        "detail": "Elevated but not failing"
+      },
+      {
+        "name": "OS drive (C:) encrypted by ADE",
+        "status": "OK",
+        "detail": "Mostly compliant"
+      }
+    ],
+    "broken": [
+      {
+        "name": "BitLocker volumes detected",
+        "status": "FAIL",
+        "detail": "Blocking issue detected"
+      },
+      {
+        "name": "ADE extension installed",
+        "status": "FAIL",
+        "detail": "Critical dependency unavailable"
+      },
+      {
+        "name": "ADE settings registry present",
+        "status": "WARN",
+        "detail": "High error rate"
+      },
+      {
+        "name": "OS drive (C:) encrypted by ADE",
+        "status": "FAIL",
+        "detail": "Drift detected"
+      }
+    ]
+  }
+}

--- a/RunCommand/Windows/Windows_EventForwarding_WEF_Health/README.md
+++ b/RunCommand/Windows/Windows_EventForwarding_WEF_Health/README.md
@@ -1,0 +1,79 @@
+# Windows EventForwarding WEF Health
+
+> **Tool ID:** RC-021 · **Bucket:** Monitoring · **Phase:** 2 (Deep diagnostic)
+
+## What It Does
+
+Validates the Windows Event Forwarding (WEF) infrastructure on an Azure VM. Checks that the Event Collector service is running, WinRM is active, subscriptions are configured, and the ForwardedEvents log channel exists with adequate sizing. Essential for VMs that should be collecting or forwarding events but logs appear empty.
+
+| Check area | What is validated |
+|---|---|
+| Event Collector service | Windows Event Collector (Wecsvc) running |
+| WinRM service | WinRM service active (required for event forwarding) |
+| Subscriptions | Event forwarding subscriptions are configured |
+| ForwardedEvents log | ForwardedEvents log channel exists and sized |
+| WinRM listener | At least one WinRM listener configured |
+
+## Run Command Constraints Met
+
+- ✅ PowerShell 5.1 only
+- ✅ No Az module required
+- ✅ No internet access needed
+- ✅ Output < 4 KB
+- ✅ No interactive prompts
+- ✅ Read-only (diagnostic only)
+
+## How to Run
+
+### Azure Run Command (recommended)
+Navigate to VM → Operations → Run Command → RunPowerShellScript → paste script.
+
+### Azure CLI
+```bash
+az vm run-command invoke -g <rg> -n <vm> --command-id RunPowerShellScript \
+  --scripts @Windows_EventForwarding_WEF_Health/Windows_EventForwarding_WEF_Health.ps1
+```
+
+### Mock test
+```powershell
+.\Windows_EventForwarding_WEF_Health.ps1 -MockConfig .\mock_config_sample.json -MockProfile degraded
+```
+
+## Sample Output (Issues Detected)
+
+```
+=== Windows EventForwarding WEF Health ===
+Check                                        Status
+-------------------------------------------- ------
+Windows Event Collector service              FAIL
+WinRM service running                        FAIL
+Event subscriptions configured               FAIL
+ForwardedEvents log exists                   WARN
+WinRM listener configured                    FAIL
+-- Decision --
+Likely cause severity                        FAIL   Hard configuration/service break
+Next action                                  OK     Follow README interpretation and remediate FAIL rows first
+-- More Info --
+Remediation references available             OK     See paired README Learn References
+
+=== RESULT: 0 OK / 4 FAIL / 1 WARN ===
+```
+
+## Interpretation Guide
+
+| FAIL/WARN condition | Likely cause | Quick fix | Learn link |
+|---|---|---|---|
+| **Windows Event Collector service** FAIL | Wecsvc is stopped or disabled. WEF cannot function without this service. | `Set-Service Wecsvc -StartupType Automatic; Start-Service Wecsvc` | [Configure computers to forward events](https://learn.microsoft.com/windows/win32/wec/setting-up-a-source-initiated-subscription) |
+| **WinRM service running** FAIL | WinRM is stopped — required for WS-Management event delivery. | `Enable-PSRemoting -Force` or `winrm quickconfig` — also verify firewall allows TCP 5985/5986 | [WinRM installation and configuration](https://learn.microsoft.com/windows/win32/winrm/installation-and-configuration-for-windows-remote-management) |
+| **Event subscriptions configured** FAIL | No event forwarding subscriptions found. Collector has no rules defining what events to collect. | `wecutil cs <subscription.xml>` to create subscriptions or configure via GPO: Computer Config → Admin Templates → Windows Components → Event Forwarding | [Create WEF subscriptions](https://learn.microsoft.com/windows/win32/wec/setting-up-a-source-initiated-subscription) |
+| **ForwardedEvents log exists** WARN | ForwardedEvents log channel missing or undersized. Events may overflow and be lost. | Increase log size: `wevtutil sl ForwardedEvents /ms:1073741824` (1 GB). Default 20 MB is usually insufficient. | [Event log channels](https://learn.microsoft.com/windows-server/administration/windows-commands/wevtutil) |
+| **WinRM listener configured** FAIL | No WinRM listener — remote connections cannot be established for event delivery. | `winrm create winrm/config/Listener?Address=*+Transport=HTTP` or `Enable-PSRemoting -Force` | [WinRM troubleshooting](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-remote-connection-winrm) |
+
+## Related Articles
+
+| Article | Link |
+|---|---|
+| Windows Event Forwarding overview | [learn.microsoft.com](https://learn.microsoft.com/windows/win32/wec/windows-event-collector) |
+| Setting up source-initiated subscriptions | [learn.microsoft.com](https://learn.microsoft.com/windows/win32/wec/setting-up-a-source-initiated-subscription) |
+| WinRM configuration for Azure VMs | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-remote-connection-winrm) |
+| Azure VM diagnostics IaaS logs | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/iaas-logs) |

--- a/RunCommand/Windows/Windows_EventForwarding_WEF_Health/Windows_EventForwarding_WEF_Health.ps1
+++ b/RunCommand/Windows/Windows_EventForwarding_WEF_Health/Windows_EventForwarding_WEF_Health.ps1
@@ -1,0 +1,67 @@
+#Requires -Version 5.1
+[CmdletBinding()]
+param(
+  [string]$MockConfig,
+  [ValidateSet('healthy','degraded','broken')]
+  [string]$MockProfile = 'degraded'
+)
+$ErrorActionPreference='Continue'
+function Pad($s,$n){$s="$s";if($s.Length -ge $n){$s.Substring(0,$n)}else{$s.PadRight($n)}}
+$W=44
+$rows=New-Object System.Collections.Generic.List[object]
+function Add-Row($c,$s,$d=''){ $rows.Add([PSCustomObject]@{Check=$c;Status=$s;Detail=$d}); Write-Output ('{0} {1}' -f (Pad $c $W), $s) }
+
+Write-Output '=== Windows Event Forwarding (WEF) Health ==='
+Write-Output ('{0} {1}' -f (Pad 'Check' $W), 'Status')
+Write-Output (('-' * $W) + ' ------')
+
+$usedMock = $false
+if($MockConfig -and (Test-Path $MockConfig)){
+  $mock = Get-Content $MockConfig -Raw | ConvertFrom-Json
+  if($mock.profiles -and $mock.profiles.$MockProfile){
+    $usedMock = $true
+    foreach($i in $mock.profiles.$MockProfile){ Add-Row $i.name $i.status $i.detail }
+  }
+}
+
+if(-not $usedMock){
+  # Probe: Windows Event Collector service
+  $wecsvc = Get-Service Wecsvc -ErrorAction SilentlyContinue
+  $_s = if($wecsvc -and $wecsvc.Status -eq "Running"){'OK'}elseif(!$wecsvc -or $wecsvc.Status -ne "Running"){'WARN'}else{'FAIL'}
+  Add-Row 'Windows Event Collector service' $_s ("Status=$(if($wecsvc){$wecsvc.Status}else{'NotFound'})")
+
+  # Probe: WinRM service running
+  $winrm = Get-Service WinRM -ErrorAction SilentlyContinue
+  $_s = if(!$winrm -or $winrm.Status -ne "Running"){'FAIL'}elseif($winrm -and $winrm.Status -eq "Running"){'OK'}else{'WARN'}
+  Add-Row 'WinRM service running' $_s ("Status=$(if($winrm){$winrm.Status}else{'NotFound'})")
+
+  # Probe: Event subscriptions configured
+  $wecutil = wecutil es 2>&1; $subCount = if($LASTEXITCODE -eq 0){ @($wecutil | Where-Object { $_.Trim() }).Count } else { 0 }
+  $_s = if($subCount -gt 0){'OK'}elseif($subCount -eq 0){'WARN'}else{'FAIL'}
+  Add-Row 'Event subscriptions configured' $_s ("Subscriptions=$subCount")
+
+  # Probe: ForwardedEvents log exists
+  $fe = Get-WinEvent -ListLog ForwardedEvents -ErrorAction SilentlyContinue
+  $_s = if($fe -ne $null){'OK'}elseif($fe -eq $null){'WARN'}else{'FAIL'}
+  Add-Row 'ForwardedEvents log exists' $_s ("$(if($fe){`"MaxSizeMB=$([math]::Round($fe.MaximumSizeInBytes/1MB,0))`"}else{'Log missing'})")
+
+  # Probe: WinRM listener configured
+  $listener = winrm enumerate winrm/config/listener 2>&1; $lisOk = $listener -match "Transport"
+  $_s = if($lisOk){'OK'}elseif(!$lisOk){'WARN'}else{'FAIL'}
+  Add-Row 'WinRM listener configured' $_s ("$(if($lisOk){'Listener active'}else{'No listener'})")
+
+}
+
+$fail=@($rows|Where-Object Status -eq 'FAIL').Count
+$warn=@($rows|Where-Object Status -eq 'WARN').Count
+Write-Output '-- Decision --'
+Add-Row 'Likely cause severity' $(if($fail -gt 0){'FAIL'}elseif($warn -gt 0){'WARN'}else{'OK'}) $(if($fail -gt 0){'Hard configuration/service break'}elseif($warn -gt 0){'Configuration drift or transient condition'}else{'No blocking signals'})
+Add-Row 'Next action' 'OK' $(if($fail -gt 0){'Follow README interpretation and remediate FAIL rows first'}elseif($warn -gt 0){'Review WARN rows and re-run after targeted fix'}else{'No immediate action'})
+Write-Output '-- More Info --'
+Add-Row 'Remediation references available' 'OK' 'See paired README Learn References'
+
+$ok=@($rows|Where-Object Status -eq 'OK').Count
+Write-Output ''
+Write-Output "=== RESULT: $ok OK / $fail FAIL / $warn WARN ==="
+$rows
+

--- a/RunCommand/Windows/Windows_EventForwarding_WEF_Health/mock_config_sample.json
+++ b/RunCommand/Windows/Windows_EventForwarding_WEF_Health/mock_config_sample.json
@@ -1,0 +1,85 @@
+{
+  "profiles": {
+    "healthy": [
+      {
+        "name": "Windows Event Collector service",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "WinRM service running",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Event subscriptions configured",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "ForwardedEvents log exists",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "WinRM listener configured",
+        "status": "OK",
+        "detail": "Healthy profile"
+      }
+    ],
+    "broken": [
+      {
+        "name": "Windows Event Collector service",
+        "status": "FAIL",
+        "detail": "Critical failure detected"
+      },
+      {
+        "name": "WinRM service running",
+        "status": "FAIL",
+        "detail": "Critical failure detected"
+      },
+      {
+        "name": "Event subscriptions configured",
+        "status": "WARN",
+        "detail": "Degraded state"
+      },
+      {
+        "name": "ForwardedEvents log exists",
+        "status": "OK",
+        "detail": "Operational"
+      },
+      {
+        "name": "WinRM listener configured",
+        "status": "WARN",
+        "detail": "Degraded state"
+      }
+    ],
+    "degraded": [
+      {
+        "name": "Windows Event Collector service",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "WinRM service running",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Event subscriptions configured",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "ForwardedEvents log exists",
+        "status": "WARN",
+        "detail": "Configuration drift detected"
+      },
+      {
+        "name": "WinRM listener configured",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      }
+    ]
+  }
+}

--- a/RunCommand/Windows/Windows_EventLog_Channel_Health/README.md
+++ b/RunCommand/Windows/Windows_EventLog_Channel_Health/README.md
@@ -1,0 +1,108 @@
+# Windows EventLog Channel Health
+
+> **Tool ID:** RC-020 · **Bucket:** Monitoring · **Phase:** 2 (Deep diagnostic)
+
+## What It Does
+
+Validates Windows Event Log channel health and accessibility. Checks that the EventLog service is running, core log channels (System, Application, Security) are readable, and the System event error volume is within normal thresholds. Critical for VMs where diagnostic data collection fails or event logs appear empty.
+
+| Check area | What is validated |
+|---|---|
+| EventLog service | Windows Event Log service running |
+| System channel | System event log readable |
+| Application channel | Application event log readable |
+| Security channel | Security event log readable |
+| Error volume | System error events in last 4 hours below threshold |
+
+## Run Command Constraints Met
+
+- ✅ PowerShell 5.1 only
+- ✅ No Az module required
+- ✅ No internet access needed
+- ✅ Output < 4 KB
+- ✅ No interactive prompts
+- ✅ Read-only (diagnostic only)
+
+## How to Run
+
+### Azure Run Command (recommended)
+Navigate to VM → Operations → Run Command → RunPowerShellScript → paste script.
+
+### Azure CLI
+```bash
+az vm run-command invoke -g <rg> -n <vm> --command-id RunPowerShellScript \
+  --scripts @Windows_EventLog_Channel_Health/Windows_EventLog_Channel_Health.ps1
+```
+
+### Mock test
+```powershell
+.\Windows_EventLog_Channel_Health.ps1 -MockConfig .\mock_config_sample.json -MockProfile broken
+```
+
+## Sample Output (Issues Detected)
+
+```
+=== Windows EventLog Channel Health ===
+Check                                        Status
+-------------------------------------------- ------
+EventLog service running                     FAIL
+System channel readable                      FAIL
+Application channel readable                 FAIL
+Security channel readable                    WARN
+System errors in last 4h below threshold     WARN
+-- Decision --
+Likely cause severity                        FAIL   Hard configuration/service break
+Next action                                  OK     Follow README interpretation and remediate FAIL rows first
+-- More Info --
+Remediation references available             OK     See paired README Learn References
+
+=== RESULT: 0 OK / 3 FAIL / 2 WARN ===
+```
+
+## Interpretation Guide
+
+| FAIL/WARN condition | Likely cause | Quick fix | Learn link |
+|---|---|---|---|
+| **EventLog service running** FAIL | EventLog service stopped or crashed. No events can be written or read. Diagnostic data collection fails. | `Start-Service EventLog` — this is a critical system service. If it fails to start, check for disk space issues or corrupted log files. | [IaaS diagnostic logs](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/iaas-logs) |
+| **System channel readable** FAIL | System event log inaccessible. May be corrupted, at max size, or permissions changed. | `wevtutil cl System` to clear (after backup). Recreate: `wevtutil sl System /ms:20971520` (set max size). Check `C:\Windows\System32\winevt\Logs\System.evtx` permissions. | [Event log troubleshooting](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/iaas-logs) |
+| **Application channel readable** FAIL | Application log inaccessible. Application-level diagnostics unavailable. | Same approach as System: `wevtutil cl Application` (after backup). Check file permissions and disk space. | [Azure VM IaaS logs](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/iaas-logs) |
+| **Security channel readable** WARN | Security log inaccessible. May require elevated permissions or audit policy changes. Non-critical for basic diagnostics. | `wevtutil gl Security` to check config. May need `SeSecurityPrivilege`. Generally informational unless security auditing is required. | [Event ID troubleshoot VM RDP](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/event-id-troubleshoot-vm-rdp-connecton) |
+| **System errors in last 4h below threshold** WARN | High error rate (>200 errors in 4 hours) in System log. May indicate a cascading failure or noisy service. | `Get-WinEvent -FilterHashtable @{LogName='System'; Level=2; StartTime=(Get-Date).AddHours(-4)} \| Group-Object ProviderName \| Sort-Object Count -Descending` to identify top error sources | [Event-based RDP troubleshooting](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/event-id-troubleshoot-vm-rdp-connecton) |
+
+## Related Articles
+
+| Article | Link |
+|---|---|
+| Azure VM IaaS diagnostic logs | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/iaas-logs) |
+| Event ID-based RDP troubleshooting | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/event-id-troubleshoot-vm-rdp-connecton) |
+-------------------------------------------- ------
+EventLog service running                     FAIL
+System channel readable                      FAIL
+Application channel readable                 FAIL
+Security channel readable                    WARN
+System errors in last 4h below threshold     WARN
+-- Decision --
+Likely cause severity                        FAIL   Hard configuration/service break
+Next action                                  OK     Follow README interpretation and remediate FAIL rows first
+-- More Info --
+Remediation references available             OK     See paired README Learn References
+
+=== RESULT: 0 OK / 3 FAIL / 2 WARN ===
+```
+
+## Interpretation Guide
+
+| FAIL/WARN condition | Likely cause | Quick fix | Learn link |
+|---|---|---|---|
+| **EventLog service running** FAIL | EventLog service stopped or crashed. No events can be written or read. Diagnostic data collection fails. | `Start-Service EventLog` — this is a critical system service. If it fails to start, check for disk space issues or corrupted log files. | [IaaS diagnostic logs](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/iaas-logs) |
+| **System channel readable** FAIL | System event log inaccessible. May be corrupted, at max size, or permissions changed. | `wevtutil cl System` to clear (after backup). Recreate: `wevtutil sl System /ms:20971520` (set max size). Check `C:\Windows\System32\winevt\Logs\System.evtx` permissions. | [Event log troubleshooting](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/iaas-logs) |
+| **Application channel readable** FAIL | Application log inaccessible. Application-level diagnostics unavailable. | Same approach as System: `wevtutil cl Application` (after backup). Check file permissions and disk space. | [Azure VM IaaS logs](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/iaas-logs) |
+| **Security channel readable** WARN | Security log inaccessible. May require elevated permissions or audit policy changes. Non-critical for basic diagnostics. | `wevtutil gl Security` to check config. May need `SeSecurityPrivilege`. Generally informational unless security auditing is required. | [Event ID troubleshoot VM RDP](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/event-id-troubleshoot-vm-rdp-connecton) |
+| **System errors in last 4h below threshold** WARN | High error rate (>200 errors in 4 hours) in System log. May indicate a cascading failure or noisy service. | `Get-WinEvent -FilterHashtable @{LogName='System'; Level=2; StartTime=(Get-Date).AddHours(-4)} \| Group-Object ProviderName \| Sort-Object Count -Descending` to identify top error sources | [Event-based RDP troubleshooting](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/event-id-troubleshoot-vm-rdp-connecton) |
+
+## Related Articles
+
+| Article | Link |
+|---|---|
+| Azure VM IaaS diagnostic logs | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/iaas-logs) |
+| Event ID-based RDP troubleshooting | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/event-id-troubleshoot-vm-rdp-connecton) |

--- a/RunCommand/Windows/Windows_EventLog_Channel_Health/Windows_EventLog_Channel_Health.ps1
+++ b/RunCommand/Windows/Windows_EventLog_Channel_Health/Windows_EventLog_Channel_Health.ps1
@@ -1,0 +1,51 @@
+#Requires -Version 5.1
+[CmdletBinding()]
+param(
+  [string]$MockConfig,
+  [ValidateSet('healthy','degraded','broken')]
+  [string]$MockProfile = 'degraded'
+)
+$ErrorActionPreference='Continue'
+function Pad($s,$n){$s="$s";if($s.Length -ge $n){$s.Substring(0,$n)}else{$s.PadRight($n)}}
+$W=44
+$rows=New-Object System.Collections.Generic.List[object]
+function Add-Row($c,$s,$d=''){ $rows.Add([PSCustomObject]@{Check=$c;Status=$s;Detail=$d}); Write-Output ('{0} {1}' -f (Pad $c $W), $s) }
+
+Write-Output '=== Windows EventLog Channel Health ==='
+Write-Output ('{0} {1}' -f (Pad 'Check' $W), 'Status')
+Write-Output (('-' * $W) + ' ------')
+
+$usedMock = $false
+if($MockConfig -and (Test-Path $MockConfig)){
+  $mock = Get-Content $MockConfig -Raw | ConvertFrom-Json
+  if($mock.profiles -and $mock.profiles.$MockProfile){
+    $usedMock = $true
+    foreach($i in $mock.profiles.$MockProfile){ Add-Row $i.name $i.status $i.detail }
+  }
+}
+
+if(-not $usedMock){
+  $svc = Get-Service EventLog -ErrorAction SilentlyContinue
+  Add-Row 'EventLog service running' $(if($svc -and $svc.Status -eq 'Running'){'OK'}else{'FAIL'}) ''
+  $sys = Get-WinEvent -LogName System -MaxEvents 1 -ErrorAction SilentlyContinue
+  Add-Row 'System channel readable' $(if($sys){'OK'}else{'FAIL'}) ''
+  $app = Get-WinEvent -LogName Application -MaxEvents 1 -ErrorAction SilentlyContinue
+  Add-Row 'Application channel readable' $(if($app){'OK'}else{'FAIL'}) ''
+  $sec = Get-WinEvent -LogName Security -MaxEvents 1 -ErrorAction SilentlyContinue
+  Add-Row 'Security channel readable' $(if($sec){'OK'}else{'WARN'}) ''
+  $err = @(Get-WinEvent -FilterHashtable @{LogName='System'; Level=2; StartTime=(Get-Date).AddHours(-4)} -ErrorAction SilentlyContinue).Count
+  Add-Row 'System errors in last 4h below threshold' $(if($err -gt 200){'WARN'}else{'OK'}) "Errors=$err"
+}
+
+$fail=@($rows|Where-Object Status -eq 'FAIL').Count
+$warn=@($rows|Where-Object Status -eq 'WARN').Count
+Write-Output '-- Decision --'
+Add-Row 'Likely cause severity' $(if($fail -gt 0){'FAIL'}elseif($warn -gt 0){'WARN'}else{'OK'}) $(if($fail -gt 0){'Hard configuration/service break'}elseif($warn -gt 0){'Configuration drift or transient condition'}else{'No blocking signals'})
+Add-Row 'Next action' 'OK' $(if($fail -gt 0){'Follow README interpretation and remediate FAIL rows first'}elseif($warn -gt 0){'Review WARN rows and re-run after targeted fix'}else{'No immediate action'})
+Write-Output '-- More Info --'
+Add-Row 'Remediation references available' 'OK' 'See paired README Learn References'
+
+$ok=@($rows|Where-Object Status -eq 'OK').Count
+Write-Output ''
+Write-Output "=== RESULT: $ok OK / $fail FAIL / $warn WARN ==="
+$rows

--- a/RunCommand/Windows/Windows_EventLog_Channel_Health/mock_config_sample.json
+++ b/RunCommand/Windows/Windows_EventLog_Channel_Health/mock_config_sample.json
@@ -1,0 +1,85 @@
+{
+  "profiles": {
+    "healthy": [
+      {
+        "name": "EventLog service running",
+        "status": "OK",
+        "detail": "Healthy"
+      },
+      {
+        "name": "System channel readable",
+        "status": "OK",
+        "detail": "All dependencies available"
+      },
+      {
+        "name": "Application channel readable",
+        "status": "OK",
+        "detail": "Below threshold"
+      },
+      {
+        "name": "Security channel readable",
+        "status": "OK",
+        "detail": "Baseline compliant"
+      },
+      {
+        "name": "System errors in last 4h below threshold",
+        "status": "OK",
+        "detail": "Reachable"
+      }
+    ],
+    "degraded": [
+      {
+        "name": "EventLog service running",
+        "status": "OK",
+        "detail": "Operational with warnings"
+      },
+      {
+        "name": "System channel readable",
+        "status": "WARN",
+        "detail": "One non-blocking issue"
+      },
+      {
+        "name": "Application channel readable",
+        "status": "WARN",
+        "detail": "Elevated but not failing"
+      },
+      {
+        "name": "Security channel readable",
+        "status": "WARN",
+        "detail": "Mostly compliant"
+      },
+      {
+        "name": "System errors in last 4h below threshold",
+        "status": "OK",
+        "detail": "Reachable with latency"
+      }
+    ],
+    "broken": [
+      {
+        "name": "EventLog service running",
+        "status": "FAIL",
+        "detail": "Blocking issue detected"
+      },
+      {
+        "name": "System channel readable",
+        "status": "FAIL",
+        "detail": "Critical dependency unavailable"
+      },
+      {
+        "name": "Application channel readable",
+        "status": "WARN",
+        "detail": "High error rate"
+      },
+      {
+        "name": "Security channel readable",
+        "status": "WARN",
+        "detail": "Drift detected"
+      },
+      {
+        "name": "System errors in last 4h below threshold",
+        "status": "FAIL",
+        "detail": "Unreachable"
+      }
+    ]
+  }
+}

--- a/RunCommand/Windows/Windows_Extension_Install_Chain_Health/README.md
+++ b/RunCommand/Windows/Windows_Extension_Install_Chain_Health/README.md
@@ -1,0 +1,82 @@
+# Windows Extension Install Chain Health
+
+> **Tool ID:** RC-022 · **Bucket:** Azure Agent · **Phase:** 2 (Deep diagnostic)
+
+## What It Does
+
+Validates the Azure VM Agent extension installation pipeline. Checks that the Guest Agent (WindowsAzureGuestAgent) and RdAgent services are running, extension handler registry entries exist, the extension plugin directory is accessible, WireServer (168.63.129.16) is reachable, and agent logs are free of recent errors. Critical for diagnosing extension install/update failures.
+
+| Check area | What is validated |
+|---|---|
+| VM Agent service | Guest Agent (WindowsAzureGuestAgent) running |
+| RdAgent service | RdAgent service running |
+| Handler registry | Extension handler registry entries present |
+| Config folder | C:\Packages\Plugins exists and accessible |
+| WireServer | Connectivity to 168.63.129.16 |
+| Agent log errors | Recent errors in Guest Agent logs |
+
+## Run Command Constraints Met
+
+- ✅ PowerShell 5.1 only
+- ✅ No Az module required
+- ✅ No internet access needed (WireServer is host-local)
+- ✅ Output < 4 KB
+- ✅ No interactive prompts
+- ✅ Read-only (diagnostic only)
+
+## How to Run
+
+### Azure Run Command (recommended)
+Navigate to VM → Operations → Run Command → RunPowerShellScript → paste script.
+
+### Azure CLI
+```bash
+az vm run-command invoke -g <rg> -n <vm> --command-id RunPowerShellScript \
+  --scripts @Windows_Extension_Install_Chain_Health/Windows_Extension_Install_Chain_Health.ps1
+```
+
+### Mock test
+```powershell
+.\Windows_Extension_Install_Chain_Health.ps1 -MockConfig .\mock_config_sample.json -MockProfile broken
+```
+
+## Sample Output (Issues Detected)
+
+```
+=== Windows Extension Install Chain Health ===
+Check                                        Status
+-------------------------------------------- ------
+VM Agent service running                     FAIL
+RdAgent service running                      FAIL
+Extension handler registry entries           WARN
+Extension config folder accessible           FAIL
+WireServer connectivity (168.63.129.16)      FAIL
+Agent log recent errors                      FAIL
+-- Decision --
+Likely cause severity                        FAIL   Hard configuration/service break
+Next action                                  OK     Follow README interpretation and remediate FAIL rows first
+-- More Info --
+Remediation references available             OK     See paired README Learn References
+
+=== RESULT: 0 OK / 5 FAIL / 1 WARN ===
+```
+
+## Interpretation Guide
+
+| FAIL/WARN condition | Likely cause | Quick fix | Learn link |
+|---|---|---|---|
+| **VM Agent service running** FAIL | Guest Agent service is stopped, crashed, or was uninstalled. Extensions cannot install or report status without it. | Reinstall agent from `https://aka.ms/waagent`. Restart service: `Start-Service WindowsAzureGuestAgent` | [Troubleshoot Azure VM Agent](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/support-agent-extensions) |
+| **RdAgent service running** FAIL | RdAgent is stopped — it coordinates with the fabric and launches extension handlers. | `Start-Service RdAgent`. If missing, reinstall the VM Agent MSI. | [VM Agent overview](https://learn.microsoft.com/azure/virtual-machines/extensions/agent-windows) |
+| **Extension handler registry entries** WARN | Few or no handler registry keys. May indicate agent was recently installed or extensions were cleaned. | Check `HKLM:\SOFTWARE\Microsoft\Windows Azure\HandlerState`. If empty, trigger extension reinstall from Azure Portal. | [Extension troubleshooting](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-extension-certificates-issues-windows-vm) |
+| **Extension config folder accessible** FAIL | `C:\Packages\Plugins` missing or inaccessible. Extensions cannot be staged or executed. | Create if missing: `mkdir 'C:\Packages\Plugins'`. Check disk space on C: drive. Verify NTFS permissions allow SYSTEM full access. | [Troubleshoot extension certificates](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-extension-certificates-issues-windows-vm) |
+| **WireServer connectivity (168.63.129.16)** FAIL | Cannot reach WireServer — NSG, UDR, or Windows Firewall blocking 168.63.129.16. Agent cannot fetch configuration or report status. | Check: `Test-NetConnection 168.63.129.16 -Port 80`. Verify no UDR overrides the 168.63.129.16 route. Allow in firewall. | [What is IP 168.63.129.16?](https://learn.microsoft.com/azure/virtual-network/what-is-ip-address-168-63-129-16) |
+| **Agent log recent errors** WARN | Errors in `C:\WindowsAzure\Logs\WaAppAgent.log`. May indicate extension timeout, download failure, or certificate issue. | Review last 50 lines: `Get-Content 'C:\WindowsAzure\Logs\WaAppAgent.log' -Tail 50`. Common: cert expired, disk full, proxy block. | [Collect VM Agent logs](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/support-agent-extensions) |
+
+## Related Articles
+
+| Article | Link |
+|---|---|
+| Troubleshoot Azure VM Agent and extensions | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/support-agent-extensions) |
+| Azure VM Agent for Windows | [learn.microsoft.com](https://learn.microsoft.com/azure/virtual-machines/extensions/agent-windows) |
+| What is IP address 168.63.129.16? | [learn.microsoft.com](https://learn.microsoft.com/azure/virtual-network/what-is-ip-address-168-63-129-16) |
+| Troubleshoot extension certificate issues | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-extension-certificates-issues-windows-vm) |

--- a/RunCommand/Windows/Windows_Extension_Install_Chain_Health/Windows_Extension_Install_Chain_Health.ps1
+++ b/RunCommand/Windows/Windows_Extension_Install_Chain_Health/Windows_Extension_Install_Chain_Health.ps1
@@ -1,0 +1,72 @@
+#Requires -Version 5.1
+[CmdletBinding()]
+param(
+  [string]$MockConfig,
+  [ValidateSet('healthy','degraded','broken')]
+  [string]$MockProfile = 'degraded'
+)
+$ErrorActionPreference='Continue'
+function Pad($s,$n){$s="$s";if($s.Length -ge $n){$s.Substring(0,$n)}else{$s.PadRight($n)}}
+$W=44
+$rows=New-Object System.Collections.Generic.List[object]
+function Add-Row($c,$s,$d=''){ $rows.Add([PSCustomObject]@{Check=$c;Status=$s;Detail=$d}); Write-Output ('{0} {1}' -f (Pad $c $W), $s) }
+
+Write-Output '=== Windows Extension Install Chain Health ==='
+Write-Output ('{0} {1}' -f (Pad 'Check' $W), 'Status')
+Write-Output (('-' * $W) + ' ------')
+
+$usedMock = $false
+if($MockConfig -and (Test-Path $MockConfig)){
+  $mock = Get-Content $MockConfig -Raw | ConvertFrom-Json
+  if($mock.profiles -and $mock.profiles.$MockProfile){
+    $usedMock = $true
+    foreach($i in $mock.profiles.$MockProfile){ Add-Row $i.name $i.status $i.detail }
+  }
+}
+
+if(-not $usedMock){
+  # Probe: VM Agent service running
+  $ga = Get-Service WindowsAzureGuestAgent -ErrorAction SilentlyContinue
+  $_s = if(!$ga -or $ga.Status -ne "Running"){'FAIL'}elseif($ga -and $ga.Status -eq "Running"){'OK'}else{'WARN'}
+  Add-Row 'VM Agent service running' $_s ("Status=$(if($ga){$ga.Status}else{'NotFound'})")
+
+  # Probe: RdAgent service running
+  $rd = Get-Service RdAgent -ErrorAction SilentlyContinue
+  $_s = if(!$rd -or $rd.Status -ne "Running"){'FAIL'}elseif($rd -and $rd.Status -eq "Running"){'OK'}else{'WARN'}
+  Add-Row 'RdAgent service running' $_s ("Status=$(if($rd){$rd.Status}else{'NotFound'})")
+
+  # Probe: Extension handler registry entries
+  $hRoot = "HKLM:\SOFTWARE\Microsoft\Windows Azure\HandlerState"; $handlers = if(Test-Path $hRoot){ @(Get-ChildItem $hRoot -ErrorAction SilentlyContinue).Count } else { 0 }
+  $_s = if($handlers -gt 0){'OK'}elseif($handlers -eq 0){'WARN'}else{'FAIL'}
+  Add-Row 'Extension handler registry entries' $_s ("Handlers=$handlers")
+
+  # Probe: Extension config folder accessible
+  $extCfg = Test-Path "C:\Packages\Plugins"
+  $_s = if($extCfg){'OK'}elseif(!$extCfg){'WARN'}else{'FAIL'}
+  Add-Row 'Extension config folder accessible' $_s ("C:\Packages\Plugins exists=$extCfg")
+
+  # Probe: WireServer connectivity (168.63.129.16)
+  $ws = Test-NetConnection -ComputerName 168.63.129.16 -Port 80 -WarningAction SilentlyContinue -ErrorAction SilentlyContinue; $wsOk = $ws.TcpTestSucceeded
+  $_s = if(!$wsOk){'FAIL'}elseif($wsOk){'OK'}else{'WARN'}
+  Add-Row 'WireServer connectivity (168.63.129.16)' $_s ("WireServer=$wsOk")
+
+  # Probe: Agent log recent errors
+  $agLog = "C:\WindowsAzure\Logs\WaAppAgent.log"; $errs = if(Test-Path $agLog){ @(Get-Content $agLog -Tail 50 -ErrorAction SilentlyContinue | Where-Object { $_ -match "ERROR" }).Count } else { -1 }
+  $_s = if($errs -eq 0){'OK'}elseif($errs -le 5){'WARN'}else{'FAIL'}
+  Add-Row 'Agent log recent errors' $_s ("RecentErrors=$errs")
+
+}
+
+$fail=@($rows|Where-Object Status -eq 'FAIL').Count
+$warn=@($rows|Where-Object Status -eq 'WARN').Count
+Write-Output '-- Decision --'
+Add-Row 'Likely cause severity' $(if($fail -gt 0){'FAIL'}elseif($warn -gt 0){'WARN'}else{'OK'}) $(if($fail -gt 0){'Hard configuration/service break'}elseif($warn -gt 0){'Configuration drift or transient condition'}else{'No blocking signals'})
+Add-Row 'Next action' 'OK' $(if($fail -gt 0){'Follow README interpretation and remediate FAIL rows first'}elseif($warn -gt 0){'Review WARN rows and re-run after targeted fix'}else{'No immediate action'})
+Write-Output '-- More Info --'
+Add-Row 'Remediation references available' 'OK' 'See paired README Learn References'
+
+$ok=@($rows|Where-Object Status -eq 'OK').Count
+Write-Output ''
+Write-Output "=== RESULT: $ok OK / $fail FAIL / $warn WARN ==="
+$rows
+

--- a/RunCommand/Windows/Windows_Extension_Install_Chain_Health/mock_config_sample.json
+++ b/RunCommand/Windows/Windows_Extension_Install_Chain_Health/mock_config_sample.json
@@ -1,0 +1,100 @@
+{
+  "profiles": {
+    "healthy": [
+      {
+        "name": "VM Agent service running",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "RdAgent service running",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Extension handler registry entries",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Extension config folder accessible",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "WireServer connectivity (168.63.129.16)",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Agent log recent errors",
+        "status": "OK",
+        "detail": "Healthy profile"
+      }
+    ],
+    "broken": [
+      {
+        "name": "VM Agent service running",
+        "status": "FAIL",
+        "detail": "Critical failure detected"
+      },
+      {
+        "name": "RdAgent service running",
+        "status": "FAIL",
+        "detail": "Critical failure detected"
+      },
+      {
+        "name": "Extension handler registry entries",
+        "status": "WARN",
+        "detail": "Degraded state"
+      },
+      {
+        "name": "Extension config folder accessible",
+        "status": "OK",
+        "detail": "Operational"
+      },
+      {
+        "name": "WireServer connectivity (168.63.129.16)",
+        "status": "WARN",
+        "detail": "Degraded state"
+      },
+      {
+        "name": "Agent log recent errors",
+        "status": "OK",
+        "detail": "Operational"
+      }
+    ],
+    "degraded": [
+      {
+        "name": "VM Agent service running",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "RdAgent service running",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Extension handler registry entries",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Extension config folder accessible",
+        "status": "WARN",
+        "detail": "Configuration drift detected"
+      },
+      {
+        "name": "WireServer connectivity (168.63.129.16)",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Agent log recent errors",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      }
+    ]
+  }
+}

--- a/RunCommand/Windows/Windows_Firewall_Profile_Baseline_Check/README.md
+++ b/RunCommand/Windows/Windows_Firewall_Profile_Baseline_Check/README.md
@@ -1,0 +1,77 @@
+# Windows Firewall Profile Baseline Check
+
+> **Tool ID:** RC-022 · **Bucket:** Network / Firewall · **Phase:** 2 (Deep diagnostic)
+
+## What It Does
+
+Validates Windows Firewall profile configuration and critical rule state. Checks profile query capability, enabled profiles, RDP firewall rule, inbound default policy, and Base Filtering Engine (BFE) service. Essential for diagnosing VMs where connectivity is blocked by guest firewall misconfiguration.
+
+| Check area | What is validated |
+|---|---|
+| Profile query | Firewall profiles query succeeds |
+| Enabled profiles | At least one firewall profile enabled |
+| RDP rule | Remote Desktop rule enabled |
+| Inbound default | Inbound default block active |
+| BFE service | Base Filtering Engine running |
+
+## Run Command Constraints Met
+
+- ✅ PowerShell 5.1 only
+- ✅ No Az module required
+- ✅ No internet access needed
+- ✅ Output < 4 KB
+- ✅ No interactive prompts
+- ✅ Read-only (diagnostic only)
+
+## How to Run
+
+### Azure Run Command (recommended)
+Navigate to VM → Operations → Run Command → RunPowerShellScript → paste script.
+
+### Azure CLI
+```bash
+az vm run-command invoke -g <rg> -n <vm> --command-id RunPowerShellScript \
+  --scripts @Windows_Firewall_Profile_Baseline_Check/Windows_Firewall_Profile_Baseline_Check.ps1
+```
+
+### Mock test
+```powershell
+.\Windows_Firewall_Profile_Baseline_Check.ps1 -MockConfig .\mock_config_sample.json -MockProfile broken
+```
+
+## Sample Output (Issues Detected)
+
+```
+=== Windows Firewall Profile Baseline Check ===
+Check                                        Status
+-------------------------------------------- ------
+Firewall profiles query succeeds             OK
+At least one profile enabled                 FAIL
+Remote Desktop rule enabled                  WARN
+Inbound default block active                 WARN
+BFE service running                          FAIL
+-- Decision --
+Likely cause severity                        FAIL   Hard configuration/service break
+Next action                                  OK     Follow README interpretation and remediate FAIL rows first
+-- More Info --
+Remediation references available             OK     See paired README Learn References
+
+=== RESULT: 1 OK / 2 FAIL / 2 WARN ===
+```
+
+## Interpretation Guide
+
+| FAIL/WARN condition | Likely cause | Quick fix | Learn link |
+|---|---|---|---|
+| **Firewall profiles query succeeds** FAIL | `Get-NetFirewallProfile` failed. WMI/CIM subsystem issue or firewall provider crashed. | Restart WMI: `Restart-Service winmgmt -Force`. If persistent, check WMI repository integrity. | [Guest OS firewall misconfigured](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/guest-os-firewall-misconfigured) |
+| **At least one profile enabled** FAIL | All firewall profiles disabled. VM has no firewall protection and may allow unexpected traffic. | `Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled True` | [Enable/disable firewall rule](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/enable-disable-firewall-rule-guest-os) |
+| **Remote Desktop rule enabled** WARN | Windows Firewall RDP inbound rule is disabled. Remote Desktop connections will be blocked at the guest level. | `Enable-NetFirewallRule -DisplayGroup "Remote Desktop"` | [Enable/disable firewall rule](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/enable-disable-firewall-rule-guest-os) |
+| **Inbound default block active** WARN | Default inbound policy is Allow instead of Block. VM is accepting all inbound traffic not explicitly denied. | `Set-NetFirewallProfile -Profile Domain,Public,Private -DefaultInboundAction Block` | [Guest OS firewall misconfigured](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/guest-os-firewall-misconfigured) |
+| **BFE service running** FAIL | Base Filtering Engine stopped. Windows Firewall and all WFP-based filtering is non-functional. | `Set-Service BFE -StartupType Automatic; Start-Service BFE; Start-Service MpsSvc` | [Guest OS firewall misconfigured](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/guest-os-firewall-misconfigured) |
+
+## Related Articles
+
+| Article | Link |
+|---|---|
+| Guest OS firewall misconfigured | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/guest-os-firewall-misconfigured) |
+| Enable/disable guest OS firewall rule | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/enable-disable-firewall-rule-guest-os) |

--- a/RunCommand/Windows/Windows_Firewall_Profile_Baseline_Check/Windows_Firewall_Profile_Baseline_Check.ps1
+++ b/RunCommand/Windows/Windows_Firewall_Profile_Baseline_Check/Windows_Firewall_Profile_Baseline_Check.ps1
@@ -1,0 +1,51 @@
+#Requires -Version 5.1
+[CmdletBinding()]
+param(
+  [string]$MockConfig,
+  [ValidateSet('healthy','degraded','broken')]
+  [string]$MockProfile = 'degraded'
+)
+$ErrorActionPreference='Continue'
+function Pad($s,$n){$s="$s";if($s.Length -ge $n){$s.Substring(0,$n)}else{$s.PadRight($n)}}
+$W=44
+$rows=New-Object System.Collections.Generic.List[object]
+function Add-Row($c,$s,$d=''){ $rows.Add([PSCustomObject]@{Check=$c;Status=$s;Detail=$d}); Write-Output ('{0} {1}' -f (Pad $c $W), $s) }
+
+Write-Output '=== Windows Firewall Profile Baseline Check ==='
+Write-Output ('{0} {1}' -f (Pad 'Check' $W), 'Status')
+Write-Output (('-' * $W) + ' ------')
+
+$usedMock = $false
+if($MockConfig -and (Test-Path $MockConfig)){
+  $mock = Get-Content $MockConfig -Raw | ConvertFrom-Json
+  if($mock.profiles -and $mock.profiles.$MockProfile){
+    $usedMock = $true
+    foreach($i in $mock.profiles.$MockProfile){ Add-Row $i.name $i.status $i.detail }
+  }
+}
+
+if(-not $usedMock){
+  $p = Get-NetFirewallProfile -ErrorAction SilentlyContinue
+  Add-Row 'Firewall profiles query succeeds' $(if($p){'OK'}else{'FAIL'}) ''
+  $enabled = @($p | Where-Object Enabled -eq 'True').Count
+  Add-Row 'At least one profile enabled' $(if($enabled -gt 0){'OK'}else{'FAIL'}) "Enabled=$enabled"
+  $rdp = Get-NetFirewallRule -DisplayGroup 'Remote Desktop' -ErrorAction SilentlyContinue | Where-Object Enabled -eq 'True'
+  Add-Row 'Remote Desktop rule enabled' $(if($rdp){'OK'}else{'WARN'}) ''
+  $blockAll = @($p | Where-Object DefaultInboundAction -eq 'Block').Count
+  Add-Row 'Inbound default block active' $(if($blockAll -ge 1){'OK'}else{'WARN'}) ''
+  $bfe = Get-Service BFE -ErrorAction SilentlyContinue
+  Add-Row 'BFE service running' $(if($bfe -and $bfe.Status -eq 'Running'){'OK'}else{'FAIL'}) ''
+}
+
+$fail=@($rows|Where-Object Status -eq 'FAIL').Count
+$warn=@($rows|Where-Object Status -eq 'WARN').Count
+Write-Output '-- Decision --'
+Add-Row 'Likely cause severity' $(if($fail -gt 0){'FAIL'}elseif($warn -gt 0){'WARN'}else{'OK'}) $(if($fail -gt 0){'Hard configuration/service break'}elseif($warn -gt 0){'Configuration drift or transient condition'}else{'No blocking signals'})
+Add-Row 'Next action' 'OK' $(if($fail -gt 0){'Follow README interpretation and remediate FAIL rows first'}elseif($warn -gt 0){'Review WARN rows and re-run after targeted fix'}else{'No immediate action'})
+Write-Output '-- More Info --'
+Add-Row 'Remediation references available' 'OK' 'See paired README Learn References'
+
+$ok=@($rows|Where-Object Status -eq 'OK').Count
+Write-Output ''
+Write-Output "=== RESULT: $ok OK / $fail FAIL / $warn WARN ==="
+$rows

--- a/RunCommand/Windows/Windows_Firewall_Profile_Baseline_Check/mock_config_sample.json
+++ b/RunCommand/Windows/Windows_Firewall_Profile_Baseline_Check/mock_config_sample.json
@@ -1,0 +1,85 @@
+{
+  "profiles": {
+    "healthy": [
+      {
+        "name": "Firewall profiles query succeeds",
+        "status": "OK",
+        "detail": "Healthy"
+      },
+      {
+        "name": "At least one profile enabled",
+        "status": "OK",
+        "detail": "All dependencies available"
+      },
+      {
+        "name": "Remote Desktop rule enabled",
+        "status": "OK",
+        "detail": "Below threshold"
+      },
+      {
+        "name": "Inbound default block active",
+        "status": "OK",
+        "detail": "Baseline compliant"
+      },
+      {
+        "name": "BFE service running",
+        "status": "OK",
+        "detail": "Reachable"
+      }
+    ],
+    "degraded": [
+      {
+        "name": "Firewall profiles query succeeds",
+        "status": "OK",
+        "detail": "Operational with warnings"
+      },
+      {
+        "name": "At least one profile enabled",
+        "status": "WARN",
+        "detail": "One non-blocking issue"
+      },
+      {
+        "name": "Remote Desktop rule enabled",
+        "status": "WARN",
+        "detail": "Elevated but not failing"
+      },
+      {
+        "name": "Inbound default block active",
+        "status": "WARN",
+        "detail": "Mostly compliant"
+      },
+      {
+        "name": "BFE service running",
+        "status": "OK",
+        "detail": "Reachable with latency"
+      }
+    ],
+    "broken": [
+      {
+        "name": "Firewall profiles query succeeds",
+        "status": "FAIL",
+        "detail": "Blocking issue detected"
+      },
+      {
+        "name": "At least one profile enabled",
+        "status": "FAIL",
+        "detail": "Critical dependency unavailable"
+      },
+      {
+        "name": "Remote Desktop rule enabled",
+        "status": "WARN",
+        "detail": "High error rate"
+      },
+      {
+        "name": "Inbound default block active",
+        "status": "WARN",
+        "detail": "Drift detected"
+      },
+      {
+        "name": "BFE service running",
+        "status": "FAIL",
+        "detail": "Unreachable"
+      }
+    ]
+  }
+}

--- a/RunCommand/Windows/Windows_GroupPolicy_Processing_Health/README.md
+++ b/RunCommand/Windows/Windows_GroupPolicy_Processing_Health/README.md
@@ -1,0 +1,77 @@
+# Windows Group Policy Processing Health
+
+> **Tool ID:** RC-024 · **Bucket:** Identity / Group Policy · **Phase:** 2 (Deep diagnostic)
+
+## What It Does
+
+Validates Group Policy processing health on a domain-joined Azure VM. Checks GPSvc service state, operational log accessibility, recent GP error volume, and NETLOGON/SYSVOL path accessibility. Important for VMs stuck at "Applying Group Policy" or failing to apply policies.
+
+| Check area | What is validated |
+|---|---|
+| GPSvc service | Group Policy Client service running |
+| Operational log | GroupPolicy operational log readable |
+| GP errors | Recent GP errors below threshold |
+| NETLOGON path | NETLOGON network path accessible |
+| SYSVOL path | SYSVOL network path accessible |
+
+## Run Command Constraints Met
+
+- ✅ PowerShell 5.1 only
+- ✅ No Az module required
+- ✅ No internet access needed
+- ✅ Output < 4 KB
+- ✅ No interactive prompts
+- ✅ Read-only (diagnostic only)
+
+## How to Run
+
+### Azure Run Command (recommended)
+Navigate to VM → Operations → Run Command → RunPowerShellScript → paste script.
+
+### Azure CLI
+```bash
+az vm run-command invoke -g <rg> -n <vm> --command-id RunPowerShellScript \
+  --scripts @Windows_GroupPolicy_Processing_Health/Windows_GroupPolicy_Processing_Health.ps1
+```
+
+### Mock test
+```powershell
+.\Windows_GroupPolicy_Processing_Health.ps1 -MockConfig .\mock_config_sample.json -MockProfile broken
+```
+
+## Sample Output (Issues Detected)
+
+```
+=== Windows Group Policy Processing Health ===
+Check                                        Status
+-------------------------------------------- ------
+GPSvc service running                        FAIL
+GroupPolicy operational log readable         WARN
+Recent GP errors below threshold             WARN
+NETLOGON path accessible                     WARN
+SYSVOL path accessible                       WARN
+-- Decision --
+Likely cause severity                        FAIL   Hard configuration/service break
+Next action                                  OK     Follow README interpretation and remediate FAIL rows first
+-- More Info --
+Remediation references available             OK     See paired README Learn References
+
+=== RESULT: 0 OK / 1 FAIL / 4 WARN ===
+```
+
+## Interpretation Guide
+
+| FAIL/WARN condition | Likely cause | Quick fix | Learn link |
+|---|---|---|---|
+| **GPSvc service running** FAIL | Group Policy Client service (gpsvc) is stopped. Policies cannot be applied. VM may be stuck at boot. | `Set-Service gpsvc -StartupType Automatic; Start-Service gpsvc`. If stuck at boot, use Serial Console. | [Unresponsive VM applying Group Policy](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/unresponsive-vm-apply-group-policy) |
+| **GroupPolicy operational log readable** WARN | GroupPolicy operational event log is empty or inaccessible. Cannot determine GP processing state. | `wevtutil gl "Microsoft-Windows-GroupPolicy/Operational"` — if disabled, enable: `wevtutil sl "Microsoft-Windows-GroupPolicy/Operational" /e:true` | [Applying Group Policy services policy](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/applying-group-policy-services-policy) |
+| **Recent GP errors below threshold** WARN | More than 5 GP errors in operational log. May indicate policy conflicts, missing DC, or WMI filter failures. | `gpresult /h C:\temp\gpreport.html` — review for failed policies. Check DC connectivity. | [Unresponsive VM applying Group Policy](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/unresponsive-vm-apply-group-policy) |
+| **NETLOGON path accessible** WARN | `\\<domain>\NETLOGON` is inaccessible. Logon scripts and some policies will fail. | Verify DNS points to DC. Test: `net use \\<domain>\NETLOGON`. Check firewall allows SMB (445). | [Applying Group Policy services policy](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/applying-group-policy-services-policy) |
+| **SYSVOL path accessible** WARN | `\\<domain>\SYSVOL` is inaccessible. GPO templates cannot be downloaded. | Same as NETLOGON — verify DNS, SMB connectivity, and DC replication. `dcdiag /test:sysvolcheck` on DC. | [Applying Group Policy services policy](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/applying-group-policy-services-policy) |
+
+## Related Articles
+
+| Article | Link |
+|---|---|
+| Unresponsive VM applying Group Policy | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/unresponsive-vm-apply-group-policy) |
+| Applying Group Policy services policy | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/applying-group-policy-services-policy) |

--- a/RunCommand/Windows/Windows_GroupPolicy_Processing_Health/Windows_GroupPolicy_Processing_Health.ps1
+++ b/RunCommand/Windows/Windows_GroupPolicy_Processing_Health/Windows_GroupPolicy_Processing_Health.ps1
@@ -1,0 +1,51 @@
+#Requires -Version 5.1
+[CmdletBinding()]
+param(
+  [string]$MockConfig,
+  [ValidateSet('healthy','degraded','broken')]
+  [string]$MockProfile = 'degraded'
+)
+$ErrorActionPreference='Continue'
+function Pad($s,$n){$s="$s";if($s.Length -ge $n){$s.Substring(0,$n)}else{$s.PadRight($n)}}
+$W=44
+$rows=New-Object System.Collections.Generic.List[object]
+function Add-Row($c,$s,$d=''){ $rows.Add([PSCustomObject]@{Check=$c;Status=$s;Detail=$d}); Write-Output ('{0} {1}' -f (Pad $c $W), $s) }
+
+Write-Output '=== Windows Group Policy Processing Health ==='
+Write-Output ('{0} {1}' -f (Pad 'Check' $W), 'Status')
+Write-Output (('-' * $W) + ' ------')
+
+$usedMock = $false
+if($MockConfig -and (Test-Path $MockConfig)){
+  $mock = Get-Content $MockConfig -Raw | ConvertFrom-Json
+  if($mock.profiles -and $mock.profiles.$MockProfile){
+    $usedMock = $true
+    foreach($i in $mock.profiles.$MockProfile){ Add-Row $i.name $i.status $i.detail }
+  }
+}
+
+if(-not $usedMock){
+  $gpsvc = Get-Service gpsvc -ErrorAction SilentlyContinue
+  Add-Row 'GPSvc service running' $(if($gpsvc -and $gpsvc.Status -eq 'Running'){'OK'}else{'FAIL'}) ''
+  $ev = Get-WinEvent -LogName 'Microsoft-Windows-GroupPolicy/Operational' -MaxEvents 50 -ErrorAction SilentlyContinue
+  Add-Row 'GroupPolicy operational log readable' $(if($ev){'OK'}else{'WARN'}) ''
+  $errs = @($ev | Where-Object LevelDisplayName -in @('Error','Critical')).Count
+  Add-Row 'Recent GP errors below threshold' $(if($errs -gt 5){'WARN'}else{'OK'}) "Errors=$errs"
+  $netlogon = Test-Path '\\localhost\NETLOGON'
+  Add-Row 'NETLOGON path accessible' $(if($netlogon){'OK'}else{'WARN'}) ''
+  $sysvol = Test-Path '\\localhost\SYSVOL'
+  Add-Row 'SYSVOL path accessible' $(if($sysvol){'OK'}else{'WARN'}) ''
+}
+
+$fail=@($rows|Where-Object Status -eq 'FAIL').Count
+$warn=@($rows|Where-Object Status -eq 'WARN').Count
+Write-Output '-- Decision --'
+Add-Row 'Likely cause severity' $(if($fail -gt 0){'FAIL'}elseif($warn -gt 0){'WARN'}else{'OK'}) $(if($fail -gt 0){'Hard configuration/service break'}elseif($warn -gt 0){'Configuration drift or transient condition'}else{'No blocking signals'})
+Add-Row 'Next action' 'OK' $(if($fail -gt 0){'Follow README interpretation and remediate FAIL rows first'}elseif($warn -gt 0){'Review WARN rows and re-run after targeted fix'}else{'No immediate action'})
+Write-Output '-- More Info --'
+Add-Row 'Remediation references available' 'OK' 'See paired README Learn References'
+
+$ok=@($rows|Where-Object Status -eq 'OK').Count
+Write-Output ''
+Write-Output "=== RESULT: $ok OK / $fail FAIL / $warn WARN ==="
+$rows

--- a/RunCommand/Windows/Windows_GroupPolicy_Processing_Health/mock_config_sample.json
+++ b/RunCommand/Windows/Windows_GroupPolicy_Processing_Health/mock_config_sample.json
@@ -1,0 +1,85 @@
+{
+  "profiles": {
+    "healthy": [
+      {
+        "name": "GPSvc service running",
+        "status": "OK",
+        "detail": "Healthy"
+      },
+      {
+        "name": "GroupPolicy operational log readable",
+        "status": "OK",
+        "detail": "All dependencies available"
+      },
+      {
+        "name": "Recent GP errors below threshold",
+        "status": "OK",
+        "detail": "Below threshold"
+      },
+      {
+        "name": "NETLOGON path accessible",
+        "status": "OK",
+        "detail": "Baseline compliant"
+      },
+      {
+        "name": "SYSVOL path accessible",
+        "status": "OK",
+        "detail": "Reachable"
+      }
+    ],
+    "degraded": [
+      {
+        "name": "GPSvc service running",
+        "status": "OK",
+        "detail": "Operational with warnings"
+      },
+      {
+        "name": "GroupPolicy operational log readable",
+        "status": "WARN",
+        "detail": "One non-blocking issue"
+      },
+      {
+        "name": "Recent GP errors below threshold",
+        "status": "WARN",
+        "detail": "Elevated but not failing"
+      },
+      {
+        "name": "NETLOGON path accessible",
+        "status": "WARN",
+        "detail": "Mostly compliant"
+      },
+      {
+        "name": "SYSVOL path accessible",
+        "status": "OK",
+        "detail": "Reachable with latency"
+      }
+    ],
+    "broken": [
+      {
+        "name": "GPSvc service running",
+        "status": "FAIL",
+        "detail": "Blocking issue detected"
+      },
+      {
+        "name": "GroupPolicy operational log readable",
+        "status": "FAIL",
+        "detail": "Critical dependency unavailable"
+      },
+      {
+        "name": "Recent GP errors below threshold",
+        "status": "WARN",
+        "detail": "High error rate"
+      },
+      {
+        "name": "NETLOGON path accessible",
+        "status": "WARN",
+        "detail": "Drift detected"
+      },
+      {
+        "name": "SYSVOL path accessible",
+        "status": "FAIL",
+        "detail": "Unreachable"
+      }
+    ]
+  }
+}

--- a/RunCommand/Windows/Windows_IMDS_Attested_Monitor/README.md
+++ b/RunCommand/Windows/Windows_IMDS_Attested_Monitor/README.md
@@ -1,0 +1,99 @@
+# Azure VM IMDS Attested Data Access Monitor
+
+This PowerShell script monitors which processes on an Azure VM are accessing the Instance Metadata Service (IMDS) attested data endpoint (`http://169.254.169.254/metadata/attested`). It runs for a configurable time window (default 30 minutes), captures all processes making connections to 169.254.169.254, and reports the process name, PID, path, and command line.
+
+## Features
+
+- Monitors all connections to the IMDS endpoint (169.254.169.254) over a configurable time window
+- Uses three detection methods for maximum coverage:
+  - **TCP Connection Polling** – polls active TCP connections every 5 seconds
+  - **WFP Audit Events** – leverages Windows Filtering Platform audit logs (Security Event ID 5156) for process-to-connection correlation
+  - **HTTP ETW Tracing** – checks WebIO diagnostic events for HTTP-level attested endpoint access
+- Captures an ETW network trace (netsh trace) filtered to IMDS IP for offline analysis
+- Reports process name, PID, executable path, and command line for each detected process
+- Exports full results to CSV
+- Provides a summary of unique processes and hit counts at completion
+
+## Prerequisites
+
+- PowerShell 5.1 or later
+- Must be run as **Administrator** (required for ETW tracing and audit policy)
+- Must be executed within an Azure VM (accesses the IMDS endpoint at 169.254.169.254)
+
+## Usage
+
+### Option 1 – Azure Run Command (Portal)
+
+1. Navigate to the Azure Portal → Virtual Machine → **Operations** → **Run Command** → **RunPowerShellScript**
+2. Paste the contents of `Windows_IMDS_Attested_Monitor.ps1`
+3. Execute
+
+> **Note:** Run Command has a default timeout. For 30-minute monitoring, consider running directly on the VM instead.
+
+### Option 2 – Directly on the VM
+
+```powershell
+# Default 30-minute monitoring window
+Set-ExecutionPolicy Bypass -Force
+.\Windows_IMDS_Attested_Monitor.ps1
+
+# Custom duration (e.g., 60 minutes)
+.\Windows_IMDS_Attested_Monitor.ps1 -MonitorMinutes 60
+```
+
+## Output
+
+The script produces:
+
+1. **Console output** – real-time detection alerts as processes are caught accessing IMDS
+2. **CSV file** – full results exported to `%TEMP%\IMDS_Attested_Monitor_<timestamp>.csv`
+3. **ETL trace** – network trace file at `%TEMP%\IMDSAttestedMonitor.etl` (can be converted with `netsh trace convert`)
+
+### Sample Output
+
+```
+[14:32:15] DETECTED - PID: 4832 | Process: python | State: Established | Port: 49721->80
+           Path: C:\Python39\python.exe
+           CmdLine: python.exe fetch_attested.py
+
+[14:45:02] DETECTED (WFP) - PID: 1284 | Process: WaAppAgent | Path: \device\harddiskvolume2\windowsazure\packages\...
+```
+
+### Results Summary
+
+```
+Unique Processes Detected Accessing IMDS (169.254.169.254):
+---------------------------------------------------------
+  Process     : python
+  PID(s)      : 4832
+  Hit Count   : 3
+  Path        : C:\Python39\python.exe
+  First Seen  : 2026-02-13 14:32:15
+  Last Seen   : 2026-02-13 14:45:02
+```
+
+## How It Works
+
+1. **ETW Trace** – starts a `netsh trace` session filtered to 169.254.169.254 for packet-level capture
+2. **Audit Policy** – temporarily enables WFP connection auditing to generate Security Event 5156 entries that include the owning process
+3. **Polling Loop** – every 5 seconds, checks `Get-NetTCPConnection` for active connections to IMDS; every 50 seconds checks WFP audit events; every 150 seconds checks HTTP ETW events
+4. **Cleanup** – stops the trace, restores audit policy, and outputs results
+
+## References
+
+- [Azure Instance Metadata Service](https://learn.microsoft.com/azure/virtual-machines/windows/instance-metadata-service)
+- [IMDS Attested Data](https://learn.microsoft.com/azure/virtual-machines/instance-metadata-service?tabs=windows#attested-data)
+
+## Liability
+
+As described in the [MIT license](..\..\..\LICENSE.txt), these scripts are provided as-is with no warranty or liability associated with their use.
+
+## Provide Feedback
+
+We value your input. If you encounter problems with the scripts or ideas on how they can be improved please file an issue in the [Issues](https://github.com/Azure/azure-support-scripts/issues) section of the project.
+
+## Known Issues
+
+- Azure Run Command has a default execution timeout that may be shorter than the monitoring window. For long monitoring sessions, run directly on the VM.
+- Very short-lived connections (sub-second) may be missed by TCP polling but should be captured by WFP audit events or the ETW trace.
+- WFP audit events require the Security event log to have sufficient capacity.

--- a/RunCommand/Windows/Windows_IMDS_Attested_Monitor/Windows_IMDS_Attested_Monitor.ps1
+++ b/RunCommand/Windows/Windows_IMDS_Attested_Monitor/Windows_IMDS_Attested_Monitor.ps1
@@ -1,0 +1,311 @@
+<# 
+Disclaimer:
+    The sample scripts are not supported under any Microsoft standard support program or service.
+    The sample scripts are provided AS IS without warranty of any kind.
+    Microsoft further disclaims all implied warranties including, without limitation, any implied warranties of merchantability
+    or of fitness for a particular purpose.
+    The entire risk arising out of the use or performance of the sample scripts and documentation remains with you.
+    In no event shall Microsoft, its authors, or anyone else involved in the creation, production,
+    or delivery of the scripts be liable for any damages whatsoever (including, without limitation,
+    damages for loss of business profits, business interruption, loss of business information, or other pecuniary loss)
+    arising out of the use of or inability to use the sample scripts or documentation,
+    even if Microsoft has been advised of the possibility of such damages.
+
+.SYNOPSIS
+    Monitors which processes access the IMDS Attested Data endpoint on an Azure VM.
+
+.DESCRIPTION
+    This script monitors network connections to the Azure Instance Metadata Service (IMDS)
+    attested data endpoint (http://169.254.169.254/metadata/attested) over a configurable
+    time window (default 30 minutes). It uses ETW network tracing to capture TCP connections
+    to 169.254.169.254 and correlates them to the owning process ID and name.
+
+    The script will:
+    - Start an ETW trace session capturing TCP connections to 169.254.169.254
+    - Poll active TCP connections every 5 seconds for the duration
+    - Log every process that connects to 169.254.169.254 with timestamp, PID, process name, and path
+    - At the end of the monitoring window, display a summary of all unique processes detected
+
+.NOTES
+    Requires administrator privileges.
+    Designed for Azure VMs running Windows Server 2016+.
+    Run via Azure Run Command or locally in an elevated PowerShell session.
+
+.PARAMETER MonitorMinutes
+    Duration in minutes to monitor. Default is 30.
+
+.EXAMPLE
+    PS> .\Windows_IMDS_Attested_Monitor.ps1
+    PS> .\Windows_IMDS_Attested_Monitor.ps1 -MonitorMinutes 60
+#>
+
+[CmdletBinding()]
+param(
+    [int]$MonitorMinutes = 30
+)
+
+# ---- Display banner ----------------------------------------------------------
+Write-Host "---------------------------------------------------------------------------------------------------------------------" -ForegroundColor Cyan
+Write-Host "IMDS Attested Data Access Monitor" -ForegroundColor Cyan
+Write-Host "This script monitors which processes access the IMDS attested data endpoint (169.254.169.254)" -ForegroundColor Cyan
+Write-Host "Monitoring window: $MonitorMinutes minutes" -ForegroundColor Cyan
+Write-Host "---------------------------------------------------------------------------------------------------------------------`n" -ForegroundColor Cyan
+
+# ---- Safety checks -----------------------------------------------------------
+function Assert-Admin {
+    $isAdmin = ([Security.Principal.WindowsPrincipal] `
+        [Security.Principal.WindowsIdentity]::GetCurrent()
+    ).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+
+    if (-not $isAdmin) {
+        Write-Host "Please run this script as Administrator." -ForegroundColor Red
+        exit 1
+    }
+}
+Assert-Admin
+
+# ---- Configuration ----------------------------------------------------------
+$imdsIP = "169.254.169.254"
+$endTime = (Get-Date).AddMinutes($MonitorMinutes)
+$pollIntervalSeconds = 5
+$detections = [System.Collections.ArrayList]::new()
+$seenConnections = @{}
+$outputPath = "$env:TEMP\IMDS_Attested_Monitor_$(Get-Date -Format 'yyyyMMdd_HHmmss').csv"
+
+# ---- ETW Trace Setup --------------------------------------------------------
+$traceName = "IMDSAttestedMonitor"
+$etlPath = "$env:TEMP\$traceName.etl"
+
+# Clean up any prior session
+netsh trace stop sessionname=$traceName 2>&1 | Out-Null
+
+Write-Host "[$(Get-Date -Format 'HH:mm:ss')] Starting network trace session..." -ForegroundColor Yellow
+
+try {
+    # Start a lightweight netsh trace filtered to IMDS IP
+    $traceResult = netsh trace start capture=yes tracefile=$etlPath `
+        sessionname=$traceName `
+        IPv4.Address=$imdsIP `
+        maxsize=50 `
+        overwrite=yes `
+        persistent=no 2>&1
+
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "[WARN] ETW trace could not start (may require full admin or trace already active)." -ForegroundColor Yellow
+        Write-Host "        Falling back to polling-only mode." -ForegroundColor Yellow
+        $traceStarted = $false
+    } else {
+        $traceStarted = $true
+        Write-Host "[$(Get-Date -Format 'HH:mm:ss')] Network trace started. ETL: $etlPath" -ForegroundColor Green
+    }
+} catch {
+    Write-Host "[WARN] ETW trace failed: $($_.Exception.Message). Using polling-only mode." -ForegroundColor Yellow
+    $traceStarted = $false
+}
+
+# ---- Auditing Setup ---------------------------------------------------------
+# Enable Windows Filtering Platform audit logging for richer process correlation
+Write-Host "[$(Get-Date -Format 'HH:mm:ss')] Enabling WFP connection auditing..." -ForegroundColor Yellow
+$auditBefore = auditpol /get /subcategory:"Filtering Platform Connection" 2>&1 | Out-String
+auditpol /set /subcategory:"Filtering Platform Connection" /success:enable /failure:enable 2>&1 | Out-Null
+
+# ---- HTTP Listener (lightweight proxy check) ---------------------------------
+# We also set up a scheduled job to periodically check event logs for IMDS connections
+Write-Host "[$(Get-Date -Format 'HH:mm:ss')] Monitoring started. Will run until $(Get-Date $endTime -Format 'HH:mm:ss') ($MonitorMinutes minutes)" -ForegroundColor Green
+Write-Host "[$(Get-Date -Format 'HH:mm:ss')] Polling every $pollIntervalSeconds seconds for connections to $imdsIP..." -ForegroundColor Green
+Write-Host ""
+
+# ---- Main Monitoring Loop ----------------------------------------------------
+$iteration = 0
+while ((Get-Date) -lt $endTime) {
+    $iteration++
+
+    # --- Method 1: Poll active TCP connections ---
+    try {
+        $connections = Get-NetTCPConnection -RemoteAddress $imdsIP -ErrorAction SilentlyContinue
+        if ($connections) {
+            foreach ($conn in $connections) {
+                $connKey = "$($conn.OwningProcess)-$($conn.LocalPort)-$($conn.RemotePort)"
+                if (-not $seenConnections.ContainsKey($connKey)) {
+                    $seenConnections[$connKey] = $true
+                    $proc = Get-Process -Id $conn.OwningProcess -ErrorAction SilentlyContinue
+                    $detection = [PSCustomObject]@{
+                        Timestamp    = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+                        Method       = "TCP Poll"
+                        PID          = $conn.OwningProcess
+                        ProcessName  = if ($proc) { $proc.ProcessName } else { "Unknown" }
+                        ProcessPath  = if ($proc) { $proc.Path } else { "N/A" }
+                        LocalPort    = $conn.LocalPort
+                        RemotePort   = $conn.RemotePort
+                        State        = $conn.State
+                        CommandLine  = ""
+                    }
+
+                    # Try to get command line via WMI
+                    try {
+                        $wmiProc = Get-WmiObject Win32_Process -Filter "ProcessId=$($conn.OwningProcess)" -ErrorAction SilentlyContinue
+                        if ($wmiProc) {
+                            $detection.CommandLine = $wmiProc.CommandLine
+                        }
+                    } catch {}
+
+                    [void]$detections.Add($detection)
+
+                    Write-Host "[$(Get-Date -Format 'HH:mm:ss')] DETECTED - PID: $($detection.PID) | Process: $($detection.ProcessName) | State: $($detection.State) | Port: $($detection.LocalPort)->$($detection.RemotePort)" -ForegroundColor Red
+                    if ($detection.ProcessPath -ne "N/A") {
+                        Write-Host "           Path: $($detection.ProcessPath)" -ForegroundColor Yellow
+                    }
+                    if ($detection.CommandLine) {
+                        Write-Host "           CmdLine: $($detection.CommandLine)" -ForegroundColor Yellow
+                    }
+                }
+            }
+        }
+    } catch {}
+
+    # --- Method 2: Check WFP audit events for IMDS connections (every 10th iteration) ---
+    if ($iteration % 10 -eq 0) {
+        try {
+            $wfpEvents = Get-WinEvent -FilterHashtable @{
+                LogName   = 'Security'
+                Id        = 5156  # WFP permitted connection
+                StartTime = (Get-Date).AddSeconds(-($pollIntervalSeconds * 10))
+            } -MaxEvents 50 -ErrorAction SilentlyContinue
+
+            if ($wfpEvents) {
+                $imdsEvents = $wfpEvents | Where-Object {
+                    $_.Message -match '169\.254\.169\.254'
+                }
+                foreach ($evt in $imdsEvents) {
+                    # Extract PID from event
+                    $evtXml = [xml]$evt.ToXml()
+                    $evtPid = ($evtXml.Event.EventData.Data | Where-Object { $_.Name -eq 'ProcessId' }).'#text'
+                    $evtApp = ($evtXml.Event.EventData.Data | Where-Object { $_.Name -eq 'Application' }).'#text'
+
+                    $evtKey = "WFP-$evtPid-$($evt.TimeCreated.ToString('HHmmss'))"
+                    if (-not $seenConnections.ContainsKey($evtKey)) {
+                        $seenConnections[$evtKey] = $true
+                        $proc = Get-Process -Id $evtPid -ErrorAction SilentlyContinue
+                        $detection = [PSCustomObject]@{
+                            Timestamp    = $evt.TimeCreated.ToString('yyyy-MM-dd HH:mm:ss')
+                            Method       = "WFP Audit"
+                            PID          = $evtPid
+                            ProcessName  = if ($proc) { $proc.ProcessName } else { [System.IO.Path]::GetFileNameWithoutExtension($evtApp) }
+                            ProcessPath  = if ($evtApp) { $evtApp } else { "N/A" }
+                            LocalPort    = ""
+                            RemotePort   = ""
+                            State        = "Permitted"
+                            CommandLine  = ""
+                        }
+                        [void]$detections.Add($detection)
+
+                        Write-Host "[$(Get-Date -Format 'HH:mm:ss')] DETECTED (WFP) - PID: $evtPid | Process: $($detection.ProcessName) | Path: $evtApp" -ForegroundColor Red
+                    }
+                }
+            }
+        } catch {}
+    }
+
+    # --- Method 3: Check for HTTP.sys/WinHTTP ETW events (every 30th iteration) ---
+    if ($iteration % 30 -eq 0) {
+        try {
+            $httpEvents = Get-WinEvent -FilterHashtable @{
+                LogName   = 'Microsoft-Windows-WebIO/Diagnostic'
+                StartTime = (Get-Date).AddSeconds(-($pollIntervalSeconds * 30))
+            } -MaxEvents 20 -ErrorAction SilentlyContinue
+
+            if ($httpEvents) {
+                $attestedEvents = $httpEvents | Where-Object { $_.Message -match 'attested' -or $_.Message -match '169\.254\.169\.254' }
+                foreach ($evt in $attestedEvents) {
+                    $evtKey = "HTTP-$($evt.ProcessId)-$($evt.TimeCreated.ToString('HHmmss'))"
+                    if (-not $seenConnections.ContainsKey($evtKey)) {
+                        $seenConnections[$evtKey] = $true
+                        $proc = Get-Process -Id $evt.ProcessId -ErrorAction SilentlyContinue
+                        $detection = [PSCustomObject]@{
+                            Timestamp    = $evt.TimeCreated.ToString('yyyy-MM-dd HH:mm:ss')
+                            Method       = "HTTP ETW"
+                            PID          = $evt.ProcessId
+                            ProcessName  = if ($proc) { $proc.ProcessName } else { "Unknown" }
+                            ProcessPath  = if ($proc) { $proc.Path } else { "N/A" }
+                            LocalPort    = ""
+                            RemotePort   = "80"
+                            State        = "HTTP Request"
+                            CommandLine  = ""
+                        }
+                        [void]$detections.Add($detection)
+                        Write-Host "[$(Get-Date -Format 'HH:mm:ss')] DETECTED (HTTP) - PID: $($evt.ProcessId) | Process: $($detection.ProcessName)" -ForegroundColor Red
+                    }
+                }
+            }
+        } catch {}
+    }
+
+    # Progress indicator every 60 seconds
+    if ($iteration % (60 / $pollIntervalSeconds) -eq 0) {
+        $remaining = [math]::Round(($endTime - (Get-Date)).TotalMinutes, 1)
+        Write-Host "[$(Get-Date -Format 'HH:mm:ss')] Monitoring... $remaining minutes remaining | $($detections.Count) detection(s) so far" -ForegroundColor Gray
+    }
+
+    Start-Sleep -Seconds $pollIntervalSeconds
+}
+
+# ---- Cleanup -----------------------------------------------------------------
+Write-Host "`n[$(Get-Date -Format 'HH:mm:ss')] Monitoring window complete. Cleaning up..." -ForegroundColor Yellow
+
+# Stop ETW trace
+if ($traceStarted) {
+    netsh trace stop sessionname=$traceName 2>&1 | Out-Null
+    Write-Host "[$(Get-Date -Format 'HH:mm:ss')] Network trace stopped. ETL saved: $etlPath" -ForegroundColor Green
+}
+
+# Restore audit policy
+auditpol /set /subcategory:"Filtering Platform Connection" /success:disable /failure:disable 2>&1 | Out-Null
+Write-Host "[$(Get-Date -Format 'HH:mm:ss')] WFP audit policy restored." -ForegroundColor Green
+
+# ---- Results -----------------------------------------------------------------
+Write-Host "`n=====================================================================================================================" -ForegroundColor Cyan
+Write-Host " RESULTS - IMDS Attested Data Access Monitor" -ForegroundColor Cyan
+Write-Host "=====================================================================================================================" -ForegroundColor Cyan
+Write-Host " Monitoring Duration : $MonitorMinutes minutes" -ForegroundColor White
+Write-Host " Total Detections    : $($detections.Count)" -ForegroundColor White
+Write-Host "=====================================================================================================================" -ForegroundColor Cyan
+
+if ($detections.Count -gt 0) {
+    # Export full results
+    $detections | Export-Csv $outputPath -NoTypeInformation
+    Write-Host "`nFull results exported to: $outputPath`n" -ForegroundColor Green
+
+    # Summary by unique process
+    Write-Host "Unique Processes Detected Accessing IMDS (169.254.169.254):" -ForegroundColor Yellow
+    Write-Host "---------------------------------------------------------" -ForegroundColor Yellow
+
+    $summary = $detections | Group-Object ProcessName | Sort-Object Count -Descending
+    foreach ($group in $summary) {
+        $first = $group.Group[0]
+        Write-Host "`n  Process     : $($group.Name)" -ForegroundColor White
+        Write-Host "  PID(s)      : $(($group.Group | Select-Object -ExpandProperty PID -Unique) -join ', ')" -ForegroundColor White
+        Write-Host "  Hit Count   : $($group.Count)" -ForegroundColor White
+        Write-Host "  Path        : $($first.ProcessPath)" -ForegroundColor White
+        if ($first.CommandLine) {
+            Write-Host "  Command Line: $($first.CommandLine)" -ForegroundColor White
+        }
+        Write-Host "  First Seen  : $(($group.Group | Select-Object -First 1).Timestamp)" -ForegroundColor White
+        Write-Host "  Last Seen   : $(($group.Group | Select-Object -Last 1).Timestamp)" -ForegroundColor White
+        Write-Host "  Method(s)   : $(($group.Group | Select-Object -ExpandProperty Method -Unique) -join ', ')" -ForegroundColor White
+    }
+
+    Write-Host ""
+
+    # Display table
+    $detections | Format-Table Timestamp, Method, PID, ProcessName, State, ProcessPath -AutoSize
+} else {
+    Write-Host "`nNo processes were detected accessing IMDS (169.254.169.254) during the $MonitorMinutes minute monitoring window." -ForegroundColor Green
+    Write-Host "This indicates no application accessed the attested data endpoint during this period." -ForegroundColor Green
+}
+
+if ($traceStarted) {
+    Write-Host "`nNote: A network trace ETL file was captured at: $etlPath" -ForegroundColor Cyan
+    Write-Host "You can analyze it with: netsh trace convert input=$etlPath output=$($etlPath.Replace('.etl','.txt'))" -ForegroundColor Cyan
+}
+
+Write-Host "`nScript completed successfully." -ForegroundColor Cyan

--- a/RunCommand/Windows/Windows_IPv6_RDP_Path_Check/README.md
+++ b/RunCommand/Windows/Windows_IPv6_RDP_Path_Check/README.md
@@ -1,0 +1,82 @@
+# Windows IPv6 RDP Path Check
+
+> **Tool ID:** RC-025 · **Bucket:** Networking/RDP · **Phase:** 2 (Deep diagnostic)
+
+## What It Does
+
+Validates IPv6 configuration and its impact on RDP connectivity. Checks IPv6 enablement on the primary NIC, address assignment, RDP listener binding, firewall rules for IPv6 RDP, dual-stack DNS resolution, and presence of transition technologies (Teredo/ISATAP). Important for VMs where RDP fails due to IPv6 misconfigurations or when IPv6 takes priority over IPv4.
+
+| Check area | What is validated |
+|---|---|
+| IPv6 enabled | IPv6 protocol active on primary NIC |
+| IPv6 addresses | Global IPv6 addresses assigned |
+| RDP listener | RDP listener NIC binding (0 = all NICs) |
+| RDP firewall | Firewall rules allow RDP over IPv6 |
+| Dual-stack DNS | AAAA record resolution works |
+| Transition tech | Teredo/ISATAP tunneling status |
+
+## Run Command Constraints Met
+
+- ✅ PowerShell 5.1 only
+- ✅ No Az module required
+- ✅ No internet access needed
+- ✅ Output < 4 KB
+- ✅ No interactive prompts
+- ✅ Read-only (diagnostic only)
+
+## How to Run
+
+### Azure Run Command (recommended)
+Navigate to VM → Operations → Run Command → RunPowerShellScript → paste script.
+
+### Azure CLI
+```bash
+az vm run-command invoke -g <rg> -n <vm> --command-id RunPowerShellScript \
+  --scripts @Windows_IPv6_RDP_Path_Check/Windows_IPv6_RDP_Path_Check.ps1
+```
+
+### Mock test
+```powershell
+.\Windows_IPv6_RDP_Path_Check.ps1 -MockConfig .\mock_config_sample.json -MockProfile degraded
+```
+
+## Sample Output (Issues Detected)
+
+```
+=== Windows IPv6 RDP Path Check ===
+Check                                        Status
+-------------------------------------------- ------
+IPv6 enabled on primary NIC                  OK
+IPv6 addresses assigned                      OK
+RDP listener address binding                 WARN
+RDP firewall rule for IPv6                   FAIL
+Dual-stack DNS resolution works              WARN
+Teredo/ISATAP transition disabled            WARN
+-- Decision --
+Likely cause severity                        FAIL   Hard configuration/service break
+Next action                                  OK     Follow README interpretation and remediate FAIL rows first
+-- More Info --
+Remediation references available             OK     See paired README Learn References
+
+=== RESULT: 2 OK / 1 FAIL / 3 WARN ===
+```
+
+## Interpretation Guide
+
+| FAIL/WARN condition | Likely cause | Quick fix | Learn link |
+|---|---|---|---|
+| **IPv6 enabled on primary NIC** WARN | IPv6 is disabled — some Azure services use IPv6 internally. Disabling can cause subtle issues. | Re-enable: `Enable-NetAdapterBinding -Name "Ethernet" -ComponentID ms_tcpip6`. Note: Microsoft does not support disabling IPv6 on Azure VMs. | [Troubleshoot RDP connection](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-rdp-connection) |
+| **RDP listener address binding** WARN | RDP listener (TermService) bound to a specific NIC adapter instead of all (LanAdapter=0). May miss connections arriving on other NICs. | Set to all NICs: `Set-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp" -Name LanAdapter -Value 0` | [RDP listener configuration](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-rdp-general-error) |
+| **RDP firewall rule for IPv6** FAIL | Windows Firewall blocks inbound RDP (TCP 3389) on IPv6. Azure may route RDP internally via IPv6. | `Enable-NetFirewallRule -DisplayName "Remote Desktop - User Mode (TCP-In)"` — ensure rule covers both IPv4 and IPv6 profiles | [Troubleshoot RDP firewall rules](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-rdp-nsg-problem) |
+| **Dual-stack DNS resolution works** WARN | No AAAA records resolved. May be normal if environment is IPv4-only, but dual-stack improves resilience. | Verify DNS servers support IPv6: `Resolve-DnsName -Name <hostname> -Type AAAA`. Check if DNS forwarders return AAAA records. | [Azure DNS overview](https://learn.microsoft.com/azure/dns/dns-overview) |
+| **Teredo/ISATAP transition disabled** WARN | Teredo or ISATAP tunnel adapters are active. These transition technologies are generally unnecessary on Azure VMs and can cause routing confusion. | Disable: `netsh interface teredo set state disabled` and `netsh interface isatap set state disabled` | [IPv6 transition technologies](https://learn.microsoft.com/troubleshoot/windows-server/networking/configure-ipv6-in-windows) |
+| **IPv6 addresses assigned** WARN | No global IPv6 addresses. If dual-stack is expected, check Azure VNet IPv6 configuration. | Verify VNet has IPv6 address space: Azure Portal → VNet → Address space. Check NIC for IPv6 config. | [IPv6 for Azure VNet](https://learn.microsoft.com/azure/virtual-network/ip-services/ipv6-overview) |
+
+## Related Articles
+
+| Article | Link |
+|---|---|
+| Troubleshoot RDP connections to Azure VM | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-rdp-connection) |
+| Troubleshoot RDP general error | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-rdp-general-error) |
+| Configure IPv6 in Windows | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/windows-server/networking/configure-ipv6-in-windows) |
+| IPv6 for Azure Virtual Network | [learn.microsoft.com](https://learn.microsoft.com/azure/virtual-network/ip-services/ipv6-overview) |

--- a/RunCommand/Windows/Windows_IPv6_RDP_Path_Check/Windows_IPv6_RDP_Path_Check.ps1
+++ b/RunCommand/Windows/Windows_IPv6_RDP_Path_Check/Windows_IPv6_RDP_Path_Check.ps1
@@ -1,0 +1,72 @@
+#Requires -Version 5.1
+[CmdletBinding()]
+param(
+  [string]$MockConfig,
+  [ValidateSet('healthy','degraded','broken')]
+  [string]$MockProfile = 'degraded'
+)
+$ErrorActionPreference='Continue'
+function Pad($s,$n){$s="$s";if($s.Length -ge $n){$s.Substring(0,$n)}else{$s.PadRight($n)}}
+$W=44
+$rows=New-Object System.Collections.Generic.List[object]
+function Add-Row($c,$s,$d=''){ $rows.Add([PSCustomObject]@{Check=$c;Status=$s;Detail=$d}); Write-Output ('{0} {1}' -f (Pad $c $W), $s) }
+
+Write-Output '=== Windows IPv6 RDP Path Check ==='
+Write-Output ('{0} {1}' -f (Pad 'Check' $W), 'Status')
+Write-Output (('-' * $W) + ' ------')
+
+$usedMock = $false
+if($MockConfig -and (Test-Path $MockConfig)){
+  $mock = Get-Content $MockConfig -Raw | ConvertFrom-Json
+  if($mock.profiles -and $mock.profiles.$MockProfile){
+    $usedMock = $true
+    foreach($i in $mock.profiles.$MockProfile){ Add-Row $i.name $i.status $i.detail }
+  }
+}
+
+if(-not $usedMock){
+  # Probe: IPv6 enabled on primary NIC
+  $nic = Get-NetAdapterBinding -ComponentId ms_tcpip6 -ErrorAction SilentlyContinue | Select-Object -First 1; $v6 = if($nic){$nic.Enabled}else{$null}
+  $_s = if($v6 -eq $true){'OK'}elseif($v6 -eq $false){'WARN'}else{'FAIL'}
+  Add-Row 'IPv6 enabled on primary NIC' $_s ("IPv6Enabled=$v6")
+
+  # Probe: IPv6 addresses assigned
+  $v6addr = Get-NetIPAddress -AddressFamily IPv6 -ErrorAction SilentlyContinue | Where-Object { $_.IPAddress -notlike "fe80*" }; $v6Count = @($v6addr).Count
+  $_s = if($v6Count -ge 0){'OK'}elseif($false){'WARN'}else{'FAIL'}
+  Add-Row 'IPv6 addresses assigned' $_s ("GlobalIPv6=$v6Count (informational)")
+
+  # Probe: RDP listener address binding
+  $rdpBind = Get-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp" -Name "LanAdapter" -ErrorAction SilentlyContinue; $lanAdp = if($rdpBind){$rdpBind.LanAdapter}else{-1}
+  $_s = if($lanAdp -eq 0){'OK'}elseif($lanAdp -ne 0 -and $lanAdp -ne -1){'WARN'}else{'FAIL'}
+  Add-Row 'RDP listener address binding' $_s ("LanAdapter=$lanAdp (0=all NICs)")
+
+  # Probe: RDP firewall rule for IPv6
+  $fw6 = Get-NetFirewallRule -DisplayName "*Remote Desktop*" -ErrorAction SilentlyContinue | Get-NetFirewallAddressFilter -ErrorAction SilentlyContinue | Where-Object { $_.RemoteAddress -eq "Any" }; $fwOk = @($fw6).Count -gt 0
+  $_s = if($fwOk){'OK'}elseif(!$fwOk){'WARN'}else{'FAIL'}
+  Add-Row 'RDP firewall rule for IPv6' $_s ("RDPv6FW=$fwOk")
+
+  # Probe: Dual-stack DNS resolution works
+  $v6dns = Resolve-DnsName -Name "microsoft.com" -Type AAAA -ErrorAction SilentlyContinue; $v6dnsOk = @($v6dns).Count -gt 0
+  $_s = if($v6dnsOk){'OK'}elseif(!$v6dnsOk){'WARN'}else{'FAIL'}
+  Add-Row 'Dual-stack DNS resolution works' $_s ("AAAARecords=$(@($v6dns).Count)")
+
+  # Probe: Teredo/ISATAP transition disabled
+  $teredo = Get-NetTeredoConfiguration -ErrorAction SilentlyContinue; $tDisabled = if($teredo){$teredo.Type -eq "Disabled"}else{$true}
+  $_s = if($tDisabled){'OK'}elseif(!$tDisabled){'WARN'}else{'FAIL'}
+  Add-Row 'Teredo/ISATAP transition disabled' $_s ("Teredo=$(if($teredo){$teredo.Type}else{'N/A'})")
+
+}
+
+$fail=@($rows|Where-Object Status -eq 'FAIL').Count
+$warn=@($rows|Where-Object Status -eq 'WARN').Count
+Write-Output '-- Decision --'
+Add-Row 'Likely cause severity' $(if($fail -gt 0){'FAIL'}elseif($warn -gt 0){'WARN'}else{'OK'}) $(if($fail -gt 0){'Hard configuration/service break'}elseif($warn -gt 0){'Configuration drift or transient condition'}else{'No blocking signals'})
+Add-Row 'Next action' 'OK' $(if($fail -gt 0){'Follow README interpretation and remediate FAIL rows first'}elseif($warn -gt 0){'Review WARN rows and re-run after targeted fix'}else{'No immediate action'})
+Write-Output '-- More Info --'
+Add-Row 'Remediation references available' 'OK' 'See paired README Learn References'
+
+$ok=@($rows|Where-Object Status -eq 'OK').Count
+Write-Output ''
+Write-Output "=== RESULT: $ok OK / $fail FAIL / $warn WARN ==="
+$rows
+

--- a/RunCommand/Windows/Windows_IPv6_RDP_Path_Check/mock_config_sample.json
+++ b/RunCommand/Windows/Windows_IPv6_RDP_Path_Check/mock_config_sample.json
@@ -1,0 +1,100 @@
+{
+  "profiles": {
+    "healthy": [
+      {
+        "name": "IPv6 enabled on primary NIC",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "IPv6 addresses assigned",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "RDP listener address binding",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "RDP firewall rule for IPv6",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Dual-stack DNS resolution works",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Teredo/ISATAP transition disabled",
+        "status": "OK",
+        "detail": "Healthy profile"
+      }
+    ],
+    "broken": [
+      {
+        "name": "IPv6 enabled on primary NIC",
+        "status": "FAIL",
+        "detail": "Critical failure detected"
+      },
+      {
+        "name": "IPv6 addresses assigned",
+        "status": "FAIL",
+        "detail": "Critical failure detected"
+      },
+      {
+        "name": "RDP listener address binding",
+        "status": "WARN",
+        "detail": "Degraded state"
+      },
+      {
+        "name": "RDP firewall rule for IPv6",
+        "status": "OK",
+        "detail": "Operational"
+      },
+      {
+        "name": "Dual-stack DNS resolution works",
+        "status": "WARN",
+        "detail": "Degraded state"
+      },
+      {
+        "name": "Teredo/ISATAP transition disabled",
+        "status": "OK",
+        "detail": "Operational"
+      }
+    ],
+    "degraded": [
+      {
+        "name": "IPv6 enabled on primary NIC",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "IPv6 addresses assigned",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "RDP listener address binding",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "RDP firewall rule for IPv6",
+        "status": "WARN",
+        "detail": "Configuration drift detected"
+      },
+      {
+        "name": "Dual-stack DNS resolution works",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Teredo/ISATAP transition disabled",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      }
+    ]
+  }
+}

--- a/RunCommand/Windows/Windows_LSA_SSP_Baseline_Check/README.md
+++ b/RunCommand/Windows/Windows_LSA_SSP_Baseline_Check/README.md
@@ -1,0 +1,78 @@
+# Windows LSA SSP Baseline Check
+
+> **Tool ID:** RC-027 · **Bucket:** Security · **Phase:** 2 (Deep diagnostic)
+
+## What It Does
+
+Audits the Local Security Authority (LSA) configuration for security hardening. Checks RunAsPPL protection, Credential Guard status, registered Security Support Providers (SSPs), and LSASS audit mode. Detects unauthorized SSP injection — a common credential theft technique — and validates that modern protections are enabled.
+
+| Check area | What is validated |
+|---|---|
+| RunAsPPL | LSA runs as Protected Process Light |
+| Credential Guard | VBS Credential Guard active |
+| Security packages | Registered SSPs match expected baseline |
+| Unauthorized SSPs | No unknown SSPs loaded |
+| LSASS audit | LSASS audit mode level |
+
+## Run Command Constraints Met
+
+- ✅ PowerShell 5.1 only
+- ✅ No Az module required
+- ✅ No internet access needed
+- ✅ Output < 4 KB
+- ✅ No interactive prompts
+- ✅ Read-only (diagnostic only)
+
+## How to Run
+
+### Azure Run Command (recommended)
+Navigate to VM → Operations → Run Command → RunPowerShellScript → paste script.
+
+### Azure CLI
+```bash
+az vm run-command invoke -g <rg> -n <vm> --command-id RunPowerShellScript \
+  --scripts @Windows_LSA_SSP_Baseline_Check/Windows_LSA_SSP_Baseline_Check.ps1
+```
+
+### Mock test
+```powershell
+.\Windows_LSA_SSP_Baseline_Check.ps1 -MockConfig .\mock_config_sample.json -MockProfile broken
+```
+
+## Sample Output (Issues Detected)
+
+```
+=== Windows LSA SSP Baseline Check ===
+Check                                        Status
+-------------------------------------------- ------
+LSA RunAsPPL protection                      FAIL
+Credential Guard status                      WARN
+Security packages registered                 OK
+No unauthorized SSPs loaded                  FAIL
+LSASS audit mode                             WARN
+-- Decision --
+Likely cause severity                        FAIL   Hard configuration/service break
+Next action                                  OK     Follow README interpretation and remediate FAIL rows first
+-- More Info --
+Remediation references available             OK     See paired README Learn References
+
+=== RESULT: 1 OK / 2 FAIL / 2 WARN ===
+```
+
+## Interpretation Guide
+
+| FAIL/WARN condition | Likely cause | Quick fix | Learn link |
+|---|---|---|---|
+| **LSA RunAsPPL protection** FAIL | LSA is not running as a Protected Process Light. Credential extraction tools (Mimikatz) can read LSASS memory. | `Set-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Control\Lsa" -Name RunAsPPL -Value 1 -Type DWord` then reboot | [Configure LSA protection](https://learn.microsoft.com/windows-server/security/credentials-protection-and-management/configuring-additional-lsa-protection) |
+| **Credential Guard status** WARN | VBS Credential Guard is not active. NTLM hashes and Kerberos tickets are stored in plain LSASS memory. | Enable via GPO: Computer Config → Admin Templates → System → Device Guard → Turn On Virtualization Based Security. Requires UEFI, Secure Boot, and Gen2 VM. | [Credential Guard overview](https://learn.microsoft.com/windows/security/identity-protection/credential-guard/) |
+| **No unauthorized SSPs loaded** FAIL | Unknown Security Support Providers detected in `HKLM\SYSTEM\CurrentControlSet\Control\Lsa\Security Packages`. May indicate credential theft malware. | Review `Security Packages` reg value. Known-good: `kerberos`, `msv1_0`, `schannel`, `wdigest`, `tspkg`, `pku2u`, `cloudAP`. Remove unknown entries. | [SSP/AP overview](https://learn.microsoft.com/windows-server/security/windows-authentication/security-support-provider-interface-architecture) |
+| **LSASS audit mode** WARN | LSASS audit logging is disabled. Cannot detect credential access attempts. | `Set-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\LSASS.exe" -Name AuditLevel -Value 8 -Type DWord` | [Audit LSASS access](https://learn.microsoft.com/windows-server/security/credentials-protection-and-management/configuring-additional-lsa-protection#auditing-mode) |
+| **Security packages registered** WARN | Non-standard packages present. May be legitimate (third-party SSO) or suspicious. Cross-reference with installed software. | `reg query "HKLM\SYSTEM\CurrentControlSet\Control\Lsa" /v "Security Packages"` — validate each entry against known-good list | [SSP/AP architecture](https://learn.microsoft.com/windows-server/security/windows-authentication/security-support-provider-interface-architecture) |
+
+## Related Articles
+
+| Article | Link |
+|---|---|
+| Configure LSA additional protection | [learn.microsoft.com](https://learn.microsoft.com/windows-server/security/credentials-protection-and-management/configuring-additional-lsa-protection) |
+| Credential Guard overview | [learn.microsoft.com](https://learn.microsoft.com/windows/security/identity-protection/credential-guard/) |
+| Troubleshoot RDP access denied | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-rdp-access-denied) |

--- a/RunCommand/Windows/Windows_LSA_SSP_Baseline_Check/Windows_LSA_SSP_Baseline_Check.ps1
+++ b/RunCommand/Windows/Windows_LSA_SSP_Baseline_Check/Windows_LSA_SSP_Baseline_Check.ps1
@@ -1,0 +1,67 @@
+#Requires -Version 5.1
+[CmdletBinding()]
+param(
+  [string]$MockConfig,
+  [ValidateSet('healthy','degraded','broken')]
+  [string]$MockProfile = 'degraded'
+)
+$ErrorActionPreference='Continue'
+function Pad($s,$n){$s="$s";if($s.Length -ge $n){$s.Substring(0,$n)}else{$s.PadRight($n)}}
+$W=44
+$rows=New-Object System.Collections.Generic.List[object]
+function Add-Row($c,$s,$d=''){ $rows.Add([PSCustomObject]@{Check=$c;Status=$s;Detail=$d}); Write-Output ('{0} {1}' -f (Pad $c $W), $s) }
+
+Write-Output '=== Windows LSA SSP Baseline Check ==='
+Write-Output ('{0} {1}' -f (Pad 'Check' $W), 'Status')
+Write-Output (('-' * $W) + ' ------')
+
+$usedMock = $false
+if($MockConfig -and (Test-Path $MockConfig)){
+  $mock = Get-Content $MockConfig -Raw | ConvertFrom-Json
+  if($mock.profiles -and $mock.profiles.$MockProfile){
+    $usedMock = $true
+    foreach($i in $mock.profiles.$MockProfile){ Add-Row $i.name $i.status $i.detail }
+  }
+}
+
+if(-not $usedMock){
+  # Probe: LSA RunAsPPL protection
+  $ppl = Get-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Control\Lsa" -Name "RunAsPPL" -ErrorAction SilentlyContinue; $pplVal = if($ppl){$ppl.RunAsPPL}else{0}
+  $_s = if($pplVal -eq 1){'OK'}elseif($pplVal -ne 1){'WARN'}else{'FAIL'}
+  Add-Row 'LSA RunAsPPL protection' $_s ("RunAsPPL=$pplVal")
+
+  # Probe: Credential Guard status
+  $cg = Get-CimInstance -Namespace root/Microsoft/Windows/DeviceGuard -ClassName Win32_DeviceGuard -ErrorAction SilentlyContinue; $cgOn = if($cg){ $cg.SecurityServicesRunning -contains 1 }else{ $false }
+  $_s = if($cgOn){'OK'}elseif(!$cgOn){'WARN'}else{'FAIL'}
+  Add-Row 'Credential Guard status' $_s ("CredGuard=$cgOn")
+
+  # Probe: Security packages registered
+  $sp = (Get-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Control\Lsa" -Name "Security Packages" -ErrorAction SilentlyContinue)."Security Packages"; $spCount = @($sp).Count
+  $_s = if($spCount -ge 1){'OK'}elseif($spCount -eq 0){'WARN'}else{'FAIL'}
+  Add-Row 'Security packages registered' $_s ("Packages=$(@($sp) -join `",`")")
+
+  # Probe: No unauthorized SSPs loaded
+  $ssp = (Get-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Control\Lsa\OSConfig" -Name "Security Packages" -ErrorAction SilentlyContinue)."Security Packages"; $knownSSPs = @("","kerberos","msv1_0","schannel","wdigest","tspkg","pku2u","cloudAP"); $unk = @($ssp | Where-Object { $_ -and $_ -notin $knownSSPs }).Count
+  $_s = if($unk -gt 0){'FAIL'}elseif($unk -eq 0){'OK'}else{'WARN'}
+  Add-Row 'No unauthorized SSPs loaded' $_s ("UnknownSSPs=$unk")
+
+  # Probe: LSASS audit mode
+  $audit = Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\LSASS.exe" -Name "AuditLevel" -ErrorAction SilentlyContinue; $auditVal = if($audit){$audit.AuditLevel}else{0}
+  $_s = if($auditVal -ge 8){'OK'}elseif($auditVal -lt 8){'WARN'}else{'FAIL'}
+  Add-Row 'LSASS audit mode' $_s ("AuditLevel=$auditVal")
+
+}
+
+$fail=@($rows|Where-Object Status -eq 'FAIL').Count
+$warn=@($rows|Where-Object Status -eq 'WARN').Count
+Write-Output '-- Decision --'
+Add-Row 'Likely cause severity' $(if($fail -gt 0){'FAIL'}elseif($warn -gt 0){'WARN'}else{'OK'}) $(if($fail -gt 0){'Hard configuration/service break'}elseif($warn -gt 0){'Configuration drift or transient condition'}else{'No blocking signals'})
+Add-Row 'Next action' 'OK' $(if($fail -gt 0){'Follow README interpretation and remediate FAIL rows first'}elseif($warn -gt 0){'Review WARN rows and re-run after targeted fix'}else{'No immediate action'})
+Write-Output '-- More Info --'
+Add-Row 'Remediation references available' 'OK' 'See paired README Learn References'
+
+$ok=@($rows|Where-Object Status -eq 'OK').Count
+Write-Output ''
+Write-Output "=== RESULT: $ok OK / $fail FAIL / $warn WARN ==="
+$rows
+

--- a/RunCommand/Windows/Windows_LSA_SSP_Baseline_Check/mock_config_sample.json
+++ b/RunCommand/Windows/Windows_LSA_SSP_Baseline_Check/mock_config_sample.json
@@ -1,0 +1,85 @@
+{
+  "profiles": {
+    "healthy": [
+      {
+        "name": "LSA RunAsPPL protection",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Credential Guard status",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Security packages registered",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "No unauthorized SSPs loaded",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "LSASS audit mode",
+        "status": "OK",
+        "detail": "Healthy profile"
+      }
+    ],
+    "broken": [
+      {
+        "name": "LSA RunAsPPL protection",
+        "status": "FAIL",
+        "detail": "Critical failure detected"
+      },
+      {
+        "name": "Credential Guard status",
+        "status": "FAIL",
+        "detail": "Critical failure detected"
+      },
+      {
+        "name": "Security packages registered",
+        "status": "WARN",
+        "detail": "Degraded state"
+      },
+      {
+        "name": "No unauthorized SSPs loaded",
+        "status": "OK",
+        "detail": "Operational"
+      },
+      {
+        "name": "LSASS audit mode",
+        "status": "WARN",
+        "detail": "Degraded state"
+      }
+    ],
+    "degraded": [
+      {
+        "name": "LSA RunAsPPL protection",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Credential Guard status",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Security packages registered",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "No unauthorized SSPs loaded",
+        "status": "WARN",
+        "detail": "Configuration drift detected"
+      },
+      {
+        "name": "LSASS audit mode",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      }
+    ]
+  }
+}

--- a/RunCommand/Windows/Windows_NIC_AdvancedProperties_Baseline/README.md
+++ b/RunCommand/Windows/Windows_NIC_AdvancedProperties_Baseline/README.md
@@ -1,0 +1,81 @@
+# Windows NIC Advanced Properties Baseline
+
+> **Tool ID:** RC-032 · **Bucket:** Networking · **Phase:** 2 (Deep diagnostic)
+
+## What It Does
+
+Inspects NIC advanced driver properties that impact network performance on Azure VMs. Validates Receive Side Scaling (RSS), checksum offload, Large Send Offload v2 (LSOv2), VMQ settings, jumbo frames, and speed/duplex configuration. Important for diagnosing throughput issues, packet loss, or netvsc driver problems in Azure VMs.
+
+| Check area | What is validated |
+|---|---|
+| RSS | Receive Side Scaling enabled for multi-core packet processing |
+| Checksum offload | Hardware checksum offloading active |
+| LSOv2 | Large Send Offload v2 for TCP throughput |
+| VMQ | Virtual Machine Queue status (informational) |
+| Jumbo frames | Jumbo frame not set (Azure default — 1500 MTU) |
+| Speed/Duplex | Auto-negotiation for speed and duplex |
+
+## Run Command Constraints Met
+
+- ✅ PowerShell 5.1 only
+- ✅ No Az module required
+- ✅ No internet access needed
+- ✅ Output < 4 KB
+- ✅ No interactive prompts
+- ✅ Read-only (diagnostic only)
+
+## How to Run
+
+### Azure Run Command (recommended)
+Navigate to VM → Operations → Run Command → RunPowerShellScript → paste script.
+
+### Azure CLI
+```bash
+az vm run-command invoke -g <rg> -n <vm> --command-id RunPowerShellScript \
+  --scripts @Windows_NIC_AdvancedProperties_Baseline/Windows_NIC_AdvancedProperties_Baseline.ps1
+```
+
+### Mock test
+```powershell
+.\Windows_NIC_AdvancedProperties_Baseline.ps1 -MockConfig .\mock_config_sample.json -MockProfile degraded
+```
+
+## Sample Output (Issues Detected)
+
+```
+=== Windows NIC Advanced Properties Baseline ===
+Check                                        Status
+-------------------------------------------- ------
+RSS (Receive Side Scaling) enabled           FAIL
+Checksum offload enabled                     WARN
+Large Send Offload v2 (LSOv2)               WARN
+VMQ (Virtual Machine Queue)                  OK
+Jumbo Frame not set (Azure default)          FAIL
+Speed and duplex auto-negotiation            OK
+-- Decision --
+Likely cause severity                        FAIL   Hard configuration/service break
+Next action                                  OK     Follow README interpretation and remediate FAIL rows first
+-- More Info --
+Remediation references available             OK     See paired README Learn References
+
+=== RESULT: 2 OK / 2 FAIL / 2 WARN ===
+```
+
+## Interpretation Guide
+
+| FAIL/WARN condition | Likely cause | Quick fix | Learn link |
+|---|---|---|---|
+| **RSS (Receive Side Scaling) enabled** FAIL | RSS disabled — all network interrupts go to a single CPU core, causing packet loss under load. Azure netvsc driver supports RSS. | `Enable-NetAdapterRss -Name "Ethernet"` or `Set-NetAdapterRss -Name "Ethernet" -Enabled $true` | [Troubleshoot netvsc driver issues](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-rdp-driver-netvsc) |
+| **Checksum offload enabled** WARN | Hardware checksum offload disabled. CPU handles all checksum calculations, increasing overhead and reducing throughput. | `Set-NetAdapterChecksumOffload -Name "Ethernet" -TcpIPv4 RxTxEnabled -UdpIPv4 RxTxEnabled` | [Azure VM networking best practices](https://learn.microsoft.com/azure/virtual-network/accelerated-networking-overview) |
+| **Large Send Offload v2 (LSOv2)** WARN | LSO disabled. Large TCP sends are segmented by CPU instead of NIC, reducing throughput on large transfers. | `Enable-NetAdapterLso -Name "Ethernet"` | [Accelerated Networking overview](https://learn.microsoft.com/azure/virtual-network/accelerated-networking-overview) |
+| **Jumbo Frame not set (Azure default)** FAIL | Jumbo frames enabled (MTU > 1500). Azure virtual network MTU is 1500; jumbo frames cause fragmentation and packet drops. | `Set-NetAdapterAdvancedProperty -Name "Ethernet" -RegistryKeyword "*JumboPacket" -RegistryValue "1514"` (1514 = disabled/standard) | [Azure VM MTU and fragmentation](https://learn.microsoft.com/azure/virtual-network/virtual-network-tcpip-performance-tuning) |
+| **VMQ (Virtual Machine Queue)** WARN | VMQ disabled or not supported. Informational on most Azure VM sizes — Hyper-V handles RSS instead. | Usually no action needed on Azure VMs. If using Accelerated Networking, VMQ is managed by the hardware. | [Accelerated Networking](https://learn.microsoft.com/azure/virtual-network/accelerated-networking-overview) |
+| **Speed and duplex auto-negotiation** WARN | Forced speed/duplex setting. Azure synthetic NICs should use auto-negotiation. Manual settings can cause connectivity issues. | `Set-NetAdapterAdvancedProperty -Name "Ethernet" -RegistryKeyword "*SpeedDuplex" -RegistryValue "0"` (0 = auto) | [Troubleshoot netvsc driver](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-rdp-driver-netvsc) |
+
+## Related Articles
+
+| Article | Link |
+|---|---|
+| Troubleshoot netvsc driver issues | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-rdp-driver-netvsc) |
+| Accelerated Networking overview | [learn.microsoft.com](https://learn.microsoft.com/azure/virtual-network/accelerated-networking-overview) |
+| TCP/IP performance tuning for Azure VMs | [learn.microsoft.com](https://learn.microsoft.com/azure/virtual-network/virtual-network-tcpip-performance-tuning) |

--- a/RunCommand/Windows/Windows_NIC_AdvancedProperties_Baseline/Windows_NIC_AdvancedProperties_Baseline.ps1
+++ b/RunCommand/Windows/Windows_NIC_AdvancedProperties_Baseline/Windows_NIC_AdvancedProperties_Baseline.ps1
@@ -1,0 +1,72 @@
+#Requires -Version 5.1
+[CmdletBinding()]
+param(
+  [string]$MockConfig,
+  [ValidateSet('healthy','degraded','broken')]
+  [string]$MockProfile = 'degraded'
+)
+$ErrorActionPreference='Continue'
+function Pad($s,$n){$s="$s";if($s.Length -ge $n){$s.Substring(0,$n)}else{$s.PadRight($n)}}
+$W=44
+$rows=New-Object System.Collections.Generic.List[object]
+function Add-Row($c,$s,$d=''){ $rows.Add([PSCustomObject]@{Check=$c;Status=$s;Detail=$d}); Write-Output ('{0} {1}' -f (Pad $c $W), $s) }
+
+Write-Output '=== Windows NIC Advanced Properties Baseline ==='
+Write-Output ('{0} {1}' -f (Pad 'Check' $W), 'Status')
+Write-Output (('-' * $W) + ' ------')
+
+$usedMock = $false
+if($MockConfig -and (Test-Path $MockConfig)){
+  $mock = Get-Content $MockConfig -Raw | ConvertFrom-Json
+  if($mock.profiles -and $mock.profiles.$MockProfile){
+    $usedMock = $true
+    foreach($i in $mock.profiles.$MockProfile){ Add-Row $i.name $i.status $i.detail }
+  }
+}
+
+if(-not $usedMock){
+  # Probe: RSS (Receive Side Scaling) enabled
+  $adv = Get-NetAdapterAdvancedProperty -ErrorAction SilentlyContinue; $rss = Get-NetAdapterRss -ErrorAction SilentlyContinue | Select-Object -First 1; $rssOn = if($rss){$rss.Enabled}else{$null}
+  $_s = if($rssOn -eq $true){'OK'}elseif($rssOn -ne $true){'WARN'}else{'FAIL'}
+  Add-Row 'RSS (Receive Side Scaling) enabled' $_s ("RSS=$rssOn")
+
+  # Probe: Checksum offload enabled
+  $cso = $adv | Where-Object { $_.DisplayName -match "Checksum Offload" -and $_.DisplayValue -ne "Disabled" } | Select-Object -First 1; $csoOn = $cso -ne $null
+  $_s = if($csoOn){'OK'}elseif(!$csoOn){'WARN'}else{'FAIL'}
+  Add-Row 'Checksum offload enabled' $_s ("ChecksumOffload=$(if($cso){$cso.DisplayValue}else{'not found'})")
+
+  # Probe: Large Send Offload v2 (LSOv2)
+  $lso = $adv | Where-Object { $_.DisplayName -match "Large Send Offload V2" -and $_.DisplayValue -ne "Disabled" } | Select-Object -First 1; $lsoOn = $lso -ne $null
+  $_s = if($lsoOn){'OK'}elseif(!$lsoOn){'WARN'}else{'FAIL'}
+  Add-Row 'Large Send Offload v2 (LSOv2)' $_s ("LSOv2=$(if($lso){$lso.DisplayValue}else{'not found'})")
+
+  # Probe: VMQ (Virtual Machine Queue)
+  $vmq = Get-NetAdapterVmq -ErrorAction SilentlyContinue | Select-Object -First 1; $vmqOn = if($vmq){$vmq.Enabled}else{$null}
+  $_s = if($true){'OK'}elseif($false){'WARN'}else{'FAIL'}
+  Add-Row 'VMQ (Virtual Machine Queue)' $_s ("VMQ=$(if($vmq){$vmq.Enabled}else{'N/A'}) (informational)")
+
+  # Probe: Jumbo Frame not set (Azure default)
+  $jumbo = $adv | Where-Object { $_.DisplayName -match "Jumbo" } | Select-Object -First 1; $jumboDefault = if($jumbo){$jumbo.DisplayValue -match "Disabled|1514"}else{$true}
+  $_s = if($jumboDefault){'OK'}elseif(!$jumboDefault){'WARN'}else{'FAIL'}
+  Add-Row 'Jumbo Frame not set (Azure default)' $_s ("JumboFrame=$(if($jumbo){$jumbo.DisplayValue}else{'default'})")
+
+  # Probe: Speed and duplex auto-negotiation
+  $sd = $adv | Where-Object { $_.DisplayName -match "Speed.*Duplex" } | Select-Object -First 1; $autoNeg = if($sd){$sd.DisplayValue -match "Auto"}else{$true}
+  $_s = if($autoNeg){'OK'}elseif(!$autoNeg){'WARN'}else{'FAIL'}
+  Add-Row 'Speed and duplex auto-negotiation' $_s ("SpeedDuplex=$(if($sd){$sd.DisplayValue}else{'auto (default)'})")
+
+}
+
+$fail=@($rows|Where-Object Status -eq 'FAIL').Count
+$warn=@($rows|Where-Object Status -eq 'WARN').Count
+Write-Output '-- Decision --'
+Add-Row 'Likely cause severity' $(if($fail -gt 0){'FAIL'}elseif($warn -gt 0){'WARN'}else{'OK'}) $(if($fail -gt 0){'Hard configuration/service break'}elseif($warn -gt 0){'Configuration drift or transient condition'}else{'No blocking signals'})
+Add-Row 'Next action' 'OK' $(if($fail -gt 0){'Follow README interpretation and remediate FAIL rows first'}elseif($warn -gt 0){'Review WARN rows and re-run after targeted fix'}else{'No immediate action'})
+Write-Output '-- More Info --'
+Add-Row 'Remediation references available' 'OK' 'See paired README Learn References'
+
+$ok=@($rows|Where-Object Status -eq 'OK').Count
+Write-Output ''
+Write-Output "=== RESULT: $ok OK / $fail FAIL / $warn WARN ==="
+$rows
+

--- a/RunCommand/Windows/Windows_NIC_AdvancedProperties_Baseline/mock_config_sample.json
+++ b/RunCommand/Windows/Windows_NIC_AdvancedProperties_Baseline/mock_config_sample.json
@@ -1,0 +1,100 @@
+{
+  "profiles": {
+    "healthy": [
+      {
+        "name": "RSS (Receive Side Scaling) enabled",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Checksum offload enabled",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Large Send Offload v2 (LSOv2)",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "VMQ (Virtual Machine Queue)",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Jumbo Frame not set (Azure default)",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Speed and duplex auto-negotiation",
+        "status": "OK",
+        "detail": "Healthy profile"
+      }
+    ],
+    "broken": [
+      {
+        "name": "RSS (Receive Side Scaling) enabled",
+        "status": "FAIL",
+        "detail": "Critical failure detected"
+      },
+      {
+        "name": "Checksum offload enabled",
+        "status": "FAIL",
+        "detail": "Critical failure detected"
+      },
+      {
+        "name": "Large Send Offload v2 (LSOv2)",
+        "status": "WARN",
+        "detail": "Degraded state"
+      },
+      {
+        "name": "VMQ (Virtual Machine Queue)",
+        "status": "OK",
+        "detail": "Operational"
+      },
+      {
+        "name": "Jumbo Frame not set (Azure default)",
+        "status": "WARN",
+        "detail": "Degraded state"
+      },
+      {
+        "name": "Speed and duplex auto-negotiation",
+        "status": "OK",
+        "detail": "Operational"
+      }
+    ],
+    "degraded": [
+      {
+        "name": "RSS (Receive Side Scaling) enabled",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Checksum offload enabled",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Large Send Offload v2 (LSOv2)",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "VMQ (Virtual Machine Queue)",
+        "status": "WARN",
+        "detail": "Configuration drift detected"
+      },
+      {
+        "name": "Jumbo Frame not set (Azure default)",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Speed and duplex auto-negotiation",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      }
+    ]
+  }
+}

--- a/RunCommand/Windows/Windows_NTFS_Integrity_Check/README.md
+++ b/RunCommand/Windows/Windows_NTFS_Integrity_Check/README.md
@@ -1,0 +1,78 @@
+# Windows NTFS Integrity Check
+
+> **Tool ID:** RC-032 · **Bucket:** Storage / Disk · **Phase:** 2 (Deep diagnostic)
+
+## What It Does
+
+Validates NTFS volume integrity on an Azure VM. Checks for detected fixed volumes, dirty volume flags, BootExecute (chkdsk-on-boot) configuration, recent disk error events, and OS volume C: presence. Essential for VMs with boot failures, data corruption, or "check disk" errors.
+
+| Check area | What is validated |
+|---|---|
+| Fixed volumes | Fixed volumes detected |
+| Dirty volumes | Dirty volume flag count |
+| BootExecute | BootExecute key present (chkdsk autorun) |
+| Disk errors | Recent disk errors below threshold |
+| OS volume | OS volume C: exists |
+
+## Run Command Constraints Met
+
+- ✅ PowerShell 5.1 only
+- ✅ No Az module required
+- ✅ No internet access needed
+- ✅ Output < 4 KB
+- ✅ No interactive prompts
+- ✅ Read-only (diagnostic only)
+
+## How to Run
+
+### Azure Run Command (recommended)
+Navigate to VM → Operations → Run Command → RunPowerShellScript → paste script.
+
+### Azure CLI
+```bash
+az vm run-command invoke -g <rg> -n <vm> --command-id RunPowerShellScript \
+  --scripts @Windows_NTFS_Integrity_Check/Windows_NTFS_Integrity_Check.ps1
+```
+
+### Mock test
+```powershell
+.\Windows_NTFS_Integrity_Check.ps1 -MockConfig .\mock_config_sample.json -MockProfile broken
+```
+
+## Sample Output (Issues Detected)
+
+```
+=== Windows NTFS Integrity Check ===
+Check                                        Status
+-------------------------------------------- ------
+Fixed volumes detected                       OK
+Dirty volumes count                          WARN
+BootExecute key present                      WARN
+Recent disk errors below threshold           WARN
+OS volume C exists                           FAIL
+-- Decision --
+Likely cause severity                        FAIL   Hard configuration/service break
+Next action                                  OK     Follow README interpretation and remediate FAIL rows first
+-- More Info --
+Remediation references available             OK     See paired README Learn References
+
+=== RESULT: 1 OK / 1 FAIL / 3 WARN ===
+```
+
+## Interpretation Guide
+
+| FAIL/WARN condition | Likely cause | Quick fix | Learn link |
+|---|---|---|---|
+| **Fixed volumes detected** FAIL | No fixed volumes found. Disk may be offline, detached, or controller driver missing. | Check Disk Management or `Get-Disk \| Format-Table Number,OperationalStatus,Size`. If offline: `Set-Disk -Number <n> -IsOffline $false` | [Troubleshoot check disk boot error](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-check-disk-boot-error) |
+| **Dirty volumes count** WARN | One or more volumes have dirty bit set. Volume was not cleanly unmounted — chkdsk will run on next boot. | `chkntfs C:` to check dirty state. Clear: `chkntfs /x C:` to exclude from auto-check, or run `chkdsk C: /f` offline. | [Troubleshoot check disk boot error](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-check-disk-boot-error) |
+| **BootExecute key present** WARN | `HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\BootExecute` has chkdsk entries. System will run disk check on boot, potentially delaying startup. | `reg query "HKLM\SYSTEM\CurrentControlSet\Control\Session Manager" /v BootExecute` — default value should be `autocheck autochk *`. Remove extra entries if causing boot loops. | [Check disk boot error](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-check-disk-boot-error) |
+| **Recent disk errors below threshold** WARN | More than 20 disk-related events (Event ID 7, 11, 51, 153, 157) in System log. Indicates potential hardware or driver issues. | `Get-WinEvent -FilterHashtable @{LogName='System';ProviderName='Disk';StartTime=(Get-Date).AddDays(-7)} \| Measure-Object` — investigate top error sources. | [Disk surprise removed event 157](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/disk-has-been-surprise-removed-event-id-157) |
+| **OS volume C exists** FAIL | OS volume C: not found. Boot volume may be missing, offline, or assigned wrong drive letter. | Attach OS disk as data disk to rescue VM. Verify partition table and drive letter assignment. | [Troubleshoot recovery disks](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-recovery-disks-portal-windows) |
+
+## Related Articles
+
+| Article | Link |
+|---|---|
+| Troubleshoot check disk boot error | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-check-disk-boot-error) |
+| Disk surprise removed event 157 | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/disk-has-been-surprise-removed-event-id-157) |
+| Troubleshoot recovery disks | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-recovery-disks-portal-windows) |

--- a/RunCommand/Windows/Windows_NTFS_Integrity_Check/Windows_NTFS_Integrity_Check.ps1
+++ b/RunCommand/Windows/Windows_NTFS_Integrity_Check/Windows_NTFS_Integrity_Check.ps1
@@ -1,0 +1,52 @@
+#Requires -Version 5.1
+[CmdletBinding()]
+param(
+  [string]$MockConfig,
+  [ValidateSet('healthy','degraded','broken')]
+  [string]$MockProfile = 'degraded'
+)
+$ErrorActionPreference='Continue'
+function Pad($s,$n){$s="$s";if($s.Length -ge $n){$s.Substring(0,$n)}else{$s.PadRight($n)}}
+$W=44
+$rows=New-Object System.Collections.Generic.List[object]
+function Add-Row($c,$s,$d=''){ $rows.Add([PSCustomObject]@{Check=$c;Status=$s;Detail=$d}); Write-Output ('{0} {1}' -f (Pad $c $W), $s) }
+
+Write-Output '=== Windows NTFS Integrity Check ==='
+Write-Output ('{0} {1}' -f (Pad 'Check' $W), 'Status')
+Write-Output (('-' * $W) + ' ------')
+
+$usedMock = $false
+if($MockConfig -and (Test-Path $MockConfig)){
+  $mock = Get-Content $MockConfig -Raw | ConvertFrom-Json
+  if($mock.profiles -and $mock.profiles.$MockProfile){
+    $usedMock = $true
+    foreach($i in $mock.profiles.$MockProfile){ Add-Row $i.name $i.status $i.detail }
+  }
+}
+
+if(-not $usedMock){
+  $vols = Get-Volume -ErrorAction SilentlyContinue | Where-Object DriveType -eq 'Fixed'
+  Add-Row 'Fixed volumes detected' $(if($vols){'OK'}else{'FAIL'}) "Count=$(@($vols).Count)"
+  $dirty=0
+  foreach($v in $vols){ $q=(fsutil dirty query ($v.DriveLetter + ':') 2>$null); if($q -match 'is Dirty'){ $dirty++ } }
+  Add-Row 'Dirty volumes count' $(if($dirty -gt 0){'WARN'}else{'OK'}) "Dirty=$dirty"
+  $chk = Test-Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\BootExecute'
+  Add-Row 'BootExecute key present' $(if($chk){'OK'}else{'WARN'}) ''
+  $ev = @(Get-WinEvent -FilterHashtable @{LogName='System'; ProviderName='disk'; StartTime=(Get-Date).AddHours(-24)} -ErrorAction SilentlyContinue).Count
+  Add-Row 'Recent disk errors below threshold' $(if($ev -gt 20){'WARN'}else{'OK'}) "DiskEvents=$ev"
+  $c = $vols | Where-Object DriveLetter -eq 'C'
+  Add-Row 'OS volume C exists' $(if($c){'OK'}else{'FAIL'}) ''
+}
+
+$fail=@($rows|Where-Object Status -eq 'FAIL').Count
+$warn=@($rows|Where-Object Status -eq 'WARN').Count
+Write-Output '-- Decision --'
+Add-Row 'Likely cause severity' $(if($fail -gt 0){'FAIL'}elseif($warn -gt 0){'WARN'}else{'OK'}) $(if($fail -gt 0){'Hard configuration/service break'}elseif($warn -gt 0){'Configuration drift or transient condition'}else{'No blocking signals'})
+Add-Row 'Next action' 'OK' $(if($fail -gt 0){'Follow README interpretation and remediate FAIL rows first'}elseif($warn -gt 0){'Review WARN rows and re-run after targeted fix'}else{'No immediate action'})
+Write-Output '-- More Info --'
+Add-Row 'Remediation references available' 'OK' 'See paired README Learn References'
+
+$ok=@($rows|Where-Object Status -eq 'OK').Count
+Write-Output ''
+Write-Output "=== RESULT: $ok OK / $fail FAIL / $warn WARN ==="
+$rows

--- a/RunCommand/Windows/Windows_NTFS_Integrity_Check/mock_config_sample.json
+++ b/RunCommand/Windows/Windows_NTFS_Integrity_Check/mock_config_sample.json
@@ -1,0 +1,85 @@
+{
+  "profiles": {
+    "healthy": [
+      {
+        "name": "Fixed volumes detected",
+        "status": "OK",
+        "detail": "Healthy"
+      },
+      {
+        "name": "Dirty volumes count",
+        "status": "OK",
+        "detail": "All dependencies available"
+      },
+      {
+        "name": "BootExecute key present",
+        "status": "OK",
+        "detail": "Below threshold"
+      },
+      {
+        "name": "Recent disk errors below threshold",
+        "status": "OK",
+        "detail": "Baseline compliant"
+      },
+      {
+        "name": "OS volume C exists",
+        "status": "OK",
+        "detail": "Reachable"
+      }
+    ],
+    "degraded": [
+      {
+        "name": "Fixed volumes detected",
+        "status": "OK",
+        "detail": "Operational with warnings"
+      },
+      {
+        "name": "Dirty volumes count",
+        "status": "WARN",
+        "detail": "One non-blocking issue"
+      },
+      {
+        "name": "BootExecute key present",
+        "status": "WARN",
+        "detail": "Elevated but not failing"
+      },
+      {
+        "name": "Recent disk errors below threshold",
+        "status": "WARN",
+        "detail": "Mostly compliant"
+      },
+      {
+        "name": "OS volume C exists",
+        "status": "OK",
+        "detail": "Reachable with latency"
+      }
+    ],
+    "broken": [
+      {
+        "name": "Fixed volumes detected",
+        "status": "FAIL",
+        "detail": "Blocking issue detected"
+      },
+      {
+        "name": "Dirty volumes count",
+        "status": "FAIL",
+        "detail": "Critical dependency unavailable"
+      },
+      {
+        "name": "BootExecute key present",
+        "status": "WARN",
+        "detail": "High error rate"
+      },
+      {
+        "name": "Recent disk errors below threshold",
+        "status": "WARN",
+        "detail": "Drift detected"
+      },
+      {
+        "name": "OS volume C exists",
+        "status": "FAIL",
+        "detail": "Unreachable"
+      }
+    ]
+  }
+}

--- a/RunCommand/Windows/Windows_NetworkBinding_Order_Check/README.md
+++ b/RunCommand/Windows/Windows_NetworkBinding_Order_Check/README.md
@@ -1,0 +1,78 @@
+# Windows Network Binding Order Check
+
+> **Tool ID:** RC-031 · **Bucket:** Networking · **Phase:** 2 (Deep diagnostic)
+
+## What It Does
+
+Validates network adapter binding order and interface metric configuration. Ensures the primary NIC has the lowest metric, no duplicate metrics cause routing ambiguity, DNS registration is correct, and tunnel adapters (ISATAP/Teredo) aren't taking priority. Critical for multi-NIC Azure VMs experiencing intermittent connectivity or wrong-NIC routing.
+
+| Check area | What is validated |
+|---|---|
+| Primary NIC metric | Primary adapter has lowest interface metric |
+| Duplicate metrics | No two adapters share the same metric value |
+| DNS registration | NIC registration order for DNS client |
+| Binding completeness | TCP/IP binding count on primary adapter |
+| Tunnel preference | ISATAP/Teredo not preferred over physical NICs |
+
+## Run Command Constraints Met
+
+- ✅ PowerShell 5.1 only
+- ✅ No Az module required
+- ✅ No internet access needed
+- ✅ Output < 4 KB
+- ✅ No interactive prompts
+- ✅ Read-only (diagnostic only)
+
+## How to Run
+
+### Azure Run Command (recommended)
+Navigate to VM → Operations → Run Command → RunPowerShellScript → paste script.
+
+### Azure CLI
+```bash
+az vm run-command invoke -g <rg> -n <vm> --command-id RunPowerShellScript \
+  --scripts @Windows_NetworkBinding_Order_Check/Windows_NetworkBinding_Order_Check.ps1
+```
+
+### Mock test
+```powershell
+.\Windows_NetworkBinding_Order_Check.ps1 -MockConfig .\mock_config_sample.json -MockProfile degraded
+```
+
+## Sample Output (Issues Detected)
+
+```
+=== Windows Network Binding Order Check ===
+Check                                        Status
+-------------------------------------------- ------
+Primary NIC interface metric                 WARN
+No duplicate interface metrics               FAIL
+DNS client NIC registration order            OK
+Primary adapter binding complete             OK
+ISATAP/Teredo not preferred                  WARN
+-- Decision --
+Likely cause severity                        FAIL   Hard configuration/service break
+Next action                                  OK     Follow README interpretation and remediate FAIL rows first
+-- More Info --
+Remediation references available             OK     See paired README Learn References
+
+=== RESULT: 2 OK / 1 FAIL / 2 WARN ===
+```
+
+## Interpretation Guide
+
+| FAIL/WARN condition | Likely cause | Quick fix | Learn link |
+|---|---|---|---|
+| **Primary NIC interface metric** WARN | Primary NIC doesn't have the lowest metric. Traffic may route through the wrong adapter, causing connectivity issues or asymmetric routing. | `Set-NetIPInterface -InterfaceAlias "Ethernet" -InterfaceMetric 10` — set primary NIC lower than all others | [Troubleshoot multi-IP no internet](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/no-internet-access-multi-ip) |
+| **No duplicate interface metrics** FAIL | Two or more adapters share the same metric value. Windows picks one arbitrarily, causing non-deterministic routing. | Assign unique metrics: `Get-NetIPInterface \| Set-NetIPInterface -InterfaceMetric <unique_value>` | [Azure VM network binding order](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/no-internet-access-multi-ip) |
+| **DNS client NIC registration order** WARN | DNS registration is on a non-primary NIC. DNS updates may register the wrong IP address. | `Set-DnsClient -InterfaceAlias "Ethernet" -RegisterThisConnectionsAddress $true` and disable on secondary NICs | [DNS client configuration](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/azure-vm-cannot-rdp-dns-check) |
+| **Primary adapter binding complete** WARN | TCP/IP binding missing on primary adapter. Network protocols may not function correctly. | Open `ncpa.cpl` → right-click primary NIC → Properties → verify TCP/IPv4 and TCP/IPv6 are checked | [Troubleshoot ghosted NIC](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/windows-vm-ghostednic-troubleshooting) |
+| **ISATAP/Teredo not preferred** WARN | Tunnel adapters have a lower metric than physical NICs. Traffic may try to route through tunnels instead of direct Azure fabric networking. | Disable tunnels: `netsh interface isatap set state disabled` and `netsh interface teredo set state disabled` | [Configure IPv6 in Windows](https://learn.microsoft.com/troubleshoot/windows-server/networking/configure-ipv6-in-windows) |
+
+## Related Articles
+
+| Article | Link |
+|---|---|
+| No internet access with multi-IP Azure VM | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/no-internet-access-multi-ip) |
+| Ghosted NIC troubleshooting | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/windows-vm-ghostednic-troubleshooting) |
+| Configure IPv6 in Windows | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/windows-server/networking/configure-ipv6-in-windows) |

--- a/RunCommand/Windows/Windows_NetworkBinding_Order_Check/Windows_NetworkBinding_Order_Check.ps1
+++ b/RunCommand/Windows/Windows_NetworkBinding_Order_Check/Windows_NetworkBinding_Order_Check.ps1
@@ -1,0 +1,67 @@
+#Requires -Version 5.1
+[CmdletBinding()]
+param(
+  [string]$MockConfig,
+  [ValidateSet('healthy','degraded','broken')]
+  [string]$MockProfile = 'degraded'
+)
+$ErrorActionPreference='Continue'
+function Pad($s,$n){$s="$s";if($s.Length -ge $n){$s.Substring(0,$n)}else{$s.PadRight($n)}}
+$W=44
+$rows=New-Object System.Collections.Generic.List[object]
+function Add-Row($c,$s,$d=''){ $rows.Add([PSCustomObject]@{Check=$c;Status=$s;Detail=$d}); Write-Output ('{0} {1}' -f (Pad $c $W), $s) }
+
+Write-Output '=== Windows Network Binding Order Check ==='
+Write-Output ('{0} {1}' -f (Pad 'Check' $W), 'Status')
+Write-Output (('-' * $W) + ' ------')
+
+$usedMock = $false
+if($MockConfig -and (Test-Path $MockConfig)){
+  $mock = Get-Content $MockConfig -Raw | ConvertFrom-Json
+  if($mock.profiles -and $mock.profiles.$MockProfile){
+    $usedMock = $true
+    foreach($i in $mock.profiles.$MockProfile){ Add-Row $i.name $i.status $i.detail }
+  }
+}
+
+if(-not $usedMock){
+  # Probe: Primary NIC interface metric
+  $primary = Get-NetIPInterface -AddressFamily IPv4 -ErrorAction SilentlyContinue | Where-Object { $_.ConnectionState -eq "Connected" } | Sort-Object InterfaceMetric | Select-Object -First 1; $metric = if($primary){$primary.InterfaceMetric}else{9999}
+  $_s = if($metric -lt 50){'OK'}elseif($metric -ge 50){'WARN'}else{'FAIL'}
+  Add-Row 'Primary NIC interface metric' $_s ("PrimaryMetric=$metric Iface=$(if($primary){$primary.InterfaceAlias}else{'none'})")
+
+  # Probe: No duplicate interface metrics
+  $metrics = Get-NetIPInterface -AddressFamily IPv4 -ErrorAction SilentlyContinue | Where-Object { $_.ConnectionState -eq "Connected" }; $dupMetrics = @($metrics | Group-Object InterfaceMetric | Where-Object Count -gt 1).Count
+  $_s = if($dupMetrics -eq 0){'OK'}elseif($dupMetrics -gt 0){'WARN'}else{'FAIL'}
+  Add-Row 'No duplicate interface metrics' $_s ("DuplicateMetrics=$dupMetrics")
+
+  # Probe: DNS client NIC registration order
+  $dnsNics = Get-DnsClient -ErrorAction SilentlyContinue | Where-Object { $_.RegisterThisConnectionsAddress -eq $true }; $regCount = @($dnsNics).Count
+  $_s = if($regCount -ge 1){'OK'}elseif($regCount -eq 0){'WARN'}else{'FAIL'}
+  Add-Row 'DNS client NIC registration order' $_s ("RegisteredNICs=$regCount")
+
+  # Probe: Primary adapter binding complete
+  $bound = Get-NetAdapterBinding -ErrorAction SilentlyContinue | Where-Object { $_.Enabled -eq $true -and $_.ComponentId -eq "ms_tcpip" }; $boundCount = @($bound).Count
+  $_s = if($boundCount -ge 1){'OK'}elseif($boundCount -eq 0){'WARN'}else{'FAIL'}
+  Add-Row 'Primary adapter binding complete' $_s ("TCPIPBound=$boundCount")
+
+  # Probe: ISATAP/Teredo not preferred
+  $isatap = Get-NetIPInterface -AddressFamily IPv6 -ErrorAction SilentlyContinue | Where-Object { $_.InterfaceAlias -match "isatap|Teredo" -and $_.ConnectionState -eq "Connected" }; $tunnelActive = @($isatap).Count
+  $_s = if($tunnelActive -eq 0){'OK'}elseif($tunnelActive -gt 0){'WARN'}else{'FAIL'}
+  Add-Row 'ISATAP/Teredo not preferred' $_s ("TunnelIfaces=$tunnelActive")
+
+}
+
+$fail=@($rows|Where-Object Status -eq 'FAIL').Count
+$warn=@($rows|Where-Object Status -eq 'WARN').Count
+Write-Output '-- Decision --'
+Add-Row 'Likely cause severity' $(if($fail -gt 0){'FAIL'}elseif($warn -gt 0){'WARN'}else{'OK'}) $(if($fail -gt 0){'Hard configuration/service break'}elseif($warn -gt 0){'Configuration drift or transient condition'}else{'No blocking signals'})
+Add-Row 'Next action' 'OK' $(if($fail -gt 0){'Follow README interpretation and remediate FAIL rows first'}elseif($warn -gt 0){'Review WARN rows and re-run after targeted fix'}else{'No immediate action'})
+Write-Output '-- More Info --'
+Add-Row 'Remediation references available' 'OK' 'See paired README Learn References'
+
+$ok=@($rows|Where-Object Status -eq 'OK').Count
+Write-Output ''
+Write-Output "=== RESULT: $ok OK / $fail FAIL / $warn WARN ==="
+$rows
+

--- a/RunCommand/Windows/Windows_NetworkBinding_Order_Check/mock_config_sample.json
+++ b/RunCommand/Windows/Windows_NetworkBinding_Order_Check/mock_config_sample.json
@@ -1,0 +1,85 @@
+{
+  "profiles": {
+    "healthy": [
+      {
+        "name": "Primary NIC interface metric",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "No duplicate interface metrics",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "DNS client NIC registration order",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Primary adapter binding complete",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "ISATAP/Teredo not preferred",
+        "status": "OK",
+        "detail": "Healthy profile"
+      }
+    ],
+    "broken": [
+      {
+        "name": "Primary NIC interface metric",
+        "status": "FAIL",
+        "detail": "Critical failure detected"
+      },
+      {
+        "name": "No duplicate interface metrics",
+        "status": "FAIL",
+        "detail": "Critical failure detected"
+      },
+      {
+        "name": "DNS client NIC registration order",
+        "status": "WARN",
+        "detail": "Degraded state"
+      },
+      {
+        "name": "Primary adapter binding complete",
+        "status": "OK",
+        "detail": "Operational"
+      },
+      {
+        "name": "ISATAP/Teredo not preferred",
+        "status": "WARN",
+        "detail": "Degraded state"
+      }
+    ],
+    "degraded": [
+      {
+        "name": "Primary NIC interface metric",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "No duplicate interface metrics",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "DNS client NIC registration order",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Primary adapter binding complete",
+        "status": "WARN",
+        "detail": "Configuration drift detected"
+      },
+      {
+        "name": "ISATAP/Teredo not preferred",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      }
+    ]
+  }
+}

--- a/RunCommand/Windows/Windows_Network_IMDS_Reachability/README.md
+++ b/RunCommand/Windows/Windows_Network_IMDS_Reachability/README.md
@@ -1,0 +1,78 @@
+# Windows Network + IMDS Reachability
+
+> **Tool ID:** RC-007 · **Bucket:** Network / Cant-RDP-SSH / AGEX · **Phase:** 3 (Config audit)
+
+## What It Does
+
+Validates network stack and Azure endpoint health from inside a Windows VM. Checks for IP-enabled NICs, default route presence, WireServer (168.63.129.16) connectivity, and IMDS (169.254.169.254) accessibility. Critical first-pass diagnostic for VMs with agent/extension failures or network isolation.
+
+| Check area | What is validated |
+|---|---|
+| NIC | IP-enabled NIC present |
+| Default route | Default route 0.0.0.0/0 exists |
+| WireServer | WireServer 168.63.129.16 reachable |
+| IMDS TCP | IMDS TCP endpoint reachable |
+| IMDS HTTP | IMDS metadata response HTTP 200 |
+
+## Run Command Constraints Met
+
+- ✅ PowerShell 5.1 only
+- ✅ No Az module required
+- ✅ No internet access needed
+- ✅ Output < 4 KB
+- ✅ No interactive prompts
+- ✅ Read-only (diagnostic only)
+
+## How to Run
+
+### Azure Run Command (recommended)
+Navigate to VM → Operations → Run Command → RunPowerShellScript → paste script.
+
+### Azure CLI
+```bash
+az vm run-command invoke -g <rg> -n <vm> --command-id RunPowerShellScript \
+  --scripts @Windows_Network_IMDS_Reachability/Windows_Network_IMDS_Reachability.ps1
+```
+
+### Mock test
+```powershell
+.\Windows_Network_IMDS_Reachability.ps1 -MockConfig .\mock_config_sample.json -MockProfile broken
+```
+
+## Sample Output (Issues Detected)
+
+```
+=== Windows Network + IMDS Reachability ===
+Check                                        Status
+-------------------------------------------- ------
+IP-enabled NIC present                       OK
+Default route 0.0.0.0/0 exists               FAIL
+WireServer 168.63.129.16 reachable           FAIL
+IMDS TCP endpoint reachable                  FAIL
+IMDS metadata response HTTP 200              FAIL
+-- Decision --
+Likely cause severity                        FAIL   Hard configuration/service break
+Next action                                  OK     Follow README interpretation and remediate FAIL rows first
+-- More Info --
+Remediation references available             OK     See paired README Learn References
+
+=== RESULT: 1 OK / 4 FAIL / 0 WARN ===
+```
+
+## Interpretation Guide
+
+| FAIL/WARN condition | Likely cause | Quick fix | Learn link |
+|---|---|---|---|
+| **IP-enabled NIC present** FAIL | No IP-enabled network adapters found. VM has no network connectivity. | Check Device Manager for hidden/disabled NICs. `Get-NetAdapter \| Format-Table Name,Status,LinkSpeed` — if none, the VM may need a NIC reset via Azure portal (redeploy). | [Troubleshoot NIC issues](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-rdp-nic-disabled) |
+| **Default route 0.0.0.0/0 exists** FAIL | No default gateway route. Traffic cannot leave the VM subnet. Guest routing table is broken. | `route print 0.0.0.0` — if empty, re-add: `route add 0.0.0.0 mask 0.0.0.0 <gateway-ip> -p`. DHCP renewal may fix: `ipconfig /release && ipconfig /renew`. | [No internet access multi-IP](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/no-internet-access-multi-ip) |
+| **WireServer 168.63.129.16 reachable** FAIL | Cannot reach Azure WireServer. Guest agent, extensions, and DHCP will fail. Firewall or route blocking 168.63.129.16. | Check `Get-NetFirewallRule \| Where-Object { $_.Action -eq 'Block' }` for rules blocking 168.63.129.16. Ensure no custom route overrides. | [What is IP 168.63.129.16](https://learn.microsoft.com/azure/virtual-network/what-is-ip-address-168-63-129-16) |
+| **IMDS TCP endpoint reachable** FAIL | TCP connection to 169.254.169.254:80 fails. Link-local route missing or firewall blocks. | Verify route: `route print 169.254.169.254`. Add if missing: `route add 169.254.169.254/32 <gateway>`. Check no proxy intercepts link-local. | [IMDS connection troubleshooting](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/windows-vm-imds-connection) |
+| **IMDS metadata response HTTP 200** WARN | TCP connects but HTTP response is not 200. Request header or path issue, or transient IMDS issue. | Test: `Invoke-RestMethod -Uri 'http://169.254.169.254/metadata/instance?api-version=2021-02-01' -Headers @{Metadata='true'}` — ensure `Metadata:true` header is set. | [Instance metadata service](https://learn.microsoft.com/azure/virtual-machines/instance-metadata-service) |
+
+## Related Articles
+
+| Article | Link |
+|---|---|
+| Instance metadata service | [learn.microsoft.com](https://learn.microsoft.com/azure/virtual-machines/instance-metadata-service) |
+| IMDS connection troubleshooting | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/windows-vm-imds-connection) |
+| What is IP 168.63.129.16 | [learn.microsoft.com](https://learn.microsoft.com/azure/virtual-network/what-is-ip-address-168-63-129-16) |

--- a/RunCommand/Windows/Windows_Network_IMDS_Reachability/Windows_Network_IMDS_Reachability.ps1
+++ b/RunCommand/Windows/Windows_Network_IMDS_Reachability/Windows_Network_IMDS_Reachability.ps1
@@ -1,0 +1,160 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Validates guest network configuration and IMDS reachability on an Azure Windows VM.
+.DESCRIPTION
+    Checks the most common in-guest network misconfigurations impacting VM management:
+      1. NIC operational state and DHCP/static assignment
+      2. DNS server configuration sanity
+      3. Default route and gateway presence
+      4. Reachability to WireServer (168.63.129.16)
+      5. Reachability and response from IMDS endpoint (169.254.169.254)
+
+    Designed for Azure Run Command: no Az module, no internet, PS 5.1 only,
+    output fits within the 4 KB portal limit.
+.PARAMETER MockConfig
+    Path to a JSON file that replaces live system reads for offline testing.
+.NOTES
+    Author  : CSS Core Compute SPM
+    Version : 1.0.0
+    Tool ID : RC-007
+    Bucket  : Network / Cant-RDP-SSH / AGEX
+    Repo    : Azure/azure-support-scripts  RunCommand/Windows/Windows_Network_IMDS_Reachability
+#>
+[CmdletBinding()]
+param(
+  [string]$MockConfig,
+  [ValidateSet('healthy','degraded','broken')]
+  [string]$MockProfile = 'degraded'
+)
+$ErrorActionPreference = 'Continue'
+
+function Pad($s, $n) { $s = "$s"; if ($s.Length -ge $n) { $s.Substring(0,$n) } else { $s.PadRight($n) } }
+$W = 44
+$findings = [System.Collections.Generic.List[psobject]]::new()
+
+function Add-Row($check, $status, $detail = '') {
+    $script:findings.Add([PSCustomObject]@{ Check = $check; Status = $status; Detail = $detail })
+    Write-Output ('{0} {1}' -f (Pad $check $W), $status)
+}
+
+$mock = $null
+if ($MockConfig -and (Test-Path $MockConfig)) {
+    $mock = Get-Content $MockConfig -Raw | ConvertFrom-Json
+}
+
+Write-Output '=== Windows Network + IMDS Reachability ==='
+Write-Output ('{0} {1}' -f (Pad 'Check' $W), 'Status')
+Write-Output (('-' * $W) + ' ------')
+
+
+$usedMock = $false
+if($MockConfig -and (Test-Path $MockConfig)){
+  if($mock.profiles -and $mock.profiles.$MockProfile){
+    $usedMock = $true
+    foreach($i in $mock.profiles.$MockProfile){ Add-Row $i.name $i.status $i.detail }
+  }
+}
+if(-not $usedMock){
+
+# -- NICs ---------------------------------------------------------------------
+Write-Output '-- NIC Configuration --'
+if ($mock) {
+    $nics = $mock.nics
+} else {
+    $nics = Get-WmiObject Win32_NetworkAdapterConfiguration -ErrorAction SilentlyContinue |
+        Where-Object { $_.IPEnabled -eq $true } |
+        ForEach-Object {
+            [PSCustomObject]@{
+                description = $_.Description
+                dhcpEnabled = $_.DHCPEnabled
+                ipAddress   = @($_.IPAddress)[0]
+                dnsServers  = @($_.DNSServerSearchOrder)
+                gateway     = @($_.DefaultIPGateway)[0]
+            }
+        }
+}
+
+if (@($nics).Count -eq 0) {
+    Add-Row 'IP-enabled NIC present' 'FAIL' 'No IP-enabled adapters found'
+} else {
+    Add-Row 'IP-enabled NIC present' 'OK' "Count=$(@($nics).Count)"
+    foreach ($nic in $nics | Select-Object -First 2) {
+        $dhcpLabel = if ($nic.dhcpEnabled) { 'DHCP' } else { 'Static' }
+        Add-Row "NIC: $($nic.description)" 'OK' "$dhcpLabel IP=$($nic.ipAddress)"
+
+        $dnsCount = @($nic.dnsServers).Count
+        $dnsStatus = if ($dnsCount -eq 0) { 'FAIL' } elseif ($dnsCount -gt 4) { 'WARN' } else { 'OK' }
+        Add-Row "DNS servers configured" $dnsStatus "Count=$dnsCount"
+
+        $gwStatus = if ([string]::IsNullOrEmpty($nic.gateway)) { 'FAIL' } else { 'OK' }
+        Add-Row "Default gateway present" $gwStatus "$($nic.gateway)"
+    }
+}
+
+# -- Routing ------------------------------------------------------------------
+Write-Output '-- Routing --'
+if ($mock) {
+    $hasDefaultRoute = $mock.route.hasDefaultRoute
+} else {
+    $routes = Get-WmiObject Win32_IP4RouteTable -ErrorAction SilentlyContinue |
+        Where-Object { $_.Destination -eq '0.0.0.0' -and $_.Mask -eq '0.0.0.0' }
+    $hasDefaultRoute = (@($routes).Count -gt 0)
+}
+Add-Row 'Default route 0.0.0.0/0 exists' (if ($hasDefaultRoute) { 'OK' } else { 'FAIL' }) ''
+
+# -- WireServer ---------------------------------------------------------------
+Write-Output '-- Azure Fabric Endpoint --'
+if ($mock) {
+    $wireServer = $mock.fabric.wireServerReachable
+} else {
+    $wireServer = $false
+    try {
+        $wireServer = Test-NetConnection 168.63.129.16 -Port 80 -InformationLevel Quiet -WarningAction SilentlyContinue
+    } catch {
+        $ping = Test-Connection 168.63.129.16 -Count 1 -Quiet -ErrorAction SilentlyContinue
+        $wireServer = [bool]$ping
+    }
+}
+Add-Row 'WireServer 168.63.129.16 reachable' (if ($wireServer) { 'OK' } else { 'FAIL' }) ''
+
+# -- IMDS ---------------------------------------------------------------------
+Write-Output '-- IMDS Endpoint --'
+if ($mock) {
+    $imdsReachable = $mock.imds.reachable
+    $imdsHttp200   = $mock.imds.http200
+} else {
+    $imdsReachable = $false
+    $imdsHttp200   = $false
+    try {
+        $resp = Invoke-WebRequest -UseBasicParsing -Method GET -TimeoutSec 5 `
+            -Uri 'http://169.254.169.254/metadata/instance?api-version=2021-02-01' `
+            -Headers @{ Metadata = 'true' } -ErrorAction Stop
+        $imdsReachable = $true
+        $imdsHttp200   = ($resp.StatusCode -eq 200)
+    } catch {
+        try {
+            $tcp = Test-NetConnection 169.254.169.254 -Port 80 -InformationLevel Quiet -WarningAction SilentlyContinue
+            $imdsReachable = [bool]$tcp
+        } catch { $imdsReachable = $false }
+    }
+}
+
+Add-Row 'IMDS TCP endpoint reachable' (if ($imdsReachable) { 'OK' } else { 'FAIL' }) ''
+Add-Row 'IMDS metadata response HTTP 200' (if ($imdsHttp200) { 'OK' } elseif ($imdsReachable) { 'WARN' } else { 'FAIL' }) ''
+
+}
+
+$fail = @($findings | Where-Object Status -eq 'FAIL').Count
+$warn = @($findings | Where-Object Status -eq 'WARN').Count
+Write-Output '-- Decision --'
+Add-Row 'Likely cause severity' $(if($fail -gt 0){'FAIL'}elseif($warn -gt 0){'WARN'}else{'OK'}) $(if($fail -gt 0){'Hard configuration/service break'}elseif($warn -gt 0){'Configuration drift or transient condition'}else{'No blocking signals'})
+Add-Row 'Next action' 'OK' $(if($fail -gt 0){'Follow README interpretation and remediate FAIL rows first'}elseif($warn -gt 0){'Review WARN rows and re-run after targeted fix'}else{'No immediate action'})
+Write-Output '-- More Info --'
+Add-Row 'Remediation references available' 'OK' 'See paired README Learn References'
+
+$ok = @($findings | Where-Object Status -eq 'OK').Count
+Write-Output ''
+Write-Output "=== RESULT: $ok OK / $fail FAIL / $warn WARN ==="
+
+$findings

--- a/RunCommand/Windows/Windows_Network_IMDS_Reachability/mock_config_sample.json
+++ b/RunCommand/Windows/Windows_Network_IMDS_Reachability/mock_config_sample.json
@@ -1,0 +1,85 @@
+{
+  "profiles": {
+    "healthy": [
+      {
+        "name": "IP-enabled NIC present",
+        "status": "OK",
+        "detail": "Healthy"
+      },
+      {
+        "name": "Default route 0.0.0.0/0 exists",
+        "status": "OK",
+        "detail": "All dependencies available"
+      },
+      {
+        "name": "WireServer 168.63.129.16 reachable",
+        "status": "OK",
+        "detail": "Below threshold"
+      },
+      {
+        "name": "IMDS TCP endpoint reachable",
+        "status": "OK",
+        "detail": "Baseline compliant"
+      },
+      {
+        "name": "IMDS metadata response HTTP 200",
+        "status": "OK",
+        "detail": "Reachable"
+      }
+    ],
+    "degraded": [
+      {
+        "name": "IP-enabled NIC present",
+        "status": "OK",
+        "detail": "Operational with warnings"
+      },
+      {
+        "name": "Default route 0.0.0.0/0 exists",
+        "status": "WARN",
+        "detail": "One non-blocking issue"
+      },
+      {
+        "name": "WireServer 168.63.129.16 reachable",
+        "status": "WARN",
+        "detail": "Elevated but not failing"
+      },
+      {
+        "name": "IMDS TCP endpoint reachable",
+        "status": "WARN",
+        "detail": "Mostly compliant"
+      },
+      {
+        "name": "IMDS metadata response HTTP 200",
+        "status": "OK",
+        "detail": "Reachable with latency"
+      }
+    ],
+    "broken": [
+      {
+        "name": "IP-enabled NIC present",
+        "status": "FAIL",
+        "detail": "Blocking issue detected"
+      },
+      {
+        "name": "Default route 0.0.0.0/0 exists",
+        "status": "FAIL",
+        "detail": "Critical dependency unavailable"
+      },
+      {
+        "name": "WireServer 168.63.129.16 reachable",
+        "status": "WARN",
+        "detail": "High error rate"
+      },
+      {
+        "name": "IMDS TCP endpoint reachable",
+        "status": "WARN",
+        "detail": "Drift detected"
+      },
+      {
+        "name": "IMDS metadata response HTTP 200",
+        "status": "FAIL",
+        "detail": "Unreachable"
+      }
+    ]
+  }
+}

--- a/RunCommand/Windows/Windows_Port_Ephemeral_Exhaustion_Check/README.md
+++ b/RunCommand/Windows/Windows_Port_Ephemeral_Exhaustion_Check/README.md
@@ -1,0 +1,84 @@
+# Windows Port Ephemeral Exhaustion Check
+
+> **Bucket:** Connectivity / Port-Exhaustion / Intermittent-Drops
+
+## What It Does
+
+Detects ephemeral (dynamic) TCP port exhaustion on a Windows VM — a common cause of intermittent connection failures, RDP drops, and application timeouts:
+
+| Check | What is validated |
+|---|---|
+| **Dynamic port range size** | `netsh int ipv4 show dynamicport tcp` — ensures range ≥ 16,384 ports |
+| **TCP connection count** | Total active TCP connections — flags if ≥ 10,000 (WARN) or ≥ 30,000 (FAIL) |
+| **TIME_WAIT count** | Connections stuck in TIME_WAIT — flags if ≥ 5,000 (WARN) or ≥ 15,000 (FAIL) |
+| **Ephemeral port usage ratio** | Ports in use ÷ total range — flags if ≥ 60% (WARN) or ≥ 85% (FAIL) |
+| **MaxUserPort registry** | Checks if `MaxUserPort` is set too low (< 32,768) |
+| **TcpTimedWaitDelay** | Checks if TIME_WAIT timeout is tuned (≤ 60 sec = OK, default 240 sec = WARN) |
+
+The script is **read-only** — it makes no changes to the system.
+
+## How to Run
+
+### Azure Run Command (recommended)
+1. Go to your VM in the Azure portal
+2. Select **Operations → Run Command → RunPowerShellScript**
+3. Paste the contents of `Windows_Port_Ephemeral_Exhaustion_Check.ps1`
+4. Select **Run** and wait for output
+
+### Azure CLI
+```bash
+az vm run-command invoke \
+  --resource-group <rg> \
+  --name <vm-name> \
+  --command-id RunPowerShellScript \
+  --scripts @Windows_Port_Ephemeral_Exhaustion_Check.ps1
+```
+
+### Elevated PowerShell (inside VM)
+```powershell
+Set-ExecutionPolicy Bypass -Scope Process -Force
+.\Windows_Port_Ephemeral_Exhaustion_Check.ps1
+```
+
+### Mock / Offline Test
+```powershell
+.\Windows_Port_Ephemeral_Exhaustion_Check.ps1 -MockConfig .\mock_config_sample.json -MockProfile broken
+```
+
+## Sample Output (Issues Detected)
+
+```
+=== Windows Port Ephemeral Exhaustion Check ===
+Check                                        Status
+-------------------------------------------- ------
+Dynamic port range size                      WARN    Start=49152 Count=8192
+Current TCP connections count                FAIL    TCPConns=34291
+TIME_WAIT connection count                   FAIL    TimeWait=22000
+Ephemeral port usage ratio                   FAIL    EphUsed=7800 Ratio=95.2%
+MaxUserPort registry override                OK      MaxUserPort=default
+TcpTimedWaitDelay tuned                      WARN    TWDelay=240 sec
+-- Decision --
+Likely cause severity                        FAIL
+Next action                                  OK
+-- More Info --
+Remediation references available             OK
+
+=== RESULT: 1 OK / 3 FAIL / 2 WARN ===
+```
+
+## Interpretation Guide
+
+| FAIL/WARN condition | Likely cause | Quick fix |
+|---|---|---|
+| Dynamic port range < 16,384 | Range was reduced via `netsh` or GPO | Run: `netsh int ipv4 set dynamicport tcp start=49152 num=16384` then reboot |
+| TCP connections ≥ 30,000 | Application connection leak or high-traffic burst | Identify the process holding connections: `Get-NetTCPConnection \| Group-Object OwningProcess \| Sort-Object Count -Desc` |
+| TIME_WAIT ≥ 15,000 | Rapid connect/disconnect cycles (web servers, load balancers) | Reduce `TcpTimedWaitDelay` to 30 sec (see below) and investigate the calling app |
+| Ephemeral port ratio ≥ 85% | Active port exhaustion — new connections will fail | Immediate: restart the leaking process. Long-term: increase range or fix connection reuse |
+| MaxUserPort < 32,768 | Legacy registry override limiting available ports | Remove or increase `HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\MaxUserPort` |
+| TcpTimedWaitDelay > 60 sec | Default 240 sec keeps ports locked in TIME_WAIT too long | Set `TcpTimedWaitDelay` to 30: `Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters' -Name TcpTimedWaitDelay -Value 30 -Type DWord` then reboot |
+
+## Related Articles
+
+- [Troubleshoot intermittent RDP connectivity to Azure VM](https://learn.microsoft.com/azure/virtual-machines/troubleshooting/troubleshoot-rdp-intermittent-connectivity)
+- [Troubleshoot application connectivity issues on Azure VMs](https://learn.microsoft.com/azure/virtual-machines/troubleshooting/troubleshoot-app-connection)
+- [Default dynamic port range for TCP/IP (Windows Server)](https://learn.microsoft.com/troubleshoot/windows-server/networking/default-dynamic-port-range-tcpip-702)

--- a/RunCommand/Windows/Windows_Port_Ephemeral_Exhaustion_Check/Windows_Port_Ephemeral_Exhaustion_Check.ps1
+++ b/RunCommand/Windows/Windows_Port_Ephemeral_Exhaustion_Check/Windows_Port_Ephemeral_Exhaustion_Check.ps1
@@ -1,0 +1,72 @@
+#Requires -Version 5.1
+[CmdletBinding()]
+param(
+  [string]$MockConfig,
+  [ValidateSet('healthy','degraded','broken')]
+  [string]$MockProfile = 'degraded'
+)
+$ErrorActionPreference='Continue'
+function Pad($s,$n){$s="$s";if($s.Length -ge $n){$s.Substring(0,$n)}else{$s.PadRight($n)}}
+$W=44
+$rows=New-Object System.Collections.Generic.List[object]
+function Add-Row($c,$s,$d=''){ $rows.Add([PSCustomObject]@{Check=$c;Status=$s;Detail=$d}); Write-Output ('{0} {1}' -f (Pad $c $W), $s) }
+
+Write-Output '=== Windows Port Ephemeral Exhaustion Check ==='
+Write-Output ('{0} {1}' -f (Pad 'Check' $W), 'Status')
+Write-Output (('-' * $W) + ' ------')
+
+$usedMock = $false
+if($MockConfig -and (Test-Path $MockConfig)){
+  $mock = Get-Content $MockConfig -Raw | ConvertFrom-Json
+  if($mock.profiles -and $mock.profiles.$MockProfile){
+    $usedMock = $true
+    foreach($i in $mock.profiles.$MockProfile){ Add-Row $i.name $i.status $i.detail }
+  }
+}
+
+if(-not $usedMock){
+  # Probe: Dynamic port range size
+  $range = netsh int ipv4 show dynamicport tcp 2>&1; $startPort = [int]($range | Select-String "Start Port" | ForEach-Object { ($_ -split ":")[1].Trim() }); $numPorts = [int]($range | Select-String "Number of Ports" | ForEach-Object { ($_ -split ":")[1].Trim() })
+  $_s = if($numPorts -ge 16384){'OK'}elseif($numPorts -lt 16384){'WARN'}else{'FAIL'}
+  Add-Row 'Dynamic port range size' $_s ("Start=$startPort Count=$numPorts")
+
+  # Probe: Current TCP connections count
+  $conns = (Get-NetTCPConnection -ErrorAction SilentlyContinue | Measure-Object).Count
+  $_s = if($conns -lt 10000){'OK'}elseif($conns -lt 30000){'WARN'}else{'FAIL'}
+  Add-Row 'Current TCP connections count' $_s ("TCPConns=$conns")
+
+  # Probe: TIME_WAIT connection count
+  $tw = @(Get-NetTCPConnection -State TimeWait -ErrorAction SilentlyContinue).Count
+  $_s = if($tw -lt 5000){'OK'}elseif($tw -lt 15000){'WARN'}else{'FAIL'}
+  Add-Row 'TIME_WAIT connection count' $_s ("TimeWait=$tw")
+
+  # Probe: Ephemeral port usage ratio
+  $eph = @(Get-NetTCPConnection -ErrorAction SilentlyContinue | Where-Object { $_.LocalPort -ge $startPort }).Count; $ratio = if($numPorts -gt 0){[math]::Round(($eph/$numPorts)*100,1)}else{0}
+  $_s = if($ratio -lt 60){'OK'}elseif($ratio -lt 85){'WARN'}else{'FAIL'}
+  Add-Row 'Ephemeral port usage ratio' $_s ("EphUsed=$eph Ratio=$ratio%25")
+
+  # Probe: MaxUserPort registry override
+  $mup = Get-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters" -Name "MaxUserPort" -ErrorAction SilentlyContinue; $mupVal = if($mup){$mup.MaxUserPort}else{0}
+  $_s = if($mupVal -eq 0 -or $mupVal -ge 32768){'OK'}elseif($mupVal -gt 0 -and $mupVal -lt 32768){'WARN'}else{'FAIL'}
+  Add-Row 'MaxUserPort registry override' $_s ("MaxUserPort=$(if($mupVal){$mupVal}else{'default'})")
+
+  # Probe: TcpTimedWaitDelay tuned
+  $twd = Get-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters" -Name "TcpTimedWaitDelay" -ErrorAction SilentlyContinue; $twdVal = if($twd){$twd.TcpTimedWaitDelay}else{240}
+  $_s = if($twdVal -le 60){'OK'}elseif($twdVal -gt 60){'WARN'}else{'FAIL'}
+  Add-Row 'TcpTimedWaitDelay tuned' $_s ("TWDelay=$twdVal sec")
+
+}
+
+$fail=@($rows|Where-Object Status -eq 'FAIL').Count
+$warn=@($rows|Where-Object Status -eq 'WARN').Count
+Write-Output '-- Decision --'
+Add-Row 'Likely cause severity' $(if($fail -gt 0){'FAIL'}elseif($warn -gt 0){'WARN'}else{'OK'}) $(if($fail -gt 0){'Hard configuration/service break'}elseif($warn -gt 0){'Configuration drift or transient condition'}else{'No blocking signals'})
+Add-Row 'Next action' 'OK' $(if($fail -gt 0){'Follow README interpretation and remediate FAIL rows first'}elseif($warn -gt 0){'Review WARN rows and re-run after targeted fix'}else{'No immediate action'})
+Write-Output '-- More Info --'
+Add-Row 'Remediation references available' 'OK' 'See paired README Learn References'
+
+$ok=@($rows|Where-Object Status -eq 'OK').Count
+Write-Output ''
+Write-Output "=== RESULT: $ok OK / $fail FAIL / $warn WARN ==="
+$rows
+

--- a/RunCommand/Windows/Windows_Port_Ephemeral_Exhaustion_Check/mock_config_sample.json
+++ b/RunCommand/Windows/Windows_Port_Ephemeral_Exhaustion_Check/mock_config_sample.json
@@ -1,0 +1,100 @@
+{
+  "profiles": {
+    "healthy": [
+      {
+        "name": "Dynamic port range size",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Current TCP connections count",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "TIME_WAIT connection count",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Ephemeral port usage ratio",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "MaxUserPort registry override",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "TcpTimedWaitDelay tuned",
+        "status": "OK",
+        "detail": "Healthy profile"
+      }
+    ],
+    "broken": [
+      {
+        "name": "Dynamic port range size",
+        "status": "FAIL",
+        "detail": "Critical failure detected"
+      },
+      {
+        "name": "Current TCP connections count",
+        "status": "FAIL",
+        "detail": "Critical failure detected"
+      },
+      {
+        "name": "TIME_WAIT connection count",
+        "status": "WARN",
+        "detail": "Degraded state"
+      },
+      {
+        "name": "Ephemeral port usage ratio",
+        "status": "OK",
+        "detail": "Operational"
+      },
+      {
+        "name": "MaxUserPort registry override",
+        "status": "WARN",
+        "detail": "Degraded state"
+      },
+      {
+        "name": "TcpTimedWaitDelay tuned",
+        "status": "OK",
+        "detail": "Operational"
+      }
+    ],
+    "degraded": [
+      {
+        "name": "Dynamic port range size",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Current TCP connections count",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "TIME_WAIT connection count",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Ephemeral port usage ratio",
+        "status": "WARN",
+        "detail": "Configuration drift detected"
+      },
+      {
+        "name": "MaxUserPort registry override",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "TcpTimedWaitDelay tuned",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      }
+    ]
+  }
+}

--- a/RunCommand/Windows/Windows_PowerPlan_Throttling_Check/README.md
+++ b/RunCommand/Windows/Windows_PowerPlan_Throttling_Check/README.md
@@ -1,0 +1,81 @@
+# Windows PowerPlan Throttling Check
+
+> **Tool ID:** RC-035 · **Bucket:** Performance · **Phase:** 2 (Deep diagnostic)
+
+## What It Does
+
+Audits power plan settings that can silently throttle CPU and disk performance on Azure VMs. Checks the active power plan, processor max/min states, hard disk timeout, USB selective suspend, and sleep/hibernate settings. A misconfigured power plan is a frequent root cause of unexplained performance degradation in Azure VMs.
+
+| Check area | What is validated |
+|---|---|
+| Active plan | Power plan name (should be High Performance) |
+| Processor max | Maximum processor state at 100% |
+| Processor min | Minimum processor state reasonable |
+| Disk timeout | Hard disk spin-down timeout |
+| USB suspend | USB selective suspend disabled |
+| Sleep/Hibernate | Sleep timeout disabled for server workloads |
+
+## Run Command Constraints Met
+
+- ✅ PowerShell 5.1 only
+- ✅ No Az module required
+- ✅ No internet access needed
+- ✅ Output < 4 KB
+- ✅ No interactive prompts
+- ✅ Read-only (diagnostic only)
+
+## How to Run
+
+### Azure Run Command (recommended)
+Navigate to VM → Operations → Run Command → RunPowerShellScript → paste script.
+
+### Azure CLI
+```bash
+az vm run-command invoke -g <rg> -n <vm> --command-id RunPowerShellScript \
+  --scripts @Windows_PowerPlan_Throttling_Check/Windows_PowerPlan_Throttling_Check.ps1
+```
+
+### Mock test
+```powershell
+.\Windows_PowerPlan_Throttling_Check.ps1 -MockConfig .\mock_config_sample.json -MockProfile broken
+```
+
+## Sample Output (Issues Detected)
+
+```
+=== Windows PowerPlan Throttling Check ===
+Check                                        Status
+-------------------------------------------- ------
+Active power plan                            FAIL
+Processor max state = 100%                   FAIL
+Processor min state reasonable               WARN
+Hard disk timeout (not 0)                    WARN
+USB selective suspend disabled               WARN
+Sleep/Hibernate disabled for server          FAIL
+-- Decision --
+Likely cause severity                        FAIL   Hard configuration/service break
+Next action                                  OK     Follow README interpretation and remediate FAIL rows first
+-- More Info --
+Remediation references available             OK     See paired README Learn References
+
+=== RESULT: 0 OK / 3 FAIL / 3 WARN ===
+```
+
+## Interpretation Guide
+
+| FAIL/WARN condition | Likely cause | Quick fix | Learn link |
+|---|---|---|---|
+| **Active power plan** FAIL | Not running High Performance plan. Balanced or Power Saver throttles CPU frequency, adding latency. | `powercfg /setactive 8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c` (High Performance GUID) | [Troubleshoot high CPU on Azure Windows VM](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-high-cpu-issues-azure-windows-vm) |
+| **Processor max state = 100%** FAIL | Maximum processor state is capped below 100%. CPU cannot reach full clock speed, causing performance loss under load. | `powercfg /setacvalueindex scheme_current sub_processor PROCTHROTTLEMAX 100` then `powercfg /setactive scheme_current` | [Azure VM performance troubleshooting](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-high-cpu-issues-azure-windows-vm) |
+| **Processor min state reasonable** WARN | Minimum processor state is very low (e.g., 5%). CPU may park at very low frequencies during idle, causing latency spikes on wake. | `powercfg /setacvalueindex scheme_current sub_processor PROCTHROTTLEMIN 100` for consistent performance | [Power plan settings](https://learn.microsoft.com/windows-server/administration/performance-tuning/hardware/power/power-performance-tuning) |
+| **Hard disk timeout (not 0)** WARN | Disk timeout is 0 (never spin down) or very short. On Azure managed disks this is usually informational but can mask issues. | `powercfg /setacvalueindex scheme_current sub_disk DISKIDLE 0` (0 = never timeout, appropriate for server) | [Performance tuning for disks](https://learn.microsoft.com/windows-server/administration/performance-tuning/subsystem/storage/) |
+| **USB selective suspend disabled** WARN | USB selective suspend is enabled. Can cause device disconnects on USB-passthrough scenarios. | `powercfg /setacvalueindex scheme_current 2a737441-1930-4402-8d77-b2bebba308a3 48e6b7a6-50f5-4782-a5d4-53bb8f07e226 0` | [USB power management](https://learn.microsoft.com/windows-hardware/drivers/usbcon/usb-power-management) |
+| **Sleep/Hibernate disabled for server** FAIL | Sleep or hibernate is enabled. Server VMs should never sleep — causes Azure heartbeat timeouts and potential deallocation. | `powercfg /h off` and `powercfg /setacvalueindex scheme_current sub_sleep STANDBYIDLE 0` (0 = never sleep) | [Azure VM memory issues](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/azure-windows-vm-memory-issue) |
+
+## Related Articles
+
+| Article | Link |
+|---|---|
+| Troubleshoot high CPU on Azure Windows VM | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-high-cpu-issues-azure-windows-vm) |
+| Power and performance tuning | [learn.microsoft.com](https://learn.microsoft.com/windows-server/administration/performance-tuning/hardware/power/power-performance-tuning) |
+| Azure Windows VM memory issues | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/azure-windows-vm-memory-issue) |

--- a/RunCommand/Windows/Windows_PowerPlan_Throttling_Check/Windows_PowerPlan_Throttling_Check.ps1
+++ b/RunCommand/Windows/Windows_PowerPlan_Throttling_Check/Windows_PowerPlan_Throttling_Check.ps1
@@ -1,0 +1,72 @@
+#Requires -Version 5.1
+[CmdletBinding()]
+param(
+  [string]$MockConfig,
+  [ValidateSet('healthy','degraded','broken')]
+  [string]$MockProfile = 'degraded'
+)
+$ErrorActionPreference='Continue'
+function Pad($s,$n){$s="$s";if($s.Length -ge $n){$s.Substring(0,$n)}else{$s.PadRight($n)}}
+$W=44
+$rows=New-Object System.Collections.Generic.List[object]
+function Add-Row($c,$s,$d=''){ $rows.Add([PSCustomObject]@{Check=$c;Status=$s;Detail=$d}); Write-Output ('{0} {1}' -f (Pad $c $W), $s) }
+
+Write-Output '=== Windows Power Plan Throttling Check ==='
+Write-Output ('{0} {1}' -f (Pad 'Check' $W), 'Status')
+Write-Output (('-' * $W) + ' ------')
+
+$usedMock = $false
+if($MockConfig -and (Test-Path $MockConfig)){
+  $mock = Get-Content $MockConfig -Raw | ConvertFrom-Json
+  if($mock.profiles -and $mock.profiles.$MockProfile){
+    $usedMock = $true
+    foreach($i in $mock.profiles.$MockProfile){ Add-Row $i.name $i.status $i.detail }
+  }
+}
+
+if(-not $usedMock){
+  # Probe: Active power plan
+  $plan = powercfg /getactivescheme 2>&1; $planName = if($plan -match ":(.+)\((.+)\)"){$Matches[2].Trim()} else {"unknown"}; $isHP = $planName -match "High Performance"
+  $_s = if($isHP){'OK'}elseif(!$isHP){'WARN'}else{'FAIL'}
+  Add-Row 'Active power plan' $_s ("Plan=$planName")
+
+  # Probe: Processor max state = 100%
+  $pmax = powercfg /query SCHEME_CURRENT SUB_PROCESSOR PROCTHROTTLEMAX 2>&1; $maxVal = if($pmax -match "Current AC.*:\s*0x([0-9a-f]+)"){[int]"0x$($Matches[1])"}else{100}
+  $_s = if($maxVal -lt 100){'FAIL'}elseif($maxVal -eq 100){'OK'}else{'WARN'}
+  Add-Row 'Processor max state = 100%' $_s ("MaxProcessor=$maxVal%25")
+
+  # Probe: Processor min state reasonable
+  $pmin = powercfg /query SCHEME_CURRENT SUB_PROCESSOR PROCTHROTTLEMIN 2>&1; $minVal = if($pmin -match "Current AC.*:\s*0x([0-9a-f]+)"){[int]"0x$($Matches[1])"}else{5}
+  $_s = if($minVal -le 10){'OK'}elseif($minVal -gt 10){'WARN'}else{'FAIL'}
+  Add-Row 'Processor min state reasonable' $_s ("MinProcessor=$minVal%25")
+
+  # Probe: Hard disk timeout (not 0)
+  $hd = powercfg /query SCHEME_CURRENT SUB_DISK DISKIDLE 2>&1; $hdVal = if($hd -match "Current AC.*:\s*0x([0-9a-f]+)"){[int]"0x$($Matches[1])"}else{0}
+  $_s = if($hdVal -eq 0 -or $hdVal -ge 1200){'OK'}elseif($hdVal -gt 0 -and $hdVal -lt 1200){'WARN'}else{'FAIL'}
+  Add-Row 'Hard disk timeout (not 0)' $_s ("DiskTimeout=$hdVal sec")
+
+  # Probe: USB selective suspend disabled
+  $usb = powercfg /query SCHEME_CURRENT 2b6965c-629a500f 48e6b7a6-50f5-4782-a5d4-53bb8f07e226 2>&1; $usbVal = if($usb -match "Current AC.*:\s*0x([0-9a-f]+)"){[int]"0x$($Matches[1])"}else{-1}
+  $_s = if($usbVal -eq 0){'OK'}elseif($usbVal -ne 0){'WARN'}else{'FAIL'}
+  Add-Row 'USB selective suspend disabled' $_s ("USBSuspend=$usbVal")
+
+  # Probe: Sleep/Hibernate disabled for server
+  $sleep = powercfg /query SCHEME_CURRENT SUB_SLEEP STANDBYIDLE 2>&1; $sleepVal = if($sleep -match "Current AC.*:\s*0x([0-9a-f]+)"){[int]"0x$($Matches[1])"}else{0}
+  $_s = if($sleepVal -eq 0){'OK'}elseif($sleepVal -gt 0){'WARN'}else{'FAIL'}
+  Add-Row 'Sleep/Hibernate disabled for server' $_s ("SleepTimeout=$sleepVal sec")
+
+}
+
+$fail=@($rows|Where-Object Status -eq 'FAIL').Count
+$warn=@($rows|Where-Object Status -eq 'WARN').Count
+Write-Output '-- Decision --'
+Add-Row 'Likely cause severity' $(if($fail -gt 0){'FAIL'}elseif($warn -gt 0){'WARN'}else{'OK'}) $(if($fail -gt 0){'Hard configuration/service break'}elseif($warn -gt 0){'Configuration drift or transient condition'}else{'No blocking signals'})
+Add-Row 'Next action' 'OK' $(if($fail -gt 0){'Follow README interpretation and remediate FAIL rows first'}elseif($warn -gt 0){'Review WARN rows and re-run after targeted fix'}else{'No immediate action'})
+Write-Output '-- More Info --'
+Add-Row 'Remediation references available' 'OK' 'See paired README Learn References'
+
+$ok=@($rows|Where-Object Status -eq 'OK').Count
+Write-Output ''
+Write-Output "=== RESULT: $ok OK / $fail FAIL / $warn WARN ==="
+$rows
+

--- a/RunCommand/Windows/Windows_PowerPlan_Throttling_Check/mock_config_sample.json
+++ b/RunCommand/Windows/Windows_PowerPlan_Throttling_Check/mock_config_sample.json
@@ -1,0 +1,100 @@
+{
+  "profiles": {
+    "healthy": [
+      {
+        "name": "Active power plan",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Processor max state = 100%",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Processor min state reasonable",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Hard disk timeout (not 0)",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "USB selective suspend disabled",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Sleep/Hibernate disabled for server",
+        "status": "OK",
+        "detail": "Healthy profile"
+      }
+    ],
+    "broken": [
+      {
+        "name": "Active power plan",
+        "status": "FAIL",
+        "detail": "Critical failure detected"
+      },
+      {
+        "name": "Processor max state = 100%",
+        "status": "FAIL",
+        "detail": "Critical failure detected"
+      },
+      {
+        "name": "Processor min state reasonable",
+        "status": "WARN",
+        "detail": "Degraded state"
+      },
+      {
+        "name": "Hard disk timeout (not 0)",
+        "status": "OK",
+        "detail": "Operational"
+      },
+      {
+        "name": "USB selective suspend disabled",
+        "status": "WARN",
+        "detail": "Degraded state"
+      },
+      {
+        "name": "Sleep/Hibernate disabled for server",
+        "status": "OK",
+        "detail": "Operational"
+      }
+    ],
+    "degraded": [
+      {
+        "name": "Active power plan",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Processor max state = 100%",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Processor min state reasonable",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Hard disk timeout (not 0)",
+        "status": "WARN",
+        "detail": "Configuration drift detected"
+      },
+      {
+        "name": "USB selective suspend disabled",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Sleep/Hibernate disabled for server",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      }
+    ]
+  }
+}

--- a/RunCommand/Windows/Windows_ProfileDisk_TempIo_Storm_Check/README.md
+++ b/RunCommand/Windows/Windows_ProfileDisk_TempIo_Storm_Check/README.md
@@ -1,0 +1,44 @@
+# Windows ProfileDisk TempIo Storm Check
+
+> Tool focus: temp/profile growth and write-pressure triage.
+
+## What It Checks
+
+- `%TEMP%` size signal
+- `C:\Users` profile footprint signal
+- current disk queue pressure
+- top write-heavy process sample
+
+## How To Run
+
+```powershell
+.\Windows_ProfileDisk_TempIo_Storm_Check.ps1
+```
+
+Mock/offline validation:
+
+```powershell
+.\Windows_ProfileDisk_TempIo_Storm_Check.ps1 -MockConfig .\mock_config_sample.json
+```
+
+## Mock Output Example
+
+```
+=== Windows Profile/Temp I/O Storm Check ===
+Check                                        Status
+-------------------------------------------- ------
+-- Temp and Profile Pressure --
+Temp folder size healthy                     WARN
+User profiles size signal                    WARN
+Disk queue pressure                          WARN
+-- Top Writers --
+Top writer sample collected                  OK
+
+=== RESULT: 1 OK / 0 FAIL / 3 WARN ===
+```
+
+## Learn References
+
+- https://learn.microsoft.com/azure/virtual-machines/troubleshooting/azure-windows-vm-memory-issue
+- https://learn.microsoft.com/azure/virtual-machines/troubleshooting/poor-performance-emulated-storage-stack
+- https://learn.microsoft.com/azure/virtual-machines/troubleshooting/troubleshoot-high-cpu-issues-azure-windows-vm

--- a/RunCommand/Windows/Windows_ProfileDisk_TempIo_Storm_Check/Windows_ProfileDisk_TempIo_Storm_Check.ps1
+++ b/RunCommand/Windows/Windows_ProfileDisk_TempIo_Storm_Check/Windows_ProfileDisk_TempIo_Storm_Check.ps1
@@ -1,0 +1,47 @@
+#Requires -Version 5.1
+[CmdletBinding()]
+param(
+  [string]$MockConfig,
+  [ValidateSet('healthy','degraded','broken')]
+  [string]$MockProfile = 'degraded'
+)
+$ErrorActionPreference='Continue'
+function Pad($s,$n){$s="$s";if($s.Length -ge $n){$s.Substring(0,$n)}else{$s.PadRight($n)}}
+$W=44
+$rows=New-Object System.Collections.Generic.List[object]
+function Add-Row($c,$s,$d=''){ $rows.Add([PSCustomObject]@{Check=$c;Status=$s;Detail=$d}); Write-Output ('{0} {1}' -f (Pad $c $W), $s) }
+$mock=$null
+$usedMock=$false
+if($MockConfig -and (Test-Path $MockConfig)){
+  $mock=Get-Content $MockConfig -Raw | ConvertFrom-Json
+  if($mock.profiles -and $mock.profiles.$MockProfile){
+    $usedMock=$true
+    foreach($i in $mock.profiles.$MockProfile){ Add-Row $i.name $i.status $i.detail }
+  }
+}
+
+Write-Output '=== Windows Profile/Temp I/O Storm Check ==='
+Write-Output ('{0} {1}' -f (Pad 'Check' $W), 'Status')
+Write-Output (('-' * $W) + ' ------')
+
+if(-not $usedMock){
+Write-Output '-- Temp and Profile Pressure --'
+  $tempGB=[double]$mock.paths.tempSizeGB
+  $topWriters=$mock.paths.topWriters
+  if(Test-Path $tempPath){
+  }
+  $profileGB=[math]::Round(((Get-ChildItem 'C:\Users' -Recurse -Force -ErrorAction SilentlyContinue | Measure-Object Length -Sum).Sum /1GB),2)
+  $diskQueue=0
+}
+
+$fail=@($rows|? Status -eq 'FAIL').Count; $warn=@($rows|? Status -eq 'WARN').Count
+Write-Output '-- Decision --'
+Add-Row 'Likely cause severity' $(if($fail -gt 0){'FAIL'}elseif($warn -gt 0){'WARN'}else{'OK'}) $(if($fail -gt 0){'Hard configuration/service break'}elseif($warn -gt 0){'Configuration drift or transient condition'}else{'No blocking signals'})
+Add-Row 'Next action' 'OK' $(if($fail -gt 0){'Follow README interpretation and remediate FAIL rows first'}elseif($warn -gt 0){'Review WARN rows and re-run after targeted fix'}else{'No immediate action'})
+Write-Output '-- More Info --'
+Add-Row 'Remediation references available' 'OK' 'See paired README Learn References'
+
+$ok=@($rows|? Status -eq 'OK').Count
+Write-Output ''
+Write-Output "=== RESULT: $ok OK / $fail FAIL / $warn WARN ==="
+$rows

--- a/RunCommand/Windows/Windows_ProfileDisk_TempIo_Storm_Check/mock_config_sample.json
+++ b/RunCommand/Windows/Windows_ProfileDisk_TempIo_Storm_Check/mock_config_sample.json
@@ -1,0 +1,109 @@
+{
+  "legacy": {
+    "paths": {
+      "tempSizeGB": 10.4,
+      "profileSizeGB": 52.2,
+      "diskQueue": 3,
+      "topWriters": [
+        {
+          "name": "sqlservr",
+          "pid": 4560,
+          "ioMB": 7340.2
+        },
+        {
+          "name": "SearchIndexer",
+          "pid": 1232,
+          "ioMB": 940.5
+        },
+        {
+          "name": "MsMpEng",
+          "pid": 3408,
+          "ioMB": 410.8
+        }
+      ]
+    }
+  },
+  "profiles": {
+    "healthy": [
+      {
+        "detail": "All checks passing",
+        "status": "OK",
+        "name": "Primary signal"
+      },
+      {
+        "detail": "Required services running",
+        "status": "OK",
+        "name": "Service dependencies"
+      },
+      {
+        "detail": "No drift detected",
+        "status": "OK",
+        "name": "Configuration baseline"
+      },
+      {
+        "detail": "No errors in observation window",
+        "status": "OK",
+        "name": "Error signal check"
+      },
+      {
+        "detail": "All endpoints reachable",
+        "status": "OK",
+        "name": "Connectivity probe"
+      }
+    ],
+    "degraded": [
+      {
+        "detail": "Operational with warnings",
+        "status": "OK",
+        "name": "Primary signal"
+      },
+      {
+        "detail": "One non-critical dependency issue",
+        "status": "WARN",
+        "name": "Service dependencies"
+      },
+      {
+        "detail": "Mostly compliant",
+        "status": "OK",
+        "name": "Configuration baseline"
+      },
+      {
+        "detail": "Elevated error rate but not failing",
+        "status": "WARN",
+        "name": "Error signal check"
+      },
+      {
+        "detail": "Primary path reachable",
+        "status": "OK",
+        "name": "Connectivity probe"
+      }
+    ],
+    "broken": [
+      {
+        "detail": "Service or component not responding",
+        "status": "FAIL",
+        "name": "Primary signal"
+      },
+      {
+        "detail": "Critical dependency down",
+        "status": "FAIL",
+        "name": "Service dependencies"
+      },
+      {
+        "detail": "Significant drift from expected state",
+        "status": "WARN",
+        "name": "Configuration baseline"
+      },
+      {
+        "detail": "High error rate",
+        "status": "WARN",
+        "name": "Error signal check"
+      },
+      {
+        "detail": "Required endpoint unreachable",
+        "status": "FAIL",
+        "name": "Connectivity probe"
+      }
+    ]
+  }
+}

--- a/RunCommand/Windows/Windows_Proxy_WinHTTP_WinINET_Check/README.md
+++ b/RunCommand/Windows/Windows_Proxy_WinHTTP_WinINET_Check/README.md
@@ -1,0 +1,78 @@
+# Windows Proxy WinHTTP WinINET Check
+
+> **Tool ID:** RC-035 · **Bucket:** Network / Proxy · **Phase:** 2 (Deep diagnostic)
+
+## What It Does
+
+Audits proxy configuration across WinHTTP and WinINET layers. Checks proxy detection, registry settings, bypass list configuration, and verifies Azure fabric endpoints (IMDS, WireServer) are reachable without proxy interference. Critical for VMs where agent/extensions fail due to proxy misconfiguration.
+
+| Check area | What is validated |
+|---|---|
+| WinHTTP proxy | WinHTTP proxy settings parsed |
+| WinINET proxy | WinINET proxy registry key readable |
+| Bypass list | Proxy bypass list defined |
+| IMDS bypass | IMDS reachable without proxy |
+| WireServer bypass | WireServer reachable without proxy |
+
+## Run Command Constraints Met
+
+- ✅ PowerShell 5.1 only
+- ✅ No Az module required
+- ✅ No internet access needed
+- ✅ Output < 4 KB
+- ✅ No interactive prompts
+- ✅ Read-only (diagnostic only)
+
+## How to Run
+
+### Azure Run Command (recommended)
+Navigate to VM → Operations → Run Command → RunPowerShellScript → paste script.
+
+### Azure CLI
+```bash
+az vm run-command invoke -g <rg> -n <vm> --command-id RunPowerShellScript \
+  --scripts @Windows_Proxy_WinHTTP_WinINET_Check/Windows_Proxy_WinHTTP_WinINET_Check.ps1
+```
+
+### Mock test
+```powershell
+.\Windows_Proxy_WinHTTP_WinINET_Check.ps1 -MockConfig .\mock_config_sample.json -MockProfile broken
+```
+
+## Sample Output (Issues Detected)
+
+```
+=== Windows Proxy WinHTTP WinINET Check ===
+Check                                        Status
+-------------------------------------------- ------
+WinHTTP proxy parsed                         WARN
+WinINET proxy key readable                   WARN
+Proxy bypass list defined                    WARN
+IMDS reachable without proxy                 FAIL
+WireServer reachable without proxy           FAIL
+-- Decision --
+Likely cause severity                        FAIL   Hard configuration/service break
+Next action                                  OK     Follow README interpretation and remediate FAIL rows first
+-- More Info --
+Remediation references available             OK     See paired README Learn References
+
+=== RESULT: 0 OK / 2 FAIL / 3 WARN ===
+```
+
+## Interpretation Guide
+
+| FAIL/WARN condition | Likely cause | Quick fix | Learn link |
+|---|---|---|---|
+| **WinHTTP proxy parsed** WARN | WinHTTP proxy is configured system-wide. May route Azure fabric traffic through proxy that cannot reach 168.63.129.16 or 169.254.169.254. | `netsh winhttp show proxy` — if set, ensure bypass list includes `168.63.129.16;169.254.169.254`. Reset: `netsh winhttp reset proxy` | [No internet access multi-IP](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/no-internet-access-multi-ip) |
+| **WinINET proxy key readable** WARN | WinINET (Internet Explorer/user-level) proxy settings detected. Applications using WinINET will route through proxy. | Check: `reg query "HKCU\Software\Microsoft\Windows\CurrentVersion\Internet Settings" /v ProxyServer`. Clear if unneeded. | [Troubleshoot app connection](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-app-connection) |
+| **Proxy bypass list defined** WARN | Bypass list is missing or does not include Azure fabric endpoints. Proxy will intercept IMDS/WireServer calls. | Add to bypass: `netsh winhttp set proxy proxy-server="proxy:8080" bypass-list="168.63.129.16;169.254.169.254;<local>"` | [No internet access multi-IP](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/no-internet-access-multi-ip) |
+| **IMDS reachable without proxy** FAIL | Cannot reach IMDS (169.254.169.254) bypassing proxy. Proxy intercepts link-local traffic or route is missing. | Ensure bypass list includes `169.254.169.254`. Test: `Invoke-RestMethod -Uri 'http://169.254.169.254/metadata/instance?api-version=2021-02-01' -Headers @{Metadata='true'} -NoProxy` | [IMDS connection troubleshooting](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/windows-vm-imds-connection) |
+| **WireServer reachable without proxy** FAIL | Cannot reach WireServer (168.63.129.16) bypassing proxy. Guest agent and extensions will fail. | Ensure bypass list includes `168.63.129.16`. Verify no firewall rules blocking. Test: `Test-NetConnection 168.63.129.16 -Port 80` | [What is IP 168.63.129.16](https://learn.microsoft.com/azure/virtual-network/what-is-ip-address-168-63-129-16) |
+
+## Related Articles
+
+| Article | Link |
+|---|---|
+| No internet access multi-IP | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/no-internet-access-multi-ip) |
+| Troubleshoot app connection | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-app-connection) |
+| IMDS connection troubleshooting | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/windows-vm-imds-connection) |

--- a/RunCommand/Windows/Windows_Proxy_WinHTTP_WinINET_Check/Windows_Proxy_WinHTTP_WinINET_Check.ps1
+++ b/RunCommand/Windows/Windows_Proxy_WinHTTP_WinINET_Check/Windows_Proxy_WinHTTP_WinINET_Check.ps1
@@ -1,0 +1,51 @@
+#Requires -Version 5.1
+[CmdletBinding()]
+param(
+  [string]$MockConfig,
+  [ValidateSet('healthy','degraded','broken')]
+  [string]$MockProfile = 'degraded'
+)
+$ErrorActionPreference='Continue'
+function Pad($s,$n){$s="$s";if($s.Length -ge $n){$s.Substring(0,$n)}else{$s.PadRight($n)}}
+$W=44
+$rows=New-Object System.Collections.Generic.List[object]
+function Add-Row($c,$s,$d=''){ $rows.Add([PSCustomObject]@{Check=$c;Status=$s;Detail=$d}); Write-Output ('{0} {1}' -f (Pad $c $W), $s) }
+
+Write-Output '=== Windows Proxy WinHTTP WinINET Check ==='
+Write-Output ('{0} {1}' -f (Pad 'Check' $W), 'Status')
+Write-Output (('-' * $W) + ' ------')
+
+$usedMock = $false
+if($MockConfig -and (Test-Path $MockConfig)){
+  $mock = Get-Content $MockConfig -Raw | ConvertFrom-Json
+  if($mock.profiles -and $mock.profiles.$MockProfile){
+    $usedMock = $true
+    foreach($i in $mock.profiles.$MockProfile){ Add-Row $i.name $i.status $i.detail }
+  }
+}
+
+if(-not $usedMock){
+  $winhttp = (netsh winhttp show proxy) -join ' '
+  Add-Row 'WinHTTP proxy parsed' $(if($winhttp){'OK'}else{'WARN'}) ''
+  $inet = Get-ItemProperty 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Internet Settings' -ErrorAction SilentlyContinue
+  Add-Row 'WinINET proxy key readable' $(if($inet){'OK'}else{'WARN'}) ''
+  $bypass = if($winhttp -match 'Bypass List'){ 'OK' } else { 'WARN' }
+  Add-Row 'Proxy bypass list defined' $bypass ''
+  $imds = Test-NetConnection 169.254.169.254 -Port 80 -InformationLevel Quiet -WarningAction SilentlyContinue
+  Add-Row 'IMDS reachable without proxy' $(if($imds){'OK'}else{'FAIL'}) ''
+  $wire = Test-NetConnection 168.63.129.16 -Port 80 -InformationLevel Quiet -WarningAction SilentlyContinue
+  Add-Row 'WireServer reachable without proxy' $(if($wire){'OK'}else{'FAIL'}) ''
+}
+
+$fail=@($rows|Where-Object Status -eq 'FAIL').Count
+$warn=@($rows|Where-Object Status -eq 'WARN').Count
+Write-Output '-- Decision --'
+Add-Row 'Likely cause severity' $(if($fail -gt 0){'FAIL'}elseif($warn -gt 0){'WARN'}else{'OK'}) $(if($fail -gt 0){'Hard configuration/service break'}elseif($warn -gt 0){'Configuration drift or transient condition'}else{'No blocking signals'})
+Add-Row 'Next action' 'OK' $(if($fail -gt 0){'Follow README interpretation and remediate FAIL rows first'}elseif($warn -gt 0){'Review WARN rows and re-run after targeted fix'}else{'No immediate action'})
+Write-Output '-- More Info --'
+Add-Row 'Remediation references available' 'OK' 'See paired README Learn References'
+
+$ok=@($rows|Where-Object Status -eq 'OK').Count
+Write-Output ''
+Write-Output "=== RESULT: $ok OK / $fail FAIL / $warn WARN ==="
+$rows

--- a/RunCommand/Windows/Windows_Proxy_WinHTTP_WinINET_Check/mock_config_sample.json
+++ b/RunCommand/Windows/Windows_Proxy_WinHTTP_WinINET_Check/mock_config_sample.json
@@ -1,0 +1,85 @@
+{
+  "profiles": {
+    "healthy": [
+      {
+        "name": "WinHTTP proxy parsed",
+        "status": "OK",
+        "detail": "Healthy"
+      },
+      {
+        "name": "WinINET proxy key readable",
+        "status": "OK",
+        "detail": "All dependencies available"
+      },
+      {
+        "name": "Proxy bypass list defined",
+        "status": "OK",
+        "detail": "Below threshold"
+      },
+      {
+        "name": "IMDS reachable without proxy",
+        "status": "OK",
+        "detail": "Baseline compliant"
+      },
+      {
+        "name": "WireServer reachable without proxy",
+        "status": "OK",
+        "detail": "Reachable"
+      }
+    ],
+    "degraded": [
+      {
+        "name": "WinHTTP proxy parsed",
+        "status": "OK",
+        "detail": "Operational with warnings"
+      },
+      {
+        "name": "WinINET proxy key readable",
+        "status": "WARN",
+        "detail": "One non-blocking issue"
+      },
+      {
+        "name": "Proxy bypass list defined",
+        "status": "WARN",
+        "detail": "Elevated but not failing"
+      },
+      {
+        "name": "IMDS reachable without proxy",
+        "status": "WARN",
+        "detail": "Mostly compliant"
+      },
+      {
+        "name": "WireServer reachable without proxy",
+        "status": "OK",
+        "detail": "Reachable with latency"
+      }
+    ],
+    "broken": [
+      {
+        "name": "WinHTTP proxy parsed",
+        "status": "FAIL",
+        "detail": "Blocking issue detected"
+      },
+      {
+        "name": "WinINET proxy key readable",
+        "status": "FAIL",
+        "detail": "Critical dependency unavailable"
+      },
+      {
+        "name": "Proxy bypass list defined",
+        "status": "WARN",
+        "detail": "High error rate"
+      },
+      {
+        "name": "IMDS reachable without proxy",
+        "status": "WARN",
+        "detail": "Drift detected"
+      },
+      {
+        "name": "WireServer reachable without proxy",
+        "status": "FAIL",
+        "detail": "Unreachable"
+      }
+    ]
+  }
+}

--- a/RunCommand/Windows/Windows_RDP_Certificate_Binding_Check/README.md
+++ b/RunCommand/Windows/Windows_RDP_Certificate_Binding_Check/README.md
@@ -1,0 +1,78 @@
+# Windows RDP Certificate Binding Check
+
+> **Tool ID:** RC-036 · **Bucket:** RDP / Connectivity · **Phase:** 2 (Deep diagnostic)
+
+## What It Does
+
+Validates RDP certificate binding and TLS readiness. Checks certificate thumbprint configuration, certificate presence in the local machine store, expiry status, NLA settings, and RDP port listener. Critical for diagnosing RDP failures caused by expired or missing certificates.
+
+| Check area | What is validated |
+|---|---|
+| Cert thumbprint | RDP certificate thumbprint configured |
+| Cert present | Bound certificate present in LM\\My store |
+| Cert expiry | Bound certificate not near expiry |
+| NLA setting | NLA setting readable |
+| Port listener | RDP port 3389 listening |
+
+## Run Command Constraints Met
+
+- ✅ PowerShell 5.1 only
+- ✅ No Az module required
+- ✅ No internet access needed
+- ✅ Output < 4 KB
+- ✅ No interactive prompts
+- ✅ Read-only (diagnostic only)
+
+## How to Run
+
+### Azure Run Command (recommended)
+Navigate to VM → Operations → Run Command → RunPowerShellScript → paste script.
+
+### Azure CLI
+```bash
+az vm run-command invoke -g <rg> -n <vm> --command-id RunPowerShellScript \
+  --scripts @Windows_RDP_Certificate_Binding_Check/Windows_RDP_Certificate_Binding_Check.ps1
+```
+
+### Mock test
+```powershell
+.\Windows_RDP_Certificate_Binding_Check.ps1 -MockConfig .\mock_config_sample.json -MockProfile broken
+```
+
+## Sample Output (Issues Detected)
+
+```
+=== Windows RDP Certificate Binding Check ===
+Check                                        Status
+-------------------------------------------- ------
+RDP certificate thumbprint configured        WARN
+Bound certificate present in LM\My           FAIL
+Bound certificate not near expiry            WARN
+NLA setting readable                         OK
+RDP port 3389 listening                      FAIL
+-- Decision --
+Likely cause severity                        FAIL   Hard configuration/service break
+Next action                                  OK     Follow README interpretation and remediate FAIL rows first
+-- More Info --
+Remediation references available             OK     See paired README Learn References
+
+=== RESULT: 1 OK / 2 FAIL / 2 WARN ===
+```
+
+## Interpretation Guide
+
+| FAIL/WARN condition | Likely cause | Quick fix | Learn link |
+|---|---|---|---|
+| **RDP certificate thumbprint configured** WARN | No certificate thumbprint is set in RDP-Tcp registry. RDP will use a self-signed cert (may cause warnings but usually works). | Check: `reg query "HKLM\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp" /v SSLCertificateSHA1Hash`. If needed, bind a certificate. | [Troubleshoot RDP general error](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-rdp-general-error) |
+| **Bound certificate present in LM\\My** FAIL | Certificate thumbprint is configured but the certificate is missing from `Cert:\LocalMachine\My`. RDP handshake will fail. | Re-enroll or import the certificate. Quick fix: clear thumbprint to fall back to self-signed: `reg delete "HKLM\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp" /v SSLCertificateSHA1Hash /f` | [Reset RDP](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/reset-rdp) |
+| **Bound certificate not near expiry** WARN | Certificate expires within 30 days. RDP will fail after expiry. | Renew the certificate before expiry. `Get-ChildItem Cert:\LocalMachine\My \| Where-Object { $_.NotAfter -lt (Get-Date).AddDays(30) }` to identify. | [Troubleshoot RDP general error](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-rdp-general-error) |
+| **NLA setting readable** WARN | Cannot read NLA (UserAuthentication) registry value. NLA enforcement state unknown. | Check: `reg query "HKLM\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp" /v UserAuthentication` — set to 1 for NLA enabled. | [CredSSP encryption oracle remediation](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/credssp-encryption-oracle-remediation) |
+| **RDP port 3389 listening** FAIL | Nothing listening on TCP 3389. TermService may be stopped, port changed, or another service conflict. | `Get-Service TermService \| Start-Service`. If port changed: `reg query "HKLM\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp" /v PortNumber`. | [Reset RDP](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/reset-rdp) |
+
+## Related Articles
+
+| Article | Link |
+|---|---|
+| Troubleshoot RDP general error | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-rdp-general-error) |
+| Reset RDP configuration | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/reset-rdp) |
+| CredSSP encryption oracle remediation | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/credssp-encryption-oracle-remediation) |

--- a/RunCommand/Windows/Windows_RDP_Certificate_Binding_Check/Windows_RDP_Certificate_Binding_Check.ps1
+++ b/RunCommand/Windows/Windows_RDP_Certificate_Binding_Check/Windows_RDP_Certificate_Binding_Check.ps1
@@ -1,0 +1,52 @@
+#Requires -Version 5.1
+[CmdletBinding()]
+param(
+  [string]$MockConfig,
+  [ValidateSet('healthy','degraded','broken')]
+  [string]$MockProfile = 'degraded'
+)
+$ErrorActionPreference='Continue'
+function Pad($s,$n){$s="$s";if($s.Length -ge $n){$s.Substring(0,$n)}else{$s.PadRight($n)}}
+$W=44
+$rows=New-Object System.Collections.Generic.List[object]
+function Add-Row($c,$s,$d=''){ $rows.Add([PSCustomObject]@{Check=$c;Status=$s;Detail=$d}); Write-Output ('{0} {1}' -f (Pad $c $W), $s) }
+
+Write-Output '=== Windows RDP Certificate Binding Check ==='
+Write-Output ('{0} {1}' -f (Pad 'Check' $W), 'Status')
+Write-Output (('-' * $W) + ' ------')
+
+$usedMock = $false
+if($MockConfig -and (Test-Path $MockConfig)){
+  $mock = Get-Content $MockConfig -Raw | ConvertFrom-Json
+  if($mock.profiles -and $mock.profiles.$MockProfile){
+    $usedMock = $true
+    foreach($i in $mock.profiles.$MockProfile){ Add-Row $i.name $i.status $i.detail }
+  }
+}
+
+if(-not $usedMock){
+  $rdp='HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp'
+  $thumb=(Get-ItemProperty $rdp -Name SSLCertificateSHA1Hash -ErrorAction SilentlyContinue).SSLCertificateSHA1Hash
+  Add-Row 'RDP certificate thumbprint configured' $(if($thumb){'OK'}else{'WARN'}) ''
+  $store = Get-ChildItem Cert:\LocalMachine\My -ErrorAction SilentlyContinue | Where-Object { $_.Thumbprint -eq $thumb }
+  Add-Row 'Bound certificate present in LM\\My' $(if($thumb -and $store){'OK'}elseif($thumb){'FAIL'}else{'WARN'}) ''
+  $exp = if($store){$store.NotAfter -gt (Get-Date).AddDays(14)}else{$false}
+  Add-Row 'Bound certificate not near expiry' $(if($store){if($exp){'OK'}else{'WARN'}}else{'WARN'}) ''
+  $nla=(Get-ItemProperty $rdp -Name UserAuthentication -ErrorAction SilentlyContinue).UserAuthentication
+  Add-Row 'NLA setting readable' $(if($null -ne $nla){'OK'}else{'WARN'}) ''
+  $listen = ((netstat -an) -match ':3389\s+.*LISTENING').Count -gt 0
+  Add-Row 'RDP port 3389 listening' $(if($listen){'OK'}else{'FAIL'}) ''
+}
+
+$fail=@($rows|Where-Object Status -eq 'FAIL').Count
+$warn=@($rows|Where-Object Status -eq 'WARN').Count
+Write-Output '-- Decision --'
+Add-Row 'Likely cause severity' $(if($fail -gt 0){'FAIL'}elseif($warn -gt 0){'WARN'}else{'OK'}) $(if($fail -gt 0){'Hard configuration/service break'}elseif($warn -gt 0){'Configuration drift or transient condition'}else{'No blocking signals'})
+Add-Row 'Next action' 'OK' $(if($fail -gt 0){'Follow README interpretation and remediate FAIL rows first'}elseif($warn -gt 0){'Review WARN rows and re-run after targeted fix'}else{'No immediate action'})
+Write-Output '-- More Info --'
+Add-Row 'Remediation references available' 'OK' 'See paired README Learn References'
+
+$ok=@($rows|Where-Object Status -eq 'OK').Count
+Write-Output ''
+Write-Output "=== RESULT: $ok OK / $fail FAIL / $warn WARN ==="
+$rows

--- a/RunCommand/Windows/Windows_RDP_Certificate_Binding_Check/mock_config_sample.json
+++ b/RunCommand/Windows/Windows_RDP_Certificate_Binding_Check/mock_config_sample.json
@@ -1,0 +1,85 @@
+{
+  "profiles": {
+    "healthy": [
+      {
+        "name": "RDP certificate thumbprint configured",
+        "status": "OK",
+        "detail": "Healthy"
+      },
+      {
+        "name": "Bound certificate present in LM\\My",
+        "status": "OK",
+        "detail": "All dependencies available"
+      },
+      {
+        "name": "Bound certificate not near expiry",
+        "status": "OK",
+        "detail": "Below threshold"
+      },
+      {
+        "name": "NLA setting readable",
+        "status": "OK",
+        "detail": "Baseline compliant"
+      },
+      {
+        "name": "RDP port 3389 listening",
+        "status": "OK",
+        "detail": "Reachable"
+      }
+    ],
+    "degraded": [
+      {
+        "name": "RDP certificate thumbprint configured",
+        "status": "OK",
+        "detail": "Operational with warnings"
+      },
+      {
+        "name": "Bound certificate present in LM\\My",
+        "status": "WARN",
+        "detail": "One non-blocking issue"
+      },
+      {
+        "name": "Bound certificate not near expiry",
+        "status": "WARN",
+        "detail": "Elevated but not failing"
+      },
+      {
+        "name": "NLA setting readable",
+        "status": "WARN",
+        "detail": "Mostly compliant"
+      },
+      {
+        "name": "RDP port 3389 listening",
+        "status": "OK",
+        "detail": "Reachable with latency"
+      }
+    ],
+    "broken": [
+      {
+        "name": "RDP certificate thumbprint configured",
+        "status": "FAIL",
+        "detail": "Blocking issue detected"
+      },
+      {
+        "name": "Bound certificate present in LM\\My",
+        "status": "FAIL",
+        "detail": "Critical dependency unavailable"
+      },
+      {
+        "name": "Bound certificate not near expiry",
+        "status": "WARN",
+        "detail": "High error rate"
+      },
+      {
+        "name": "NLA setting readable",
+        "status": "WARN",
+        "detail": "Drift detected"
+      },
+      {
+        "name": "RDP port 3389 listening",
+        "status": "FAIL",
+        "detail": "Unreachable"
+      }
+    ]
+  }
+}

--- a/RunCommand/Windows/Windows_RDP_Health_Snapshot/README.md
+++ b/RunCommand/Windows/Windows_RDP_Health_Snapshot/README.md
@@ -1,0 +1,105 @@
+# Windows RDP Health Snapshot
+
+> **Tool ID:** RC-001 · **Bucket:** VM-Responding / Cant-RDP-SSH · **Phase:** 1
+
+## What It Does
+
+Diagnoses the five most common **in-guest** causes of RDP connectivity failure on an Azure Windows VM:
+
+| Check area | What is validated |
+|---|---|
+| **Services** | TermService, Netlogon, Dnscache, LanmanWorkstation, LSM, BFE all Running |
+| **Registry** | `fDenyTSConnections = 0` (RDP not blocked by policy/GPO) |
+| **NLA** | `SecurityLayer` value is a valid setting (0/1/2) |
+| **Firewall** | RDP inbound rule enabled for port 3389; BFE running |
+| **Listener** | Port 3389 is in LISTENING state |
+
+The script is **read-only** — it makes no changes to the system.
+
+## Run Command Constraints Met
+
+- PowerShell 5.1 only (no `?.`, ternary, or PS7 syntax)
+- No Az module used
+- No internet access required
+- Output < 4 KB
+- No interactive prompts
+
+## How to Run
+
+### Azure Run Command (recommended)
+1. Go to your VM in the Azure portal
+2. Select **Operations → Run Command → RunPowerShellScript**
+3. Paste the contents of `Windows_RDP_Health_Snapshot.ps1`
+4. Select **Run** and wait for output
+
+### Azure CLI
+```bash
+az vm run-command invoke \
+  --resource-group <rg> \
+  --name <vm-name> \
+  --command-id RunPowerShellScript \
+  --scripts @Windows_RDP_Health_Snapshot.ps1
+```
+
+### Elevated PowerShell (inside VM)
+```powershell
+Set-ExecutionPolicy Bypass -Scope Process -Force
+.\Windows_RDP_Health_Snapshot.ps1
+```
+
+### Mock / Offline Test
+```powershell
+.\Windows_RDP_Health_Snapshot.ps1 -MockConfig .\mock_config_sample.json
+```
+
+## Sample Output (Healthy VM)
+
+```
+=== Windows RDP Health Snapshot ===
+Check                                        Status
+-------------------------------------------- ------
+-- Services --
+Remote Desktop Service (TermService)         OK
+Netlogon                                     OK
+DNS Client (Dnscache)                        OK
+Workstation (LanmanWorkstation)              OK
+Local Session Manager (LSM)                  OK
+Base Filtering Engine (BFE/Firewall)         OK
+-- Registry --
+fDenyTSConnections = 0 (RDP allowed)         OK
+NLA SecurityLayer: Negotiate                 OK
+-- Windows Firewall --
+RDP inbound rule enabled (port 3389)         OK
+BFE running (firewall enforcement)           OK
+-- RDP Listener --
+Port 3389 in LISTENING state                 OK
+
+=== RESULT: 11 OK / 0 FAIL / 0 WARN ===
+```
+
+## Mock Schema
+
+| Key path | Values |
+|---|---|
+| `services.<ServiceName>` | `"Running"` \| `"Stopped"` \| `"NotFound"` |
+| `registry.fDenyTSConnections` | `0` (OK) · `1` (FAIL) |
+| `registry.SecurityLayer` | `0` (RDP) · `1` (Negotiate) · `2` (NLA/SSL) |
+| `firewall.rdpRuleEnabled` | `true` / `false` |
+| `firewall.bfeRunning` | `true` / `false` |
+| `listener.port3389Listening` | `true` / `false` |
+
+## Interpretation Guide
+
+| FAIL condition | Likely cause | Quick fix |
+|---|---|---|
+| TermService FAIL | Service crashed or disabled | `Set-Service TermService -StartupType Auto; Start-Service TermService` |
+| fDenyTSConnections = 1 | GPO or manual policy block | Check `HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server` |
+| RDP firewall rule FAIL | Rule deleted or custom FW profile | `Enable-NetFirewallRule -DisplayGroup 'Remote Desktop'` |
+| Port 3389 not listening | Service stopped OR listener misconfigured | Restart TermService, check `netsh interface portproxy` |
+| BFE FAIL | Windows Firewall enforcement broken | Critical — restart BFE and associated services |
+
+## Related Articles
+
+- [Troubleshoot RDP connections to an Azure VM](https://learn.microsoft.com/azure/virtual-machines/troubleshooting/troubleshoot-rdp-connection)
+- [Detailed troubleshooting steps for RDP](https://learn.microsoft.com/azure/virtual-machines/troubleshooting/detailed-troubleshoot-rdp)
+- [Remote Desktop Services issues](https://learn.microsoft.com/azure/virtual-machines/troubleshooting/troubleshoot-remote-desktop-services-issues)

--- a/RunCommand/Windows/Windows_RDP_Health_Snapshot/Windows_RDP_Health_Snapshot.ps1
+++ b/RunCommand/Windows/Windows_RDP_Health_Snapshot/Windows_RDP_Health_Snapshot.ps1
@@ -1,0 +1,137 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Diagnoses RDP connectivity blockers on a running Azure Windows VM.
+.DESCRIPTION
+    Checks the five most common in-guest causes of RDP failure:
+      1. Critical service state (TermService, Netlogon, Dnscache, etc.)
+      2. fDenyTSConnections registry flag
+      3. NLA / SecurityLayer setting
+      4. Windows Firewall inbound rule for port 3389
+      5. RDP listener state (current active connections / listen port)
+
+    Designed for Azure Run Command: no Az module, no internet access,
+    PowerShell 5.1 only, output fits within the 4 KB portal limit.
+.PARAMETER MockConfig
+    Path to a JSON file that replaces live system reads for offline testing.
+.NOTES
+    Author  : CSS Core Compute SPM
+    Version : 1.0.0
+    Tool ID : RC-001
+    Bucket  : VM-Responding / Cant-RDP-SSH
+    Repo    : Azure/azure-support-scripts  RunCommand/Windows/Windows_RDP_Health_Snapshot
+#>
+[CmdletBinding()]
+param(
+  [string]$MockConfig,
+  [ValidateSet('healthy','degraded','broken')]
+  [string]$MockProfile = 'degraded'
+)
+$ErrorActionPreference = 'Continue'
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+function Pad($s, $n) { $s = "$s"; if ($s.Length -ge $n) { $s.Substring(0,$n) } else { $s.PadRight($n) } }
+$W = 44
+$findings = [System.Collections.Generic.List[psobject]]::new()
+
+function Add-Row($check, $status, $detail = '') {
+    $script:findings.Add([PSCustomObject]@{ Check = $check; Status = $status; Detail = $detail })
+    Write-Output ('{0} {1}' -f (Pad $check $W), $status)
+}
+
+# ── mock vs live ──────────────────────────────────────────────────────────────
+$mock = $null
+if ($MockConfig -and (Test-Path $MockConfig)) {
+    $mock = Get-Content $MockConfig -Raw | ConvertFrom-Json
+}
+
+# ── header ────────────────────────────────────────────────────────────────────
+Write-Output '=== Windows RDP Health Snapshot ==='
+Write-Output ('{0} {1}' -f (Pad 'Check' $W), 'Status')
+Write-Output (('-' * $W) + ' ------')
+
+$usedMock = $false
+if ($MockConfig -and (Test-Path $MockConfig)) {
+  if ($mock.profiles -and $mock.profiles.$MockProfile) {
+    $usedMock = $true
+    foreach ($i in $mock.profiles.$MockProfile) { Add-Row $i.name $i.status $i.detail }
+  }
+}
+if (-not $usedMock) {
+
+# -- Services -----------------------------------------------------------------
+Write-Output '-- Services --'
+$svcNames = @('TermService','Netlogon','Dnscache','LanmanWorkstation','LSM','BFE')
+$svcLabels = @{
+    TermService='Remote Desktop Service (TermService)'; Netlogon='Netlogon';
+    Dnscache='DNS Client (Dnscache)'; LanmanWorkstation='Workstation (LanmanWorkstation)';
+    LSM='Local Session Manager (LSM)'; BFE='Base Filtering Engine (BFE/Firewall)'
+}
+foreach ($sn in $svcNames) {
+    if ($mock) {
+        $st = $mock.legacy.services.$sn
+    } else {
+        $svc = Get-Service $sn -ErrorAction SilentlyContinue
+        $st = if ($svc) { $svc.Status.ToString() } else { 'NotFound' }
+    }
+    $status = if ($st -eq 'Running') { 'OK' } else { 'FAIL' }
+    Add-Row $svcLabels[$sn] $status $st
+}
+
+# -- Registry -----------------------------------------------------------------
+Write-Output '-- Registry --'
+if ($mock) {
+    $fDeny = [int]$mock.legacy.registry.fDenyTSConnections
+    $secLayer = [int]$mock.legacy.registry.SecurityLayer
+} else {
+    $fDeny = (Get-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server' -Name fDenyTSConnections -ErrorAction SilentlyContinue).fDenyTSConnections
+    $secLayer = (Get-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp' -Name SecurityLayer -ErrorAction SilentlyContinue).SecurityLayer
+}
+Add-Row ('fDenyTSConnections = {0} ({1})' -f $fDeny, (if ($fDeny -eq 0) { 'RDP allowed' } else { 'RDP BLOCKED' })) (if ($fDeny -eq 0) { 'OK' } else { 'FAIL' }) ''
+$nlaLabel = switch ($secLayer) { 0 { 'RDP' } 1 { 'Negotiate' } 2 { 'NLA/SSL' } default { 'Unknown' } }
+Add-Row "NLA SecurityLayer: $nlaLabel" 'OK' ''
+
+# -- Windows Firewall ---------------------------------------------------------
+Write-Output '-- Windows Firewall --'
+if ($mock) {
+    $rdpRule = [bool]$mock.legacy.firewall.rdpRuleEnabled
+    $bfeRun  = [bool]$mock.legacy.firewall.bfeRunning
+} else {
+    $rdpRule = $false
+    try {
+        $rules = Get-NetFirewallRule -DisplayGroup 'Remote Desktop' -ErrorAction SilentlyContinue |
+                 Where-Object { $_.Enabled -eq 'True' -and $_.Direction -eq 'Inbound' }
+        $rdpRule = (@($rules).Count -gt 0)
+    } catch { }
+    $bfeSvc = Get-Service BFE -ErrorAction SilentlyContinue
+    $bfeRun = ($bfeSvc -and $bfeSvc.Status -eq 'Running')
+}
+Add-Row 'RDP inbound rule enabled (port 3389)' (if ($rdpRule) { 'OK' } else { 'FAIL' }) ''
+Add-Row 'BFE running (firewall enforcement)' (if ($bfeRun) { 'OK' } else { 'FAIL' }) ''
+
+# -- RDP Listener -------------------------------------------------------------
+Write-Output '-- RDP Listener --'
+if ($mock) {
+    $listening = [bool]$mock.legacy.listener.port3389Listening
+} else {
+    $listening = $false
+    $tcp = netstat -an 2>$null | Select-String ':3389\s+.*LISTENING'
+    if ($tcp) { $listening = $true }
+}
+Add-Row 'Port 3389 in LISTENING state' (if ($listening) { 'OK' } else { 'FAIL' }) ''
+
+}
+
+$fail = @($findings | Where-Object Status -eq 'FAIL').Count
+$warn = @($findings | Where-Object Status -eq 'WARN').Count
+Write-Output '-- Decision --'
+Add-Row 'Likely cause severity' $(if($fail -gt 0){'FAIL'}elseif($warn -gt 0){'WARN'}else{'OK'}) $(if($fail -gt 0){'Hard configuration/service break'}elseif($warn -gt 0){'Configuration drift or transient condition'}else{'No blocking signals'})
+Add-Row 'Next action' 'OK' $(if($fail -gt 0){'Follow README interpretation and remediate FAIL rows first'}elseif($warn -gt 0){'Review WARN rows and re-run after targeted fix'}else{'No immediate action'})
+Write-Output '-- More Info --'
+Add-Row 'Remediation references available' 'OK' 'See paired README Learn References'
+
+$ok = @($findings | Where-Object Status -eq 'OK').Count
+Write-Output ''
+Write-Output "=== RESULT: $ok OK / $fail FAIL / $warn WARN ==="
+
+$findings

--- a/RunCommand/Windows/Windows_RDP_Health_Snapshot/mock_config_sample.json
+++ b/RunCommand/Windows/Windows_RDP_Health_Snapshot/mock_config_sample.json
@@ -1,0 +1,55 @@
+{
+  "profiles": {
+    "healthy": [
+      {
+        "name": "RDP inbound rule enabled (port 3389)",
+        "status": "OK",
+        "detail": "Healthy"
+      },
+      {
+        "name": "BFE running (firewall enforcement)",
+        "status": "OK",
+        "detail": "All dependencies available"
+      },
+      {
+        "name": "Port 3389 in LISTENING state",
+        "status": "OK",
+        "detail": "Below threshold"
+      }
+    ],
+    "degraded": [
+      {
+        "name": "RDP inbound rule enabled (port 3389)",
+        "status": "OK",
+        "detail": "Operational with warnings"
+      },
+      {
+        "name": "BFE running (firewall enforcement)",
+        "status": "WARN",
+        "detail": "One non-blocking issue"
+      },
+      {
+        "name": "Port 3389 in LISTENING state",
+        "status": "OK",
+        "detail": "Elevated but not failing"
+      }
+    ],
+    "broken": [
+      {
+        "name": "RDP inbound rule enabled (port 3389)",
+        "status": "FAIL",
+        "detail": "Blocking issue detected"
+      },
+      {
+        "name": "BFE running (firewall enforcement)",
+        "status": "FAIL",
+        "detail": "Critical dependency unavailable"
+      },
+      {
+        "name": "Port 3389 in LISTENING state",
+        "status": "FAIL",
+        "detail": "High error rate"
+      }
+    ]
+  }
+}

--- a/RunCommand/Windows/Windows_RPC_EndpointMapper_Check/README.md
+++ b/RunCommand/Windows/Windows_RPC_EndpointMapper_Check/README.md
@@ -1,0 +1,81 @@
+# Windows RPC Endpoint Mapper Check
+
+> **Tool ID:** RC-040 · **Bucket:** Services · **Phase:** 2 (Deep diagnostic)
+
+## What It Does
+
+Validates the RPC (Remote Procedure Call) infrastructure that underpins Windows interprocess communication. Checks the RPC Endpoint Mapper service, DCOM Launch service, port 135 listener status, dynamic port range, recent RPC errors, and WMI repository health. RPC failures cascade into AD authentication, WMI queries, and many management tools failing.
+
+| Check area | What is validated |
+|---|---|
+| RPC service | RPC Endpoint Mapper service running |
+| DCOM Launch | DCOM Server Process Launcher service running |
+| Port 135 | Port 135 listening for RPC |
+| Dynamic ports | RPC dynamic port range configured |
+| RPC errors | RPC-related errors in System log (7 days) |
+| WMI health | WMI repository consistency |
+
+## Run Command Constraints Met
+
+- ✅ PowerShell 5.1 only
+- ✅ No Az module required
+- ✅ No internet access needed
+- ✅ Output < 4 KB
+- ✅ No interactive prompts
+- ✅ Read-only (diagnostic only)
+
+## How to Run
+
+### Azure Run Command (recommended)
+Navigate to VM → Operations → Run Command → RunPowerShellScript → paste script.
+
+### Azure CLI
+```bash
+az vm run-command invoke -g <rg> -n <vm> --command-id RunPowerShellScript \
+  --scripts @Windows_RPC_EndpointMapper_Check/Windows_RPC_EndpointMapper_Check.ps1
+```
+
+### Mock test
+```powershell
+.\Windows_RPC_EndpointMapper_Check.ps1 -MockConfig .\mock_config_sample.json -MockProfile broken
+```
+
+## Sample Output (Issues Detected)
+
+```
+=== Windows RPC Endpoint Mapper Check ===
+Check                                        Status
+-------------------------------------------- ------
+RPC Endpoint Mapper service                  FAIL
+DCOM Launch service                          FAIL
+RPC port range (135 listening)               FAIL
+RPC dynamic port range                       WARN
+RPC errors in System log (7d)                FAIL
+WMI repository healthy                       WARN
+-- Decision --
+Likely cause severity                        FAIL   Hard configuration/service break
+Next action                                  OK     Follow README interpretation and remediate FAIL rows first
+-- More Info --
+Remediation references available             OK     See paired README Learn References
+
+=== RESULT: 0 OK / 4 FAIL / 2 WARN ===
+```
+
+## Interpretation Guide
+
+| FAIL/WARN condition | Likely cause | Quick fix | Learn link |
+|---|---|---|---|
+| **RPC Endpoint Mapper service** FAIL | RpcSs service stopped. All RPC-dependent operations (WMI, DCOM, AD auth, many management tools) will fail. | `Set-Service RpcSs -StartupType Automatic; Start-Service RpcSs` — this is a critical system service, should never be disabled | [Troubleshoot RDP general error](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-rdp-general-error) |
+| **DCOM Launch service** FAIL | DcomLaunch service stopped. COM+ applications and DCOM servers cannot start. | `Start-Service DcomLaunch` — dependency of many Windows services including WMI | [RPC troubleshooting](https://learn.microsoft.com/troubleshoot/windows-server/networking/rpc-errors-troubleshooting) |
+| **RPC port range (135 listening)** FAIL | TCP 135 not listening. RPC clients cannot resolve endpoints. May indicate RpcSs crash or firewall block. | Verify: `Test-NetConnection -ComputerName localhost -Port 135`. Enable firewall rule or restart RpcSs. | [RPC Endpoint Mapper](https://learn.microsoft.com/troubleshoot/windows-server/networking/rpc-errors-troubleshooting) |
+| **RPC dynamic port range** WARN | Dynamic port range is non-standard or restricted. Default: 49152-65535 (16384 ports). Too few ports causes RPC exhaustion under load. | `netsh int ipv4 show dynamicport tcp` to check. Reset: `netsh int ipv4 set dynamicport tcp start=49152 num=16384` | [Configure RPC dynamic port range](https://learn.microsoft.com/troubleshoot/windows-server/networking/default-dynamic-port-range-tcpip-702) |
+| **RPC errors in System log (7d)** WARN | RPC error events found. May indicate transient connectivity issues, firewall blocks, or service instability. | `Get-WinEvent -FilterHashtable @{LogName='System'; ProviderName='Microsoft-Windows-RPC-Events'; StartTime=(Get-Date).AddDays(-7)}` | [RPC errors troubleshooting](https://learn.microsoft.com/troubleshoot/windows-server/networking/rpc-errors-troubleshooting) |
+| **WMI repository healthy** WARN | WMI repository may be corrupted. WMI queries (used by monitoring, SCOM, extensions) will fail. | `winmgmt /verifyrepository` — if inconsistent: `winmgmt /salvagerepository` | [WMI troubleshooting](https://learn.microsoft.com/troubleshoot/windows-server/system-management-components/scenario-guide-troubleshoot-wmi-connectivity) |
+
+## Related Articles
+
+| Article | Link |
+|---|---|
+| RPC errors troubleshooting | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/windows-server/networking/rpc-errors-troubleshooting) |
+| Default dynamic port range | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/windows-server/networking/default-dynamic-port-range-tcpip-702) |
+| RDP general error troubleshooting | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-rdp-general-error) |

--- a/RunCommand/Windows/Windows_RPC_EndpointMapper_Check/Windows_RPC_EndpointMapper_Check.ps1
+++ b/RunCommand/Windows/Windows_RPC_EndpointMapper_Check/Windows_RPC_EndpointMapper_Check.ps1
@@ -1,0 +1,72 @@
+#Requires -Version 5.1
+[CmdletBinding()]
+param(
+  [string]$MockConfig,
+  [ValidateSet('healthy','degraded','broken')]
+  [string]$MockProfile = 'degraded'
+)
+$ErrorActionPreference='Continue'
+function Pad($s,$n){$s="$s";if($s.Length -ge $n){$s.Substring(0,$n)}else{$s.PadRight($n)}}
+$W=44
+$rows=New-Object System.Collections.Generic.List[object]
+function Add-Row($c,$s,$d=''){ $rows.Add([PSCustomObject]@{Check=$c;Status=$s;Detail=$d}); Write-Output ('{0} {1}' -f (Pad $c $W), $s) }
+
+Write-Output '=== Windows RPC Endpoint Mapper Check ==='
+Write-Output ('{0} {1}' -f (Pad 'Check' $W), 'Status')
+Write-Output (('-' * $W) + ' ------')
+
+$usedMock = $false
+if($MockConfig -and (Test-Path $MockConfig)){
+  $mock = Get-Content $MockConfig -Raw | ConvertFrom-Json
+  if($mock.profiles -and $mock.profiles.$MockProfile){
+    $usedMock = $true
+    foreach($i in $mock.profiles.$MockProfile){ Add-Row $i.name $i.status $i.detail }
+  }
+}
+
+if(-not $usedMock){
+  # Probe: RPC Endpoint Mapper service
+  $rpc = Get-Service RpcSs -ErrorAction SilentlyContinue
+  $_s = if(!$rpc -or $rpc.Status -ne "Running"){'FAIL'}elseif($rpc -and $rpc.Status -eq "Running"){'OK'}else{'WARN'}
+  Add-Row 'RPC Endpoint Mapper service' $_s ("Status=$(if($rpc){$rpc.Status}else{'NotFound'})")
+
+  # Probe: DCOM Launch service
+  $dcom = Get-Service DcomLaunch -ErrorAction SilentlyContinue
+  $_s = if(!$dcom -or $dcom.Status -ne "Running"){'FAIL'}elseif($dcom -and $dcom.Status -eq "Running"){'OK'}else{'WARN'}
+  Add-Row 'DCOM Launch service' $_s ("Status=$(if($dcom){$dcom.Status}else{'NotFound'})")
+
+  # Probe: RPC port range (135 listening)
+  $p135 = Get-NetTCPConnection -LocalPort 135 -State Listen -ErrorAction SilentlyContinue; $p135Ok = @($p135).Count -gt 0
+  $_s = if(!$p135Ok){'FAIL'}elseif($p135Ok){'OK'}else{'WARN'}
+  Add-Row 'RPC port range (135 listening)' $_s ("Port135=$p135Ok")
+
+  # Probe: RPC dynamic port range
+  $rpcRange = netsh int ipv4 show dynamicport tcp 2>&1; $rpcPorts = if($rpcRange -match "Number of Ports.*:\s*(\d+)"){[int]$Matches[1]}else{0}
+  $_s = if($rpcPorts -ge 16384){'OK'}elseif($rpcPorts -lt 16384){'WARN'}else{'FAIL'}
+  Add-Row 'RPC dynamic port range' $_s ("DynPorts=$rpcPorts")
+
+  # Probe: RPC errors in System log (7d)
+  $rpcErr = Get-WinEvent -FilterHashtable @{LogName="System";Id=1753,1722;StartTime=(Get-Date).AddDays(-7)} -MaxEvents 10 -ErrorAction SilentlyContinue; $rpcErrCount = @($rpcErr).Count
+  $_s = if($rpcErrCount -eq 0){'OK'}elseif($rpcErrCount -le 3){'WARN'}else{'FAIL'}
+  Add-Row 'RPC errors in System log (7d)' $_s ("RPCErrors=$rpcErrCount")
+
+  # Probe: WMI repository healthy
+  $wmi = winmgmt /verifyrepository 2>&1; $wmiOk = $wmi -match "consistent"
+  $_s = if($wmiOk){'OK'}elseif(!$wmiOk){'WARN'}else{'FAIL'}
+  Add-Row 'WMI repository healthy' $_s ("WMI=$wmi")
+
+}
+
+$fail=@($rows|Where-Object Status -eq 'FAIL').Count
+$warn=@($rows|Where-Object Status -eq 'WARN').Count
+Write-Output '-- Decision --'
+Add-Row 'Likely cause severity' $(if($fail -gt 0){'FAIL'}elseif($warn -gt 0){'WARN'}else{'OK'}) $(if($fail -gt 0){'Hard configuration/service break'}elseif($warn -gt 0){'Configuration drift or transient condition'}else{'No blocking signals'})
+Add-Row 'Next action' 'OK' $(if($fail -gt 0){'Follow README interpretation and remediate FAIL rows first'}elseif($warn -gt 0){'Review WARN rows and re-run after targeted fix'}else{'No immediate action'})
+Write-Output '-- More Info --'
+Add-Row 'Remediation references available' 'OK' 'See paired README Learn References'
+
+$ok=@($rows|Where-Object Status -eq 'OK').Count
+Write-Output ''
+Write-Output "=== RESULT: $ok OK / $fail FAIL / $warn WARN ==="
+$rows
+

--- a/RunCommand/Windows/Windows_RPC_EndpointMapper_Check/mock_config_sample.json
+++ b/RunCommand/Windows/Windows_RPC_EndpointMapper_Check/mock_config_sample.json
@@ -1,0 +1,100 @@
+{
+  "profiles": {
+    "healthy": [
+      {
+        "name": "RPC Endpoint Mapper service",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "DCOM Launch service",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "RPC port range (135 listening)",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "RPC dynamic port range",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "RPC errors in System log (7d)",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "WMI repository healthy",
+        "status": "OK",
+        "detail": "Healthy profile"
+      }
+    ],
+    "broken": [
+      {
+        "name": "RPC Endpoint Mapper service",
+        "status": "FAIL",
+        "detail": "Critical failure detected"
+      },
+      {
+        "name": "DCOM Launch service",
+        "status": "FAIL",
+        "detail": "Critical failure detected"
+      },
+      {
+        "name": "RPC port range (135 listening)",
+        "status": "WARN",
+        "detail": "Degraded state"
+      },
+      {
+        "name": "RPC dynamic port range",
+        "status": "OK",
+        "detail": "Operational"
+      },
+      {
+        "name": "RPC errors in System log (7d)",
+        "status": "WARN",
+        "detail": "Degraded state"
+      },
+      {
+        "name": "WMI repository healthy",
+        "status": "OK",
+        "detail": "Operational"
+      }
+    ],
+    "degraded": [
+      {
+        "name": "RPC Endpoint Mapper service",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "DCOM Launch service",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "RPC port range (135 listening)",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "RPC dynamic port range",
+        "status": "WARN",
+        "detail": "Configuration drift detected"
+      },
+      {
+        "name": "RPC errors in System log (7d)",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "WMI repository healthy",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      }
+    ]
+  }
+}

--- a/RunCommand/Windows/Windows_ReliabilityMonitor_Event_Signal/README.md
+++ b/RunCommand/Windows/Windows_ReliabilityMonitor_Event_Signal/README.md
@@ -1,0 +1,120 @@
+# Windows ReliabilityMonitor Event Signal
+
+> **Tool ID:** RC-038 · **Bucket:** Reliability · **Phase:** 2 (Deep diagnostic)
+
+## What It Does
+
+Scans Windows event logs for reliability signals that indicate system instability. Counts application failures (crashes), application hangs, system BSODs, service terminations, disk errors, and unexpected shutdowns over recent time windows. Provides a quick health snapshot similar to the Windows Reliability Monitor but remotely accessible via Run Command.
+
+## Threshold Logic (from script)
+
+Use this table to interpret status transitions exactly as the script calculates them.
+
+| Check | Data source | Window | OK | WARN | FAIL |
+|---|---|---|---|---|---|
+| Application failures | Application log, Event ID 1000 | 7 days | 0 events | 1-5 events | >5 events |
+| Application hangs | Application log, Event ID 1002 | 7 days | 0 events | 1-3 events | >3 events |
+| Windows failures/BSODs | System log, Event ID 1001, provider `Microsoft-Windows-WER-SystemErrorReporting` | 30 days | 0 events | 1-2 events | >2 events |
+| Service terminations | System log, Event ID 7034 | 7 days | 0 events | 1-5 events | >5 events |
+| Disk errors | System log, Event IDs 7/11/51 | 7 days | 0 events | 1-3 events | >3 events |
+| Unexpected shutdowns | System log, Event ID 6008 | 14 days | 0 events | 1-2 events | >2 events |
+
+## Engineer Investigation Flow
+
+1. Treat any `FAIL` row as priority one and resolve in this order: disk errors -> BSODs -> unexpected shutdowns -> service terminations -> app failures/hangs.
+2. Confirm time correlation first. Pull all implicated events with timestamps and align to Azure Activity Log operations.
+3. If both disk and crash signals fail, capture crash artifacts before reboot/redeploy actions.
+4. If only app-level signals fail, triage by top crashing process names and recency, then isolate infra versus workload fault domain.
+5. Re-run this script after each fix batch and compare result trend, not only single-run status.
+
+### Correlation commands
+
+```powershell
+# Event timelines by probe family
+Get-WinEvent -FilterHashtable @{LogName='Application'; Id=1000; StartTime=(Get-Date).AddDays(-7)}
+Get-WinEvent -FilterHashtable @{LogName='Application'; Id=1002; StartTime=(Get-Date).AddDays(-7)}
+Get-WinEvent -FilterHashtable @{LogName='System'; Id=1001; ProviderName='Microsoft-Windows-WER-SystemErrorReporting'; StartTime=(Get-Date).AddDays(-30)}
+Get-WinEvent -FilterHashtable @{LogName='System'; Id=7034; StartTime=(Get-Date).AddDays(-7)}
+Get-WinEvent -FilterHashtable @{LogName='System'; Id=7,11,51; StartTime=(Get-Date).AddDays(-7)}
+Get-WinEvent -FilterHashtable @{LogName='System'; Id=6008; StartTime=(Get-Date).AddDays(-14)}
+```
+
+| Check area | What is validated |
+|---|---|
+| App failures | Application crash events (7 days) |
+| App hangs | Application hang/not responding events (7 days) |
+| System crashes | Windows failures / BSODs (30 days) |
+| Service terminations | Unexpected service termination events (7 days) |
+| Disk errors | Disk read/write error events (7 days) |
+| Unexpected shutdowns | Unclean shutdown events (14 days) |
+
+## Run Command Constraints Met
+
+- ✅ PowerShell 5.1 only
+- ✅ No Az module required
+- ✅ No internet access needed
+- ✅ Output < 4 KB
+- ✅ No interactive prompts
+- ✅ Read-only (diagnostic only)
+
+## How to Run
+
+### Azure Run Command (recommended)
+Navigate to VM → Operations → Run Command → RunPowerShellScript → paste script.
+
+### Azure CLI
+```bash
+az vm run-command invoke -g <rg> -n <vm> --command-id RunPowerShellScript \
+  --scripts @Windows_ReliabilityMonitor_Event_Signal/Windows_ReliabilityMonitor_Event_Signal.ps1
+```
+
+### Mock test
+```powershell
+.\Windows_ReliabilityMonitor_Event_Signal.ps1 -MockConfig .\mock_config_sample.json -MockProfile broken
+```
+
+## Sample Output (Issues Detected)
+
+```
+=== Windows ReliabilityMonitor Event Signal ===
+Check                                        Status
+-------------------------------------------- ------
+Application failures (7d)                    FAIL
+Application hangs (7d)                       WARN
+Windows failures/BSODs (30d)                 FAIL
+Service termination events (7d)              WARN
+Disk errors (7d)                             FAIL
+Unexpected shutdown events (14d)             FAIL
+-- Decision --
+Likely cause severity                        FAIL   Hard configuration/service break
+Next action                                  OK     Follow README interpretation and remediate FAIL rows first
+-- More Info --
+Remediation references available             OK     See paired README Learn References
+
+=== RESULT: 0 OK / 4 FAIL / 2 WARN ===
+```
+
+## Interpretation Guide
+
+| FAIL/WARN condition | Likely cause | Quick fix | Learn link |
+|---|---|---|---|
+| **Application failures (7d)** FAIL | Frequent application crashes detected. May indicate incompatible software, missing dependencies, or memory corruption. | `Get-WinEvent -FilterHashtable @{LogName='Application'; Id=1000; StartTime=(Get-Date).AddDays(-7)}` to identify crashing apps. Update or reinstall offending application. | [Troubleshoot app connection issues](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-app-connection) |
+| **Application hangs (7d)** WARN | Applications freezing (Event ID 1002). May indicate resource contention (CPU, memory, disk) or deadlocks. | Check concurrent resource usage. `Get-WinEvent -FilterHashtable @{LogName='Application'; Id=1002; StartTime=(Get-Date).AddDays(-7)}` to identify hanging processes. | [Troubleshoot high CPU issues](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-high-cpu-issues-azure-windows-vm) |
+| **Windows failures/BSODs (30d)** FAIL | System-level blue-screen crashes. Correlate with Windows_CrashHistory_Bugcheck_Summary for dump analysis and bugcheck codes. | Collect MEMORY.DMP for analysis. Check Event ID 1001 (BugCheck). Run `Windows_CrashHistory_Bugcheck_Summary` for detailed crash data. | [Troubleshoot common blue-screen errors](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-common-blue-screen-error) |
+| **Service termination events (7d)** WARN | Services terminated unexpectedly (Event ID 7034). May indicate service crashes, dependency failures, or forced kills. | `Get-WinEvent -FilterHashtable @{LogName='System'; Id=7034; StartTime=(Get-Date).AddDays(-7)}` to identify failing services. Check service dependencies. | [Understand VM reboot](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/understand-vm-reboot) |
+| **Disk errors (7d)** FAIL | Disk hardware or logical errors detected. May indicate failing disk (rare on Azure managed disks) or file system corruption. | Run `chkdsk C: /scan` (online check). Review Event ID 7, 51, 52 in System log. For persistent errors, consider VM redeployment. | [Troubleshoot data disk issues](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-data-disk-caching) |
+| **Unexpected shutdown events (14d)** FAIL | Event ID 6008 (unexpected shutdown) — VM lost power without clean shutdown. May be Azure host maintenance, crash, or forced reboot. | Cross-reference with Azure Activity Log: Portal → VM → Activity Log. Check for `Microsoft.Compute/virtualMachines/restart` events. | [Unexpected VM reboot root cause analysis](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/unexpected-vm-reboot-root-cause-analysis) |
+
+## Related Articles
+
+| Article | Link |
+|---|---|
+| Understand Azure VM reboot | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/understand-vm-reboot) |
+| Unexpected VM reboot root cause analysis | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/unexpected-vm-reboot-root-cause-analysis) |
+| Troubleshoot common blue-screen errors | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-common-blue-screen-error) |
+
+## Internal handoff notes
+
+- Include probe counts from `Detail` in case notes (`AppCrashes`, `AppHangs`, `SystemCrashes`, `SvcTerminations`, `DiskErrors`, `UnexpectedShutdowns`).
+- Capture whether failures are bursty (single date cluster) or persistent (multi-day spread).
+- When escalation is needed, provide top 3 event IDs by frequency and first/last seen timestamps.

--- a/RunCommand/Windows/Windows_ReliabilityMonitor_Event_Signal/Windows_ReliabilityMonitor_Event_Signal.ps1
+++ b/RunCommand/Windows/Windows_ReliabilityMonitor_Event_Signal/Windows_ReliabilityMonitor_Event_Signal.ps1
@@ -1,0 +1,72 @@
+#Requires -Version 5.1
+[CmdletBinding()]
+param(
+  [string]$MockConfig,
+  [ValidateSet('healthy','degraded','broken')]
+  [string]$MockProfile = 'degraded'
+)
+$ErrorActionPreference='Continue'
+function Pad($s,$n){$s="$s";if($s.Length -ge $n){$s.Substring(0,$n)}else{$s.PadRight($n)}}
+$W=44
+$rows=New-Object System.Collections.Generic.List[object]
+function Add-Row($c,$s,$d=''){ $rows.Add([PSCustomObject]@{Check=$c;Status=$s;Detail=$d}); Write-Output ('{0} {1}' -f (Pad $c $W), $s) }
+
+Write-Output '=== Windows Reliability Monitor Event Signal ==='
+Write-Output ('{0} {1}' -f (Pad 'Check' $W), 'Status')
+Write-Output (('-' * $W) + ' ------')
+
+$usedMock = $false
+if($MockConfig -and (Test-Path $MockConfig)){
+  $mock = Get-Content $MockConfig -Raw | ConvertFrom-Json
+  if($mock.profiles -and $mock.profiles.$MockProfile){
+    $usedMock = $true
+    foreach($i in $mock.profiles.$MockProfile){ Add-Row $i.name $i.status $i.detail }
+  }
+}
+
+if(-not $usedMock){
+  # Probe: Application failures (7d)
+  $af = Get-WinEvent -FilterHashtable @{LogName="Application";Id=1000;StartTime=(Get-Date).AddDays(-7)} -MaxEvents 20 -ErrorAction SilentlyContinue; $afCount = @($af).Count
+  $_s = if($afCount -eq 0){'OK'}elseif($afCount -le 5){'WARN'}else{'FAIL'}
+  Add-Row 'Application failures (7d)' $_s ("AppCrashes=$afCount")
+
+  # Probe: Application hangs (7d)
+  $ah = Get-WinEvent -FilterHashtable @{LogName="Application";Id=1002;StartTime=(Get-Date).AddDays(-7)} -MaxEvents 20 -ErrorAction SilentlyContinue; $ahCount = @($ah).Count
+  $_s = if($ahCount -eq 0){'OK'}elseif($ahCount -le 3){'WARN'}else{'FAIL'}
+  Add-Row 'Application hangs (7d)' $_s ("AppHangs=$ahCount")
+
+  # Probe: Windows failures/BSODs (30d)
+  $wf = Get-WinEvent -FilterHashtable @{LogName="System";Id=1001;ProviderName="Microsoft-Windows-WER-SystemErrorReporting";StartTime=(Get-Date).AddDays(-30)} -MaxEvents 10 -ErrorAction SilentlyContinue; $wfCount = @($wf).Count
+  $_s = if($wfCount -gt 2){'FAIL'}elseif($wfCount -eq 0){'OK'}else{'WARN'}
+  Add-Row 'Windows failures/BSODs (30d)' $_s ("SystemCrashes=$wfCount")
+
+  # Probe: Service termination events (7d)
+  $st = Get-WinEvent -FilterHashtable @{LogName="System";Id=7034;StartTime=(Get-Date).AddDays(-7)} -MaxEvents 20 -ErrorAction SilentlyContinue; $stCount = @($st).Count
+  $_s = if($stCount -eq 0){'OK'}elseif($stCount -le 5){'WARN'}else{'FAIL'}
+  Add-Row 'Service termination events (7d)' $_s ("SvcTerminations=$stCount")
+
+  # Probe: Disk errors (7d)
+  $de = Get-WinEvent -FilterHashtable @{LogName="System";Id=7,11,51;StartTime=(Get-Date).AddDays(-7)} -MaxEvents 10 -ErrorAction SilentlyContinue; $deCount = @($de).Count
+  $_s = if($deCount -gt 3){'FAIL'}elseif($deCount -eq 0){'OK'}else{'WARN'}
+  Add-Row 'Disk errors (7d)' $_s ("DiskErrors=$deCount")
+
+  # Probe: Unexpected shutdown events (14d)
+  $us = Get-WinEvent -FilterHashtable @{LogName="System";Id=6008;StartTime=(Get-Date).AddDays(-14)} -MaxEvents 10 -ErrorAction SilentlyContinue; $usCount = @($us).Count
+  $_s = if($usCount -eq 0){'OK'}elseif($usCount -le 2){'WARN'}else{'FAIL'}
+  Add-Row 'Unexpected shutdown events (14d)' $_s ("UnexpectedShutdowns=$usCount")
+
+}
+
+$fail=@($rows|Where-Object Status -eq 'FAIL').Count
+$warn=@($rows|Where-Object Status -eq 'WARN').Count
+Write-Output '-- Decision --'
+Add-Row 'Likely cause severity' $(if($fail -gt 0){'FAIL'}elseif($warn -gt 0){'WARN'}else{'OK'}) $(if($fail -gt 0){'Hard configuration/service break'}elseif($warn -gt 0){'Configuration drift or transient condition'}else{'No blocking signals'})
+Add-Row 'Next action' 'OK' $(if($fail -gt 0){'Follow README interpretation and remediate FAIL rows first'}elseif($warn -gt 0){'Review WARN rows and re-run after targeted fix'}else{'No immediate action'})
+Write-Output '-- More Info --'
+Add-Row 'Remediation references available' 'OK' 'See paired README Learn References'
+
+$ok=@($rows|Where-Object Status -eq 'OK').Count
+Write-Output ''
+Write-Output "=== RESULT: $ok OK / $fail FAIL / $warn WARN ==="
+$rows
+

--- a/RunCommand/Windows/Windows_ReliabilityMonitor_Event_Signal/mock_config_sample.json
+++ b/RunCommand/Windows/Windows_ReliabilityMonitor_Event_Signal/mock_config_sample.json
@@ -1,0 +1,100 @@
+{
+  "profiles": {
+    "healthy": [
+      {
+        "name": "Application failures (7d)",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Application hangs (7d)",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Windows failures/BSODs (30d)",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Service termination events (7d)",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Disk errors (7d)",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Unexpected shutdown events (14d)",
+        "status": "OK",
+        "detail": "Healthy profile"
+      }
+    ],
+    "broken": [
+      {
+        "name": "Application failures (7d)",
+        "status": "FAIL",
+        "detail": "Critical failure detected"
+      },
+      {
+        "name": "Application hangs (7d)",
+        "status": "FAIL",
+        "detail": "Critical failure detected"
+      },
+      {
+        "name": "Windows failures/BSODs (30d)",
+        "status": "WARN",
+        "detail": "Degraded state"
+      },
+      {
+        "name": "Service termination events (7d)",
+        "status": "OK",
+        "detail": "Operational"
+      },
+      {
+        "name": "Disk errors (7d)",
+        "status": "WARN",
+        "detail": "Degraded state"
+      },
+      {
+        "name": "Unexpected shutdown events (14d)",
+        "status": "OK",
+        "detail": "Operational"
+      }
+    ],
+    "degraded": [
+      {
+        "name": "Application failures (7d)",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Application hangs (7d)",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Windows failures/BSODs (30d)",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Service termination events (7d)",
+        "status": "WARN",
+        "detail": "Configuration drift detected"
+      },
+      {
+        "name": "Disk errors (7d)",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Unexpected shutdown events (14d)",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      }
+    ]
+  }
+}

--- a/RunCommand/Windows/Windows_Resource_Pressure_Snapshot/README.md
+++ b/RunCommand/Windows/Windows_Resource_Pressure_Snapshot/README.md
@@ -1,0 +1,77 @@
+# Windows Resource Pressure Snapshot
+
+> **Tool ID:** RC-006 · **Bucket:** Performance / High-CPU / Memory-Pressure · **Phase:** 2
+
+## What It Does
+
+Point-in-time resource utilization snapshot for diagnosing Azure Windows VM performance complaints:
+
+| Check area | What is captured |
+|---|---|
+| **CPU** | Overall utilization (2-sample avg) + top 5 CPU processes |
+| **Memory** | Physical used %, commit charge %, top 5 processes by Working Set |
+| **Disk I/O** | Current queue length per physical disk |
+
+Read-only — no changes to the system. One 1-second sleep for CPU sampling.
+
+## Thresholds
+
+| Metric | WARN | FAIL |
+|---|---|---|
+| CPU % | ≥ 75% | ≥ 90% |
+| Memory used % | ≥ 85% | ≥ 95% |
+| Commit charge % | ≥ 85% | ≥ 95% |
+| Disk queue length | ≥ 2 | ≥ 4 |
+
+## How to Run
+
+### Azure Run Command
+1. Portal → VM → **Operations → Run Command → RunPowerShellScript**
+2. Paste `Windows_Resource_Pressure_Snapshot.ps1` → **Run**
+
+### Azure CLI
+```bash
+az vm run-command invoke -g <rg> -n <vm> --command-id RunPowerShellScript --scripts @Windows_Resource_Pressure_Snapshot.ps1
+```
+
+### Mock / Offline Test
+```powershell
+.\Windows_Resource_Pressure_Snapshot.ps1 -MockConfig .\mock_config_sample.json
+```
+
+## Sample Output (High Pressure)
+
+```
+=== Windows Resource Pressure Snapshot ===
+Check                                        Status
+-------------------------------------------- ------
+-- CPU --
+Overall CPU utilization                      FAIL   92.5%
+  Top CPU processes:
+    sqlservr                        PID=1234   CPUsec=4821.3
+    w3wp                            PID=5678   CPUsec=1203.7
+-- Memory --
+Physical memory used                         FAIL   96.2% (0.6 GB free / 16.0 GB)
+Commit charge                                FAIL   98.1% of virtual memory committed
+  Top memory processes (Working Set):
+    sqlservr                        PID=1234   WS=9240 MB
+    w3wp                            PID=5678   WS=2180 MB
+-- Disk I/O Queue --
+Disk queue: 0 C:                             FAIL   Queue=5
+Disk queue: 1 D:                             OK     Queue=0
+
+=== RESULT: 1 OK / 4 FAIL / 0 WARN ===
+```
+
+## Interpretation Guide
+
+| FAIL condition | Likely cause | Next step |
+|---|---|---|
+| CPU ≥ 90% | Runaway process, AV scan, Windows Update | Check top proc — if svchost, identify child service |
+| Memory ≥ 95% | Memory leak, undersized VM, missing pagefile | Review top WS procs; consider resize or pagefile increase |
+| Commit ≥ 95% | Pagefile exhaustion imminent | Expand pagefile or stop non-critical services |
+| Disk queue ≥ 4 | Disk throttling, Premium tier needed, I/O storm | Check VM + disk SKU IOPS limits in portal |
+
+## Related Articles
+- [Troubleshoot high CPU issues on Azure Windows VMs](https://learn.microsoft.com/azure/virtual-machines/troubleshooting/troubleshoot-high-cpu-issues-azure-windows-vm)
+- [Azure VM sizes](https://learn.microsoft.com/azure/virtual-machines/sizes)

--- a/RunCommand/Windows/Windows_Resource_Pressure_Snapshot/Windows_Resource_Pressure_Snapshot.ps1
+++ b/RunCommand/Windows/Windows_Resource_Pressure_Snapshot/Windows_Resource_Pressure_Snapshot.ps1
@@ -1,0 +1,155 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Point-in-time resource utilization snapshot for Azure Windows VM performance.
+.DESCRIPTION
+    Captures current load across CPU, memory, and disk I/O:
+      1. CPU — overall utilization (2-sample avg) + top 5 processes
+      2. Memory — physical used %, commit charge %, top 5 by Working Set
+      3. Disk I/O — current queue length per physical disk
+
+    Thresholds: CPU WARN >= 75 FAIL >= 90, Mem WARN >= 85 FAIL >= 95,
+    CommitPct same, DiskQ WARN >= 2 FAIL >= 4.
+
+    Designed for Azure Run Command: no Az module, no internet, PS 5.1 only.
+.PARAMETER MockConfig
+    Path to a JSON file that replaces live reads for offline testing.
+.NOTES
+    Author  : CSS Core Compute SPM
+    Version : 1.0.0
+    Tool ID : RC-006
+    Bucket  : Performance / High-CPU / Memory-Pressure
+    Repo    : Azure/azure-support-scripts  RunCommand/Windows/Windows_Resource_Pressure_Snapshot
+#>
+[CmdletBinding()]
+param(
+  [string]$MockConfig,
+  [ValidateSet('healthy','degraded','broken')]
+  [string]$MockProfile = 'degraded'
+)
+$ErrorActionPreference = 'Continue'
+
+function Pad($s, $n) { $s = "$s"; if ($s.Length -ge $n) { $s.Substring(0,$n) } else { $s.PadRight($n) } }
+$W = 44
+$findings = [System.Collections.Generic.List[psobject]]::new()
+
+function Add-Row($check, $status, $detail = '') {
+    $script:findings.Add([PSCustomObject]@{ Check = $check; Status = $status; Detail = $detail })
+    Write-Output ('{0} {1}' -f (Pad $check $W), $status)
+}
+
+$mock = $null
+if ($MockConfig -and (Test-Path $MockConfig)) {
+    $mock = Get-Content $MockConfig -Raw | ConvertFrom-Json
+}
+
+Write-Output '=== Windows Resource Pressure Snapshot ==='
+Write-Output ('{0} {1}' -f (Pad 'Check' $W), 'Status')
+Write-Output (('-' * $W) + ' ------')
+
+$usedMock = $false
+if ($MockConfig -and (Test-Path $MockConfig)) {
+    if ($mock.profiles -and $mock.profiles.$MockProfile) {
+        $usedMock = $true
+        foreach ($i in $mock.profiles.$MockProfile) { Add-Row $i.name $i.status $i.detail }
+    }
+}
+if (-not $usedMock) {
+
+# ── CPU ───────────────────────────────────────────────────────────────────────
+Write-Output '-- CPU --'
+
+if ($mock) {
+    $cpuPct  = [double]$mock.legacy.cpu.totalPct
+    $topCpu  = @($mock.legacy.cpu.topProcs)
+} else {
+    $s1 = (Get-WmiObject Win32_Processor | Measure-Object -Property LoadPercentage -Average).Average
+    Start-Sleep -Seconds 1
+    $s2 = (Get-WmiObject Win32_Processor | Measure-Object -Property LoadPercentage -Average).Average
+    $cpuPct = [math]::Round(($s1 + $s2) / 2, 1)
+    $topCpu = Get-Process | Sort-Object CPU -Descending | Select-Object -First 5 |
+        ForEach-Object { [PSCustomObject]@{ name = $_.ProcessName; pid = $_.Id; cpuSec = [math]::Round($_.CPU, 1) } }
+}
+
+$cpuStatus = if ($cpuPct -ge 90) { 'FAIL' } elseif ($cpuPct -ge 75) { 'WARN' } else { 'OK' }
+Add-Row 'Overall CPU utilization' $cpuStatus "$cpuPct%"
+
+if (@($topCpu).Count -gt 0) {
+    Write-Output '  Top CPU processes:'
+    foreach ($p in $topCpu) {
+        Write-Output ("    {0,-32} PID={1,-8} CPUsec={2}" -f $p.name, $p.pid, $p.cpuSec)
+    }
+}
+
+# ── Memory ────────────────────────────────────────────────────────────────────
+Write-Output '-- Memory --'
+
+if ($mock) {
+    $totalGB   = [double]$mock.legacy.memory.totalGB
+    $freeGB    = [double]$mock.legacy.memory.freeGB
+    $memPct    = [double]$mock.legacy.memory.usedPct
+    $commitPct = [double]$mock.legacy.memory.commitPct
+    $topMem    = @($mock.legacy.memory.topProcs)
+} else {
+    $os = Get-WmiObject Win32_OperatingSystem
+    $totalGB   = [math]::Round($os.TotalVisibleMemorySize / 1MB, 1)
+    $freeGB    = [math]::Round($os.FreePhysicalMemory / 1MB, 1)
+    $memPct    = [math]::Round(100 - ($freeGB / $totalGB * 100), 1)
+
+    $commitTotal = [math]::Round($os.SizeStoredInPagingFiles / 1MB, 1)
+    $commitFree  = [math]::Round($os.FreeSpaceInPagingFiles / 1MB, 1)
+    if ($commitTotal -gt 0) {
+        $commitPct = [math]::Round(100 - ($commitFree / $commitTotal * 100), 1)
+    } else {
+        $commitPct = 0
+    }
+
+    $topMem = Get-Process | Sort-Object WorkingSet64 -Descending | Select-Object -First 5 |
+        ForEach-Object { [PSCustomObject]@{ name = $_.ProcessName; pid = $_.Id; wsMB = [math]::Round($_.WorkingSet64 / 1MB, 0) } }
+}
+
+$memStatus = if ($memPct -ge 95) { 'FAIL' } elseif ($memPct -ge 85) { 'WARN' } else { 'OK' }
+Add-Row 'Physical memory used' $memStatus ("{0}% ({1} GB free / {2} GB)" -f $memPct, $freeGB, $totalGB)
+
+$commitStatus = if ($commitPct -ge 95) { 'FAIL' } elseif ($commitPct -ge 85) { 'WARN' } else { 'OK' }
+Add-Row 'Commit charge' $commitStatus "$commitPct% of virtual memory committed"
+
+if (@($topMem).Count -gt 0) {
+    Write-Output '  Top memory processes (Working Set):'
+    foreach ($p in $topMem) {
+        Write-Output ("    {0,-32} PID={1,-8} WS={2} MB" -f $p.name, $p.pid, $p.wsMB)
+    }
+}
+
+# ── Disk I/O Queue ────────────────────────────────────────────────────────────
+Write-Output '-- Disk I/O Queue --'
+
+if ($mock) {
+    $diskQueues = @($mock.legacy.diskQueues)
+} else {
+    $diskQueues = Get-WmiObject Win32_PerfFormattedData_PerfDisk_PhysicalDisk -ErrorAction SilentlyContinue |
+        Where-Object { $_.Name -ne '_Total' } |
+        ForEach-Object { [PSCustomObject]@{ disk = $_.Name; queueLen = [int]$_.CurrentDiskQueueLength } }
+}
+
+foreach ($dq in $diskQueues) {
+    $qLen = [int]$dq.queueLen
+    $qStatus = if ($qLen -ge 4) { 'FAIL' } elseif ($qLen -ge 2) { 'WARN' } else { 'OK' }
+    Add-Row "Disk queue: $($dq.disk)" $qStatus "Queue=$qLen"
+}
+
+}
+
+$fail = @($findings | Where-Object Status -eq 'FAIL').Count
+$warn = @($findings | Where-Object Status -eq 'WARN').Count
+Write-Output '-- Decision --'
+Add-Row 'Likely cause severity' $(if($fail -gt 0){'FAIL'}elseif($warn -gt 0){'WARN'}else{'OK'}) $(if($fail -gt 0){'Hard configuration/service break'}elseif($warn -gt 0){'Configuration drift or transient condition'}else{'No blocking signals'})
+Add-Row 'Next action' 'OK' $(if($fail -gt 0){'Follow README interpretation and remediate FAIL rows first'}elseif($warn -gt 0){'Review WARN rows and re-run after targeted fix'}else{'No immediate action'})
+Write-Output '-- More Info --'
+Add-Row 'Remediation references available' 'OK' 'See paired README Learn References'
+
+$ok = @($findings | Where-Object Status -eq 'OK').Count
+Write-Output ''
+Write-Output "=== RESULT: $ok OK / $fail FAIL / $warn WARN ==="
+
+$findings

--- a/RunCommand/Windows/Windows_Resource_Pressure_Snapshot/mock_config_sample.json
+++ b/RunCommand/Windows/Windows_Resource_Pressure_Snapshot/mock_config_sample.json
@@ -1,0 +1,55 @@
+{
+  "profiles": {
+    "healthy": [
+      {
+        "name": "Overall CPU utilization",
+        "status": "OK",
+        "detail": "Healthy"
+      },
+      {
+        "name": "Physical memory used",
+        "status": "OK",
+        "detail": "All dependencies available"
+      },
+      {
+        "name": "Commit charge",
+        "status": "OK",
+        "detail": "Below threshold"
+      }
+    ],
+    "degraded": [
+      {
+        "name": "Overall CPU utilization",
+        "status": "OK",
+        "detail": "Operational with warnings"
+      },
+      {
+        "name": "Physical memory used",
+        "status": "WARN",
+        "detail": "One non-blocking issue"
+      },
+      {
+        "name": "Commit charge",
+        "status": "OK",
+        "detail": "Elevated but not failing"
+      }
+    ],
+    "broken": [
+      {
+        "name": "Overall CPU utilization",
+        "status": "FAIL",
+        "detail": "Blocking issue detected"
+      },
+      {
+        "name": "Physical memory used",
+        "status": "FAIL",
+        "detail": "Critical dependency unavailable"
+      },
+      {
+        "name": "Commit charge",
+        "status": "FAIL",
+        "detail": "High error rate"
+      }
+    ]
+  }
+}

--- a/RunCommand/Windows/Windows_RouteTable_Anomaly_Check/README.md
+++ b/RunCommand/Windows/Windows_RouteTable_Anomaly_Check/README.md
@@ -1,0 +1,81 @@
+# Windows RouteTable Anomaly Check
+
+> **Tool ID:** RC-039 · **Bucket:** Networking · **Phase:** 2 (Deep diagnostic)
+
+## What It Does
+
+Analyzes the Windows routing table for anomalies that break Azure VM connectivity. Validates default gateway configuration, detects split-default routing, verifies IMDS and WireServer routes exist, checks for persistent routes that may conflict, and identifies blackhole routes. Critical for diagnosing VMs that lose internet or Azure service access after route table changes.
+
+| Check area | What is validated |
+|---|---|
+| Default gateway | Default gateway is configured |
+| Single default | No split-default routing (one 0.0.0.0 route) |
+| IMDS route | Route to 169.254.169.254 exists |
+| Persistent routes | Count of persistent routes (may conflict) |
+| WireServer route | Route to 168.63.129.16 exists |
+| Blackhole routes | No routes pointing to unreachable next-hops |
+
+## Run Command Constraints Met
+
+- ✅ PowerShell 5.1 only
+- ✅ No Az module required
+- ✅ No internet access needed
+- ✅ Output < 4 KB
+- ✅ No interactive prompts
+- ✅ Read-only (diagnostic only)
+
+## How to Run
+
+### Azure Run Command (recommended)
+Navigate to VM → Operations → Run Command → RunPowerShellScript → paste script.
+
+### Azure CLI
+```bash
+az vm run-command invoke -g <rg> -n <vm> --command-id RunPowerShellScript \
+  --scripts @Windows_RouteTable_Anomaly_Check/Windows_RouteTable_Anomaly_Check.ps1
+```
+
+### Mock test
+```powershell
+.\Windows_RouteTable_Anomaly_Check.ps1 -MockConfig .\mock_config_sample.json -MockProfile broken
+```
+
+## Sample Output (Issues Detected)
+
+```
+=== Windows RouteTable Anomaly Check ===
+Check                                        Status
+-------------------------------------------- ------
+Default gateway configured                   FAIL
+Single default route (no split)              FAIL
+IMDS route 169.254.169.254                   FAIL
+Persistent routes count                      WARN
+WireServer route (168.63.129.16)             FAIL
+No blackhole routes (unreachable)            WARN
+-- Decision --
+Likely cause severity                        FAIL   Hard configuration/service break
+Next action                                  OK     Follow README interpretation and remediate FAIL rows first
+-- More Info --
+Remediation references available             OK     See paired README Learn References
+
+=== RESULT: 0 OK / 4 FAIL / 2 WARN ===
+```
+
+## Interpretation Guide
+
+| FAIL/WARN condition | Likely cause | Quick fix | Learn link |
+|---|---|---|---|
+| **Default gateway configured** FAIL | No default gateway — VM cannot reach anything outside its subnet. Gateway may have been removed by static IP misconfiguration. | `New-NetRoute -DestinationPrefix 0.0.0.0/0 -NextHop <gateway-IP> -InterfaceAlias "Ethernet"`. Find gateway: first usable IP in subnet. | [Troubleshoot no internet with multi-IP](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/no-internet-access-multi-ip) |
+| **Single default route (no split)** FAIL | Multiple 0.0.0.0/0 routes cause non-deterministic routing. Common with VPN agents or multiple NICs. | `Get-NetRoute -DestinationPrefix 0.0.0.0/0` to list all. Remove extras: `Remove-NetRoute -DestinationPrefix 0.0.0.0/0 -InterfaceAlias <secondary>` | [Azure VM routing](https://learn.microsoft.com/azure/virtual-network/virtual-networks-udr-overview) |
+| **IMDS route 169.254.169.254** FAIL | Route to Azure Instance Metadata Service missing. IMDS, managed identity, and scheduled events won't work. | `New-NetRoute -DestinationPrefix 169.254.169.254/32 -NextHop <gateway> -InterfaceAlias "Ethernet"` (or it should be automatically provided by DHCP) | [Azure Instance Metadata Service](https://learn.microsoft.com/azure/virtual-machines/instance-metadata-service) |
+| **WireServer route (168.63.129.16)** FAIL | No route to WireServer. Guest agent, extensions, and health probes will fail. | Verify DHCP is assigning routes. Route should come from Azure fabric. `Test-NetConnection 168.63.129.16 -Port 80` | [What is IP 168.63.129.16?](https://learn.microsoft.com/azure/virtual-network/what-is-ip-address-168-63-129-16) |
+| **Persistent routes count** WARN | Persistent routes exist. These survive reboots and may override Azure DHCP-assigned routes. | `route print -p` to list. Remove conflicting: `route delete <destination>` | [Troubleshoot connectivity](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-app-connection) |
+| **No blackhole routes (unreachable)** WARN | Routes pointing to non-existent or unreachable next-hops detected. Traffic matching these routes will be silently dropped. | `Get-NetRoute \| Where-Object { $_.State -ne 'Alive' }` — remove or correct stale routes | [Virtual network traffic routing](https://learn.microsoft.com/azure/virtual-network/virtual-networks-udr-overview) |
+
+## Related Articles
+
+| Article | Link |
+|---|---|
+| Azure VM routing overview | [learn.microsoft.com](https://learn.microsoft.com/azure/virtual-network/virtual-networks-udr-overview) |
+| No internet access with multi-IP | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/no-internet-access-multi-ip) |
+| What is IP address 168.63.129.16? | [learn.microsoft.com](https://learn.microsoft.com/azure/virtual-network/what-is-ip-address-168-63-129-16) |

--- a/RunCommand/Windows/Windows_RouteTable_Anomaly_Check/Windows_RouteTable_Anomaly_Check.ps1
+++ b/RunCommand/Windows/Windows_RouteTable_Anomaly_Check/Windows_RouteTable_Anomaly_Check.ps1
@@ -1,0 +1,71 @@
+#Requires -Version 5.1
+[CmdletBinding()]
+param(
+  [string]$MockConfig,
+  [ValidateSet('healthy','degraded','broken')]
+  [string]$MockProfile = 'degraded'
+)
+$ErrorActionPreference='Continue'
+function Pad($s,$n){$s="$s";if($s.Length -ge $n){$s.Substring(0,$n)}else{$s.PadRight($n)}}
+$W=44
+$rows=New-Object System.Collections.Generic.List[object]
+function Add-Row($c,$s,$d=''){ $rows.Add([PSCustomObject]@{Check=$c;Status=$s;Detail=$d}); Write-Output ('{0} {1}' -f (Pad $c $W), $s) }
+
+Write-Output '=== Windows Route Table Anomaly Check ==='
+Write-Output ('{0} {1}' -f (Pad 'Check' $W), 'Status')
+Write-Output (('-' * $W) + ' ------')
+
+$usedMock = $false
+if($MockConfig -and (Test-Path $MockConfig)){
+  $mock = Get-Content $MockConfig -Raw | ConvertFrom-Json
+  if($mock.profiles -and $mock.profiles.$MockProfile){
+    $usedMock = $true
+    foreach($i in $mock.profiles.$MockProfile){ Add-Row $i.name $i.status $i.detail }
+  }
+}
+
+if(-not $usedMock){
+  # Probe: Default gateway configured
+  $gw = Get-NetRoute -DestinationPrefix "0.0.0.0/0" -ErrorAction SilentlyContinue | Where-Object { $_.NextHop -ne "0.0.0.0" }; $gwCount = @($gw).Count
+  $_s = if($gwCount -eq 0){'FAIL'}elseif($gwCount -ge 1){'OK'}else{'WARN'}
+  Add-Row 'Default gateway configured' $_s ("DefaultGateways=$gwCount $(if($gw){$gw[0].NextHop})")
+
+  # Probe: Single default route (no split)
+  $_s = if($gwCount -eq 1){'OK'}elseif($gwCount -gt 1){'WARN'}else{'FAIL'}
+  Add-Row 'Single default route (no split)' $_s ("Routes=$gwCount (1=normal)")
+
+  # Probe: IMDS route 169.254.169.254
+  $imds = Get-NetRoute -DestinationPrefix "169.254.169.254/32" -ErrorAction SilentlyContinue; $imdsOk = @($imds).Count -gt 0
+  $_s = if($imdsOk){'OK'}elseif(!$imdsOk){'WARN'}else{'FAIL'}
+  Add-Row 'IMDS route 169.254.169.254' $_s ("IMDSRoute=$imdsOk")
+
+  # Probe: Persistent routes count
+  $persist = Get-NetRoute -ErrorAction SilentlyContinue | Where-Object { $_.Protocol -eq "NetMgmt" }; $persistCount = @($persist).Count
+  $_s = if($persistCount -le 10){'OK'}elseif($persistCount -gt 10){'WARN'}else{'FAIL'}
+  Add-Row 'Persistent routes count' $_s ("PersistentRoutes=$persistCount")
+
+  # Probe: WireServer route (168.63.129.16)
+  $ws = Get-NetRoute -DestinationPrefix "168.63.129.16/32" -ErrorAction SilentlyContinue; $wsOk = @($ws).Count -gt 0
+  $_s = if($wsOk){'OK'}elseif(!$wsOk){'WARN'}else{'FAIL'}
+  Add-Row 'WireServer route (168.63.129.16)' $_s ("WireServerRoute=$wsOk")
+
+  # Probe: No blackhole routes (unreachable)
+  $bh = Get-NetRoute -ErrorAction SilentlyContinue | Where-Object { $_.State -eq "Unreachable" -or $_.NextHop -eq "0.0.0.0" -and $_.DestinationPrefix -ne "0.0.0.0/0" -and $_.DestinationPrefix -ne "255.255.255.255/32" }; $bhCount = @($bh).Count
+  $_s = if($bhCount -le 5){'OK'}elseif($bhCount -gt 5){'WARN'}else{'FAIL'}
+  Add-Row 'No blackhole routes (unreachable)' $_s ("SuspectRoutes=$bhCount")
+
+}
+
+$fail=@($rows|Where-Object Status -eq 'FAIL').Count
+$warn=@($rows|Where-Object Status -eq 'WARN').Count
+Write-Output '-- Decision --'
+Add-Row 'Likely cause severity' $(if($fail -gt 0){'FAIL'}elseif($warn -gt 0){'WARN'}else{'OK'}) $(if($fail -gt 0){'Hard configuration/service break'}elseif($warn -gt 0){'Configuration drift or transient condition'}else{'No blocking signals'})
+Add-Row 'Next action' 'OK' $(if($fail -gt 0){'Follow README interpretation and remediate FAIL rows first'}elseif($warn -gt 0){'Review WARN rows and re-run after targeted fix'}else{'No immediate action'})
+Write-Output '-- More Info --'
+Add-Row 'Remediation references available' 'OK' 'See paired README Learn References'
+
+$ok=@($rows|Where-Object Status -eq 'OK').Count
+Write-Output ''
+Write-Output "=== RESULT: $ok OK / $fail FAIL / $warn WARN ==="
+$rows
+

--- a/RunCommand/Windows/Windows_RouteTable_Anomaly_Check/mock_config_sample.json
+++ b/RunCommand/Windows/Windows_RouteTable_Anomaly_Check/mock_config_sample.json
@@ -1,0 +1,100 @@
+{
+  "profiles": {
+    "healthy": [
+      {
+        "name": "Default gateway configured",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Single default route (no split)",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "IMDS route 169.254.169.254",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Persistent routes count",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "WireServer route (168.63.129.16)",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "No blackhole routes (unreachable)",
+        "status": "OK",
+        "detail": "Healthy profile"
+      }
+    ],
+    "broken": [
+      {
+        "name": "Default gateway configured",
+        "status": "FAIL",
+        "detail": "Critical failure detected"
+      },
+      {
+        "name": "Single default route (no split)",
+        "status": "FAIL",
+        "detail": "Critical failure detected"
+      },
+      {
+        "name": "IMDS route 169.254.169.254",
+        "status": "WARN",
+        "detail": "Degraded state"
+      },
+      {
+        "name": "Persistent routes count",
+        "status": "OK",
+        "detail": "Operational"
+      },
+      {
+        "name": "WireServer route (168.63.129.16)",
+        "status": "WARN",
+        "detail": "Degraded state"
+      },
+      {
+        "name": "No blackhole routes (unreachable)",
+        "status": "OK",
+        "detail": "Operational"
+      }
+    ],
+    "degraded": [
+      {
+        "name": "Default gateway configured",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Single default route (no split)",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "IMDS route 169.254.169.254",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Persistent routes count",
+        "status": "WARN",
+        "detail": "Configuration drift detected"
+      },
+      {
+        "name": "WireServer route (168.63.129.16)",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "No blackhole routes (unreachable)",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      }
+    ]
+  }
+}

--- a/RunCommand/Windows/Windows_SChannel_CertStore_Health/README.md
+++ b/RunCommand/Windows/Windows_SChannel_CertStore_Health/README.md
@@ -1,0 +1,81 @@
+# Windows SChannel CertStore Health
+
+> **Tool ID:** RC-041 · **Bucket:** Security/TLS · **Phase:** 2 (Deep diagnostic)
+
+## What It Does
+
+Audits SChannel (TLS/SSL) configuration and certificate store health. Validates that TLS 1.2 is enabled for both client and server roles, SSL 3.0 is disabled, the Personal certificate store has valid certs, the Root CA store is accessible, and no expired certificates remain. Essential for diagnosing RDP TLS handshake failures and HTTPS connectivity issues.
+
+| Check area | What is validated |
+|---|---|
+| TLS 1.2 (client) | TLS 1.2 enabled for outbound connections |
+| TLS 1.2 (server) | TLS 1.2 enabled for inbound connections |
+| SSL 3.0 | Legacy SSL 3.0 disabled (POODLE vulnerable) |
+| Personal certs | Certificates in Personal (My) store |
+| Root CA store | Root certificate authority store accessible |
+| Expired certs | No expired certificates in Personal store |
+
+## Run Command Constraints Met
+
+- ✅ PowerShell 5.1 only
+- ✅ No Az module required
+- ✅ No internet access needed
+- ✅ Output < 4 KB
+- ✅ No interactive prompts
+- ✅ Read-only (diagnostic only)
+
+## How to Run
+
+### Azure Run Command (recommended)
+Navigate to VM → Operations → Run Command → RunPowerShellScript → paste script.
+
+### Azure CLI
+```bash
+az vm run-command invoke -g <rg> -n <vm> --command-id RunPowerShellScript \
+  --scripts @Windows_SChannel_CertStore_Health/Windows_SChannel_CertStore_Health.ps1
+```
+
+### Mock test
+```powershell
+.\Windows_SChannel_CertStore_Health.ps1 -MockConfig .\mock_config_sample.json -MockProfile broken
+```
+
+## Sample Output (Issues Detected)
+
+```
+=== Windows SChannel CertStore Health ===
+Check                                        Status
+-------------------------------------------- ------
+TLS 1.2 enabled (client)                     FAIL
+TLS 1.2 enabled (server)                     FAIL
+SSL 3.0 disabled                             FAIL
+Personal cert store populated                OK
+Root CA store accessible                     OK
+Expired certs in Personal store              WARN
+-- Decision --
+Likely cause severity                        FAIL   Hard configuration/service break
+Next action                                  OK     Follow README interpretation and remediate FAIL rows first
+-- More Info --
+Remediation references available             OK     See paired README Learn References
+
+=== RESULT: 2 OK / 3 FAIL / 1 WARN ===
+```
+
+## Interpretation Guide
+
+| FAIL/WARN condition | Likely cause | Quick fix | Learn link |
+|---|---|---|---|
+| **TLS 1.2 enabled (client)** FAIL | TLS 1.2 disabled for client connections. Outbound HTTPS calls to Azure services will fail if they require TLS 1.2. | `New-Item "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.2\Client" -Force; Set-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.2\Client" -Name Enabled -Value 1 -Type DWord` | [Transport Layer Security registry settings](https://learn.microsoft.com/windows-server/security/tls/tls-registry-settings) |
+| **TLS 1.2 enabled (server)** FAIL | TLS 1.2 disabled for server role. RDP and any TLS-serving applications cannot negotiate TLS 1.2. Causes RDP internal errors. | Same registry path with `\Server` instead of `\Client`. Set `Enabled=1` and `DisabledByDefault=0`. | [Troubleshoot RDP internal error](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-rdp-internal-error) |
+| **SSL 3.0 disabled** FAIL | SSL 3.0 is still enabled — vulnerable to POODLE attack. Security compliance risk. | `New-Item "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\SSL 3.0\Server" -Force; Set-ItemProperty ... -Name Enabled -Value 0` | [Disable SSL 3.0](https://learn.microsoft.com/troubleshoot/developer/webapps/iis/health-diagnostic-performance/disable-ssl-poodle) |
+| **Personal cert store populated** WARN | No certificates in Personal store. RDP uses a self-signed cert by default — if missing, RDP TLS handshake fails. | Check: `Get-ChildItem Cert:\LocalMachine\My`. Regenerate RDP cert: `wmic /namespace:\\root\cimv2\TerminalServices PATH Win32_TSGeneralSetting CALL SSLCertificateSHA1HashType 2` | [CredSSP encryption oracle remediation](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/credssp-encryption-oracle-remediation) |
+| **Root CA store accessible** WARN | Root certificate store inaccessible or empty. TLS certificate chain validation will fail for all HTTPS connections. | `certutil -verifyCTL AuthRootWU` to refresh. If offline, import roots from a known-good machine. | [Manage trusted root certificates](https://learn.microsoft.com/troubleshoot/windows-server/identity/valid-root-ca-certificates-untrusted) |
+| **Expired certs in Personal store** WARN | Expired certificates present. If RDP is bound to an expired cert, clients will get TLS errors. | `Get-ChildItem Cert:\LocalMachine\My \| Where-Object { $_.NotAfter -lt (Get-Date) }` — remove or renew expired certs | [Troubleshoot RDP internal error](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-rdp-internal-error) |
+
+## Related Articles
+
+| Article | Link |
+|---|---|
+| TLS registry settings reference | [learn.microsoft.com](https://learn.microsoft.com/windows-server/security/tls/tls-registry-settings) |
+| Troubleshoot RDP internal error | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-rdp-internal-error) |
+| CredSSP encryption oracle remediation | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/credssp-encryption-oracle-remediation) |

--- a/RunCommand/Windows/Windows_SChannel_CertStore_Health/Windows_SChannel_CertStore_Health.ps1
+++ b/RunCommand/Windows/Windows_SChannel_CertStore_Health/Windows_SChannel_CertStore_Health.ps1
@@ -1,0 +1,72 @@
+#Requires -Version 5.1
+[CmdletBinding()]
+param(
+  [string]$MockConfig,
+  [ValidateSet('healthy','degraded','broken')]
+  [string]$MockProfile = 'degraded'
+)
+$ErrorActionPreference='Continue'
+function Pad($s,$n){$s="$s";if($s.Length -ge $n){$s.Substring(0,$n)}else{$s.PadRight($n)}}
+$W=44
+$rows=New-Object System.Collections.Generic.List[object]
+function Add-Row($c,$s,$d=''){ $rows.Add([PSCustomObject]@{Check=$c;Status=$s;Detail=$d}); Write-Output ('{0} {1}' -f (Pad $c $W), $s) }
+
+Write-Output '=== Windows SChannel & CertStore Health ==='
+Write-Output ('{0} {1}' -f (Pad 'Check' $W), 'Status')
+Write-Output (('-' * $W) + ' ------')
+
+$usedMock = $false
+if($MockConfig -and (Test-Path $MockConfig)){
+  $mock = Get-Content $MockConfig -Raw | ConvertFrom-Json
+  if($mock.profiles -and $mock.profiles.$MockProfile){
+    $usedMock = $true
+    foreach($i in $mock.profiles.$MockProfile){ Add-Row $i.name $i.status $i.detail }
+  }
+}
+
+if(-not $usedMock){
+  # Probe: TLS 1.2 enabled (client)
+  $tls12c = Get-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.2\Client" -Name "Enabled" -ErrorAction SilentlyContinue; $tls12cVal = if($tls12c){$tls12c.Enabled}else{1}
+  $_s = if($tls12cVal -eq 0){'FAIL'}elseif($tls12cVal -ne 0){'OK'}else{'WARN'}
+  Add-Row 'TLS 1.2 enabled (client)' $_s ("TLS1.2Client=$(if($tls12cVal -ne 0){'Enabled'}else{'Disabled'})")
+
+  # Probe: TLS 1.2 enabled (server)
+  $tls12s = Get-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.2\Server" -Name "Enabled" -ErrorAction SilentlyContinue; $tls12sVal = if($tls12s){$tls12s.Enabled}else{1}
+  $_s = if($tls12sVal -eq 0){'FAIL'}elseif($tls12sVal -ne 0){'OK'}else{'WARN'}
+  Add-Row 'TLS 1.2 enabled (server)' $_s ("TLS1.2Server=$(if($tls12sVal -ne 0){'Enabled'}else{'Disabled'})")
+
+  # Probe: SSL 3.0 disabled
+  $ssl3 = Get-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\SSL 3.0\Server" -Name "Enabled" -ErrorAction SilentlyContinue; $ssl3Val = if($ssl3){$ssl3.Enabled}else{0}
+  $_s = if($ssl3Val -eq 0){'OK'}elseif($ssl3Val -ne 0){'WARN'}else{'FAIL'}
+  Add-Row 'SSL 3.0 disabled' $_s ("SSL3=$(if($ssl3Val -eq 0){'Disabled'}else{'Enabled'})")
+
+  # Probe: Personal cert store populated
+  $certs = Get-ChildItem Cert:\LocalMachine\My -ErrorAction SilentlyContinue; $certCount = @($certs).Count
+  $_s = if($certCount -ge 1){'OK'}elseif($certCount -eq 0){'WARN'}else{'FAIL'}
+  Add-Row 'Personal cert store populated' $_s ("PersonalCerts=$certCount")
+
+  # Probe: Root CA store accessible
+  $roots = Get-ChildItem Cert:\LocalMachine\Root -ErrorAction SilentlyContinue; $rootCount = @($roots).Count
+  $_s = if($rootCount -ge 10){'OK'}elseif($rootCount -lt 10){'WARN'}else{'FAIL'}
+  Add-Row 'Root CA store accessible' $_s ("RootCAs=$rootCount")
+
+  # Probe: Expired certs in Personal store
+  $expired = @($certs | Where-Object { $_.NotAfter -lt (Get-Date) }).Count
+  $_s = if($expired -eq 0){'OK'}elseif($expired -gt 0){'WARN'}else{'FAIL'}
+  Add-Row 'Expired certs in Personal store' $_s ("Expired=$expired")
+
+}
+
+$fail=@($rows|Where-Object Status -eq 'FAIL').Count
+$warn=@($rows|Where-Object Status -eq 'WARN').Count
+Write-Output '-- Decision --'
+Add-Row 'Likely cause severity' $(if($fail -gt 0){'FAIL'}elseif($warn -gt 0){'WARN'}else{'OK'}) $(if($fail -gt 0){'Hard configuration/service break'}elseif($warn -gt 0){'Configuration drift or transient condition'}else{'No blocking signals'})
+Add-Row 'Next action' 'OK' $(if($fail -gt 0){'Follow README interpretation and remediate FAIL rows first'}elseif($warn -gt 0){'Review WARN rows and re-run after targeted fix'}else{'No immediate action'})
+Write-Output '-- More Info --'
+Add-Row 'Remediation references available' 'OK' 'See paired README Learn References'
+
+$ok=@($rows|Where-Object Status -eq 'OK').Count
+Write-Output ''
+Write-Output "=== RESULT: $ok OK / $fail FAIL / $warn WARN ==="
+$rows
+

--- a/RunCommand/Windows/Windows_SChannel_CertStore_Health/mock_config_sample.json
+++ b/RunCommand/Windows/Windows_SChannel_CertStore_Health/mock_config_sample.json
@@ -1,0 +1,100 @@
+{
+  "profiles": {
+    "healthy": [
+      {
+        "name": "TLS 1.2 enabled (client)",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "TLS 1.2 enabled (server)",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "SSL 3.0 disabled",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Personal cert store populated",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Root CA store accessible",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Expired certs in Personal store",
+        "status": "OK",
+        "detail": "Healthy profile"
+      }
+    ],
+    "broken": [
+      {
+        "name": "TLS 1.2 enabled (client)",
+        "status": "FAIL",
+        "detail": "Critical failure detected"
+      },
+      {
+        "name": "TLS 1.2 enabled (server)",
+        "status": "FAIL",
+        "detail": "Critical failure detected"
+      },
+      {
+        "name": "SSL 3.0 disabled",
+        "status": "WARN",
+        "detail": "Degraded state"
+      },
+      {
+        "name": "Personal cert store populated",
+        "status": "OK",
+        "detail": "Operational"
+      },
+      {
+        "name": "Root CA store accessible",
+        "status": "WARN",
+        "detail": "Degraded state"
+      },
+      {
+        "name": "Expired certs in Personal store",
+        "status": "OK",
+        "detail": "Operational"
+      }
+    ],
+    "degraded": [
+      {
+        "name": "TLS 1.2 enabled (client)",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "TLS 1.2 enabled (server)",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "SSL 3.0 disabled",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Personal cert store populated",
+        "status": "WARN",
+        "detail": "Configuration drift detected"
+      },
+      {
+        "name": "Root CA store accessible",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Expired certs in Personal store",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      }
+    ]
+  }
+}

--- a/RunCommand/Windows/Windows_SFC_DISM_Health_Signal/README.md
+++ b/RunCommand/Windows/Windows_SFC_DISM_Health_Signal/README.md
@@ -1,0 +1,74 @@
+# Windows SFC & DISM Health Signal
+
+> **Bucket:** OS-Service-Failures / Component-Store-Corruption / Update-Failures
+
+## What It Does
+
+Checks the Windows component store (CBS/WinSxS) and system file integrity to determine if system file corruption is contributing to VM issues:
+
+| Check | What is validated |
+|---|---|
+| **CBS log integrity marker** | Last 200 lines of `CBS.log` for "corrupt" or "Cannot repair" entries |
+| **SFC last run result** | Whether the most recent `sfc /scannow` found violations |
+| **Component store health (WinSxS)** | WinSxS folder count — flags bloat at ≥ 30,000 directories |
+| **Pending component changes** | Registry key `RebootPending` under CBS — indicates servicing reboot needed |
+| **TrustedInstaller service** | Whether the Windows Modules Installer service exists |
+| **DISM image health** | Registry `RepairNeeded` flag — set when DISM detects corruption |
+
+The script is **read-only** — it makes no changes to the system.
+
+## How to Run
+
+### Azure Run Command (recommended)
+1. Go to your VM in the Azure portal
+2. Select **Operations → Run Command → RunPowerShellScript**
+3. Paste the contents of `Windows_SFC_DISM_Health_Signal.ps1`
+4. Select **Run** and wait for output
+
+### Azure CLI
+```bash
+az vm run-command invoke \
+  --resource-group <rg> \
+  --name <vm-name> \
+  --command-id RunPowerShellScript \
+  --scripts @Windows_SFC_DISM_Health_Signal.ps1
+```
+
+### Mock / Offline Test
+```powershell
+.\Windows_SFC_DISM_Health_Signal.ps1 -MockConfig .\mock_config_sample.json -MockProfile broken
+```
+
+## Sample Output (Issues Detected)
+
+```
+=== Windows SFC & DISM Health Signal ===
+Check                                        Status
+-------------------------------------------- ------
+CBS log integrity marker                     FAIL    CorruptSignals=12
+SFC last run result in CBS log               WARN    SFC=could not perform requested operation
+Component store health (WinSxS)              OK      WinSxSFolders=18500
+Pending component changes                    WARN    RebootPending=True
+TrustedInstaller service                     OK      Status=Running
+DISM image health (registry hint)            FAIL    RepairNeeded=1
+-- Decision --
+Likely cause severity                        FAIL
+=== RESULT: 2 OK / 2 FAIL / 2 WARN ===
+```
+
+## Interpretation Guide
+
+| FAIL/WARN condition | Likely cause | Quick fix |
+|---|---|---|
+| CBS log corruption ≥ 4 signals | System files are damaged — updates and features may fail silently | Run `sfc /scannow` from an elevated prompt. If it reports "could not fix", proceed with DISM repair |
+| SFC result shows violations | Previous scan found files it could not repair | Run `DISM /Online /Cleanup-Image /RestoreHealth` then re-run `sfc /scannow` |
+| WinSxS folders ≥ 30,000 | Component store bloat — slows servicing and wastes disk | Run `DISM /Online /Cleanup-Image /StartComponentCleanup /ResetBase` |
+| RebootPending = True | A servicing operation is waiting for reboot to complete | Reboot the VM, then re-run this script to confirm the pending state clears |
+| TrustedInstaller not found | Windows Modules Installer was disabled or removed | Re-enable: `sc config TrustedInstaller start= demand` then `sc start TrustedInstaller` |
+| DISM RepairNeeded ≠ 0 | Windows image integrity is compromised | Run `DISM /Online /Cleanup-Image /RestoreHealth`. If that fails, repair from a known-good WIM source |
+
+## Related Articles
+
+- [Repair a Windows VM using the Virtual Machine Repair Commands](https://learn.microsoft.com/azure/virtual-machines/troubleshooting/repair-windows-vm-using-azure-virtual-machine-repair-commands)
+- [Use DISM to repair Windows (Windows Server)](https://learn.microsoft.com/troubleshoot/windows-server/deployment/fix-windows-update-errors)
+- [Troubleshoot Windows stop error — Bad System Config Info](https://learn.microsoft.com/azure/virtual-machines/troubleshooting/windows-stop-error-bad-system-config-info)

--- a/RunCommand/Windows/Windows_SFC_DISM_Health_Signal/Windows_SFC_DISM_Health_Signal.ps1
+++ b/RunCommand/Windows/Windows_SFC_DISM_Health_Signal/Windows_SFC_DISM_Health_Signal.ps1
@@ -1,0 +1,72 @@
+#Requires -Version 5.1
+[CmdletBinding()]
+param(
+  [string]$MockConfig,
+  [ValidateSet('healthy','degraded','broken')]
+  [string]$MockProfile = 'degraded'
+)
+$ErrorActionPreference='Continue'
+function Pad($s,$n){$s="$s";if($s.Length -ge $n){$s.Substring(0,$n)}else{$s.PadRight($n)}}
+$W=44
+$rows=New-Object System.Collections.Generic.List[object]
+function Add-Row($c,$s,$d=''){ $rows.Add([PSCustomObject]@{Check=$c;Status=$s;Detail=$d}); Write-Output ('{0} {1}' -f (Pad $c $W), $s) }
+
+Write-Output '=== Windows SFC & DISM Health Signal ==='
+Write-Output ('{0} {1}' -f (Pad 'Check' $W), 'Status')
+Write-Output (('-' * $W) + ' ------')
+
+$usedMock = $false
+if($MockConfig -and (Test-Path $MockConfig)){
+  $mock = Get-Content $MockConfig -Raw | ConvertFrom-Json
+  if($mock.profiles -and $mock.profiles.$MockProfile){
+    $usedMock = $true
+    foreach($i in $mock.profiles.$MockProfile){ Add-Row $i.name $i.status $i.detail }
+  }
+}
+
+if(-not $usedMock){
+  # Probe: CBS log integrity marker
+  $cbs = Get-Content "$env:SystemRoot\Logs\CBS\CBS.log" -Tail 200 -ErrorAction SilentlyContinue; $corruptLines = @($cbs | Where-Object { $_ -match "corrupt|Cannot repair" }).Count
+  $_s = if($corruptLines -eq 0){'OK'}elseif($corruptLines -le 3){'WARN'}else{'FAIL'}
+  Add-Row 'CBS log integrity marker' $_s ("CorruptSignals=$corruptLines")
+
+  # Probe: SFC last run result in CBS log
+  $sfcResult = @($cbs | Where-Object { $_ -match "Verify complete|no integrity violations|could not perform" }) | Select-Object -Last 1; $sfcOk = $sfcResult -match "no integrity violations|Verify complete"
+  $_s = if($sfcOk){'OK'}elseif(!$sfcOk){'WARN'}else{'FAIL'}
+  Add-Row 'SFC last run result in CBS log' $_s ("SFC=$(if($sfcResult){$sfcResult.Trim().Substring(0,[math]::Min(60,$sfcResult.Trim().Length))}else{'no recent scan'})")
+
+  # Probe: Component store health (WinSxS)
+  $winsxs = Get-ChildItem "$env:SystemRoot\WinSxS" -Directory -ErrorAction SilentlyContinue | Measure-Object; $sxsCount = $winsxs.Count
+  $_s = if($sxsCount -gt 0 -and $sxsCount -lt 30000){'OK'}elseif($sxsCount -ge 30000){'WARN'}else{'FAIL'}
+  Add-Row 'Component store health (WinSxS)' $_s ("WinSxSFolders=$sxsCount")
+
+  # Probe: Pending component changes
+  $pend = Test-Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending"
+  $_s = if(!$pend){'OK'}elseif($pend){'WARN'}else{'FAIL'}
+  Add-Row 'Pending component changes' $_s ("RebootPending=$pend")
+
+  # Probe: TrustedInstaller service
+  $ti = Get-Service TrustedInstaller -ErrorAction SilentlyContinue
+  $_s = if($ti -ne $null){'OK'}elseif($ti -eq $null){'WARN'}else{'FAIL'}
+  Add-Row 'TrustedInstaller service' $_s ("Status=$(if($ti){$ti.Status}else{'NotFound'})")
+
+  # Probe: DISM image health (registry hint)
+  $health = Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing" -Name "RepairNeeded" -ErrorAction SilentlyContinue; $needsRepair = if($health){$health.RepairNeeded}else{0}
+  $_s = if($needsRepair -ne 0){'FAIL'}elseif($needsRepair -eq 0){'OK'}else{'WARN'}
+  Add-Row 'DISM image health (registry hint)' $_s ("RepairNeeded=$needsRepair")
+
+}
+
+$fail=@($rows|Where-Object Status -eq 'FAIL').Count
+$warn=@($rows|Where-Object Status -eq 'WARN').Count
+Write-Output '-- Decision --'
+Add-Row 'Likely cause severity' $(if($fail -gt 0){'FAIL'}elseif($warn -gt 0){'WARN'}else{'OK'}) $(if($fail -gt 0){'Hard configuration/service break'}elseif($warn -gt 0){'Configuration drift or transient condition'}else{'No blocking signals'})
+Add-Row 'Next action' 'OK' $(if($fail -gt 0){'Follow README interpretation and remediate FAIL rows first'}elseif($warn -gt 0){'Review WARN rows and re-run after targeted fix'}else{'No immediate action'})
+Write-Output '-- More Info --'
+Add-Row 'Remediation references available' 'OK' 'See paired README Learn References'
+
+$ok=@($rows|Where-Object Status -eq 'OK').Count
+Write-Output ''
+Write-Output "=== RESULT: $ok OK / $fail FAIL / $warn WARN ==="
+$rows
+

--- a/RunCommand/Windows/Windows_SFC_DISM_Health_Signal/mock_config_sample.json
+++ b/RunCommand/Windows/Windows_SFC_DISM_Health_Signal/mock_config_sample.json
@@ -1,0 +1,100 @@
+{
+  "profiles": {
+    "healthy": [
+      {
+        "name": "CBS log integrity marker",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "SFC last run result in CBS log",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Component store health (WinSxS)",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Pending component changes",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "TrustedInstaller service",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "DISM image health (registry hint)",
+        "status": "OK",
+        "detail": "Healthy profile"
+      }
+    ],
+    "broken": [
+      {
+        "name": "CBS log integrity marker",
+        "status": "FAIL",
+        "detail": "Critical failure detected"
+      },
+      {
+        "name": "SFC last run result in CBS log",
+        "status": "FAIL",
+        "detail": "Critical failure detected"
+      },
+      {
+        "name": "Component store health (WinSxS)",
+        "status": "WARN",
+        "detail": "Degraded state"
+      },
+      {
+        "name": "Pending component changes",
+        "status": "OK",
+        "detail": "Operational"
+      },
+      {
+        "name": "TrustedInstaller service",
+        "status": "WARN",
+        "detail": "Degraded state"
+      },
+      {
+        "name": "DISM image health (registry hint)",
+        "status": "OK",
+        "detail": "Operational"
+      }
+    ],
+    "degraded": [
+      {
+        "name": "CBS log integrity marker",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "SFC last run result in CBS log",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Component store health (WinSxS)",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Pending component changes",
+        "status": "WARN",
+        "detail": "Configuration drift detected"
+      },
+      {
+        "name": "TrustedInstaller service",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "DISM image health (registry hint)",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      }
+    ]
+  }
+}

--- a/RunCommand/Windows/Windows_SMB_Client_Health/README.md
+++ b/RunCommand/Windows/Windows_SMB_Client_Health/README.md
@@ -1,0 +1,82 @@
+# Windows SMB Client Health
+
+> **Tool ID:** RC-043 · **Bucket:** Networking · **Phase:** 2 (Deep diagnostic)
+
+## What It Does
+
+Validates SMB client configuration and connectivity on an Azure VM. Checks that the Workstation service is running, SMB signing policy is set, the legacy SMBv1 protocol is disabled, multichannel is configured, and firewall rules allow file sharing. Critical for VMs experiencing file share access failures or Azure Files mount issues.
+
+| Check area | What is validated |
+|---|---|
+| Workstation service | LanmanWorkstation service running |
+| SMB signing | SMB signing required per client policy |
+| SMBv1 disabled | Legacy SMBv1 protocol is not active |
+| Active connections | Current SMB session count (informational) |
+| Multichannel | SMB Multichannel enabled for multi-NIC VMs |
+| Firewall rules | File sharing firewall rules enabled |
+
+## Run Command Constraints Met
+
+- ✅ PowerShell 5.1 only
+- ✅ No Az module required
+- ✅ No internet access needed
+- ✅ Output < 4 KB
+- ✅ No interactive prompts
+- ✅ Read-only (diagnostic only)
+
+## How to Run
+
+### Azure Run Command (recommended)
+Navigate to VM → Operations → Run Command → RunPowerShellScript → paste script.
+
+### Azure CLI
+```bash
+az vm run-command invoke -g <rg> -n <vm> --command-id RunPowerShellScript \
+  --scripts @Windows_SMB_Client_Health/Windows_SMB_Client_Health.ps1
+```
+
+### Mock test
+```powershell
+.\Windows_SMB_Client_Health.ps1 -MockConfig .\mock_config_sample.json -MockProfile degraded
+```
+
+## Sample Output (Issues Detected)
+
+```
+=== Windows SMB Client Health ===
+Check                                        Status
+-------------------------------------------- ------
+LanmanWorkstation service                    FAIL
+SMB signing required (client)                WARN
+SMBv1 protocol disabled                      FAIL
+SMB connections active                       OK
+Multichannel enabled                         WARN
+File sharing firewall rules                  FAIL
+-- Decision --
+Likely cause severity                        FAIL   Hard configuration/service break
+Next action                                  OK     Follow README interpretation and remediate FAIL rows first
+-- More Info --
+Remediation references available             OK     See paired README Learn References
+
+=== RESULT: 1 OK / 3 FAIL / 2 WARN ===
+```
+
+## Interpretation Guide
+
+| FAIL/WARN condition | Likely cause | Quick fix | Learn link |
+|---|---|---|---|
+| **LanmanWorkstation service** FAIL | Workstation (SMB client) service is stopped or disabled. File share access, mapped drives, and Azure Files mounts will fail. | `Set-Service LanmanWorkstation -StartupType Automatic; Start-Service LanmanWorkstation` | [Troubleshoot Azure Files connectivity (Windows)](https://learn.microsoft.com/troubleshoot/azure/azure-storage/files/connectivity/smb-troubleshoot-windows) |
+| **SMB signing required (client)** WARN | Client-side SMB signing is not required. While connections work, unsigned SMB traffic is vulnerable to MITM attacks. | `Set-SmbClientConfiguration -RequireSecuritySignature $true -Force` | [SMB signing overview](https://learn.microsoft.com/troubleshoot/windows-server/networking/overview-server-message-block-signing) |
+| **SMBv1 protocol disabled** FAIL | SMBv1 is active — deprecated, insecure, and a ransomware attack vector (WannaCry, NotPetya). Azure Files requires SMB 2.1+. | `Set-SmbServerConfiguration -EnableSMB1Protocol $false -Force; Disable-WindowsOptionalFeature -Online -FeatureName SMB1Protocol` | [Detect and disable SMBv1](https://learn.microsoft.com/windows-server/storage/file-server/troubleshoot/detect-enable-and-disable-smbv1-v2-v3) |
+| **SMB connections active** WARN | Zero active connections may be normal (no shares mounted) or indicate access failures. Informational check. | `Get-SmbConnection` to verify. If shares should be mounted, test: `Test-Path \\server\share` | [Azure Files troubleshooting](https://learn.microsoft.com/troubleshoot/azure/azure-storage/files/connectivity/smb-troubleshoot-windows) |
+| **Multichannel enabled** WARN | SMB Multichannel is disabled. VMs with multiple NICs or high-bandwidth NICs benefit from parallel SMB channels. | `Set-SmbClientConfiguration -EnableMultichannel $true -Force` | [SMB Multichannel overview](https://learn.microsoft.com/azure/storage/files/smb-multichannel-performance) |
+| **File sharing firewall rules** FAIL | Windows Firewall is blocking SMB traffic (TCP 445). File share connections will fail. | `Enable-NetFirewallRule -Group "File and Printer Sharing"` or create specific rule: `New-NetFirewallRule -Name SMB -Direction Inbound -Protocol TCP -LocalPort 445 -Action Allow` | [Troubleshoot Azure Files connectivity](https://learn.microsoft.com/troubleshoot/azure/azure-storage/files/connectivity/smb-troubleshoot-windows) |
+
+## Related Articles
+
+| Article | Link |
+|---|---|
+| Troubleshoot Azure Files on Windows (SMB) | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/azure-storage/files/connectivity/smb-troubleshoot-windows) |
+| Detect and disable SMBv1 | [learn.microsoft.com](https://learn.microsoft.com/windows-server/storage/file-server/troubleshoot/detect-enable-and-disable-smbv1-v2-v3) |
+| SMB Multichannel for Azure Files | [learn.microsoft.com](https://learn.microsoft.com/azure/storage/files/smb-multichannel-performance) |
+| SMB signing overview | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/windows-server/networking/overview-server-message-block-signing) |

--- a/RunCommand/Windows/Windows_SMB_Client_Health/Windows_SMB_Client_Health.ps1
+++ b/RunCommand/Windows/Windows_SMB_Client_Health/Windows_SMB_Client_Health.ps1
@@ -1,0 +1,72 @@
+#Requires -Version 5.1
+[CmdletBinding()]
+param(
+  [string]$MockConfig,
+  [ValidateSet('healthy','degraded','broken')]
+  [string]$MockProfile = 'degraded'
+)
+$ErrorActionPreference='Continue'
+function Pad($s,$n){$s="$s";if($s.Length -ge $n){$s.Substring(0,$n)}else{$s.PadRight($n)}}
+$W=44
+$rows=New-Object System.Collections.Generic.List[object]
+function Add-Row($c,$s,$d=''){ $rows.Add([PSCustomObject]@{Check=$c;Status=$s;Detail=$d}); Write-Output ('{0} {1}' -f (Pad $c $W), $s) }
+
+Write-Output '=== Windows SMB Client Health ==='
+Write-Output ('{0} {1}' -f (Pad 'Check' $W), 'Status')
+Write-Output (('-' * $W) + ' ------')
+
+$usedMock = $false
+if($MockConfig -and (Test-Path $MockConfig)){
+  $mock = Get-Content $MockConfig -Raw | ConvertFrom-Json
+  if($mock.profiles -and $mock.profiles.$MockProfile){
+    $usedMock = $true
+    foreach($i in $mock.profiles.$MockProfile){ Add-Row $i.name $i.status $i.detail }
+  }
+}
+
+if(-not $usedMock){
+  # Probe: LanmanWorkstation service
+  $lw = Get-Service LanmanWorkstation -ErrorAction SilentlyContinue
+  $_s = if(!$lw -or $lw.Status -ne "Running"){'FAIL'}elseif($lw -and $lw.Status -eq "Running"){'OK'}else{'WARN'}
+  Add-Row 'LanmanWorkstation service' $_s ("Status=$(if($lw){$lw.Status}else{'NotFound'})")
+
+  # Probe: SMB signing required (client)
+  $sign = Get-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Services\LanmanWorkstation\Parameters" -Name "RequireSecuritySignature" -ErrorAction SilentlyContinue; $signVal = if($sign){$sign.RequireSecuritySignature}else{0}
+  $_s = if($signVal -eq 1){'OK'}elseif($signVal -ne 1){'WARN'}else{'FAIL'}
+  Add-Row 'SMB signing required (client)' $_s ("SigningRequired=$signVal")
+
+  # Probe: SMBv1 protocol disabled
+  $v1 = Get-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Services\LanmanWorkstation\Parameters" -Name "DependOnService" -ErrorAction SilentlyContinue; $v1On = if($v1){ $v1.DependOnService -contains "MRxSmb10" }else{$false}; $v1Drv = Get-Service mrxsmb10 -ErrorAction SilentlyContinue; $v1Active = $v1Drv -and $v1Drv.Status -eq "Running"
+  $_s = if($v1Active){'FAIL'}elseif(!$v1Active){'OK'}else{'WARN'}
+  Add-Row 'SMBv1 protocol disabled' $_s ("SMBv1Active=$v1Active")
+
+  # Probe: SMB connections active
+  $smbConn = Get-SmbConnection -ErrorAction SilentlyContinue; $smbCount = @($smbConn).Count
+  $_s = if($true){'OK'}elseif($false){'WARN'}else{'FAIL'}
+  Add-Row 'SMB connections active' $_s ("ActiveConns=$smbCount (informational)")
+
+  # Probe: Multichannel enabled
+  $mc = Get-SmbClientConfiguration -ErrorAction SilentlyContinue | Select-Object -ExpandProperty EnableMultiChannel -ErrorAction SilentlyContinue
+  $_s = if($mc -eq $true){'OK'}elseif($mc -ne $true){'WARN'}else{'FAIL'}
+  Add-Row 'Multichannel enabled' $_s ("Multichannel=$mc")
+
+  # Probe: File sharing firewall rules
+  $smFw = Get-NetFirewallRule -DisplayGroup "File and Printer Sharing" -ErrorAction SilentlyContinue | Where-Object Enabled -eq True; $smFwCount = @($smFw).Count
+  $_s = if($smFwCount -gt 0){'OK'}elseif($smFwCount -eq 0){'WARN'}else{'FAIL'}
+  Add-Row 'File sharing firewall rules' $_s ("FWRulesEnabled=$smFwCount")
+
+}
+
+$fail=@($rows|Where-Object Status -eq 'FAIL').Count
+$warn=@($rows|Where-Object Status -eq 'WARN').Count
+Write-Output '-- Decision --'
+Add-Row 'Likely cause severity' $(if($fail -gt 0){'FAIL'}elseif($warn -gt 0){'WARN'}else{'OK'}) $(if($fail -gt 0){'Hard configuration/service break'}elseif($warn -gt 0){'Configuration drift or transient condition'}else{'No blocking signals'})
+Add-Row 'Next action' 'OK' $(if($fail -gt 0){'Follow README interpretation and remediate FAIL rows first'}elseif($warn -gt 0){'Review WARN rows and re-run after targeted fix'}else{'No immediate action'})
+Write-Output '-- More Info --'
+Add-Row 'Remediation references available' 'OK' 'See paired README Learn References'
+
+$ok=@($rows|Where-Object Status -eq 'OK').Count
+Write-Output ''
+Write-Output "=== RESULT: $ok OK / $fail FAIL / $warn WARN ==="
+$rows
+

--- a/RunCommand/Windows/Windows_SMB_Client_Health/mock_config_sample.json
+++ b/RunCommand/Windows/Windows_SMB_Client_Health/mock_config_sample.json
@@ -1,0 +1,100 @@
+{
+  "profiles": {
+    "healthy": [
+      {
+        "name": "LanmanWorkstation service",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "SMB signing required (client)",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "SMBv1 protocol disabled",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "SMB connections active",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Multichannel enabled",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "File sharing firewall rules",
+        "status": "OK",
+        "detail": "Healthy profile"
+      }
+    ],
+    "broken": [
+      {
+        "name": "LanmanWorkstation service",
+        "status": "FAIL",
+        "detail": "Critical failure detected"
+      },
+      {
+        "name": "SMB signing required (client)",
+        "status": "FAIL",
+        "detail": "Critical failure detected"
+      },
+      {
+        "name": "SMBv1 protocol disabled",
+        "status": "WARN",
+        "detail": "Degraded state"
+      },
+      {
+        "name": "SMB connections active",
+        "status": "OK",
+        "detail": "Operational"
+      },
+      {
+        "name": "Multichannel enabled",
+        "status": "WARN",
+        "detail": "Degraded state"
+      },
+      {
+        "name": "File sharing firewall rules",
+        "status": "OK",
+        "detail": "Operational"
+      }
+    ],
+    "degraded": [
+      {
+        "name": "LanmanWorkstation service",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "SMB signing required (client)",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "SMBv1 protocol disabled",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "SMB connections active",
+        "status": "WARN",
+        "detail": "Configuration drift detected"
+      },
+      {
+        "name": "Multichannel enabled",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "File sharing firewall rules",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      }
+    ]
+  }
+}

--- a/RunCommand/Windows/Windows_ServiceStartupTimeout_Check/README.md
+++ b/RunCommand/Windows/Windows_ServiceStartupTimeout_Check/README.md
@@ -1,0 +1,78 @@
+# Windows Service Startup Timeout Check
+
+> **Tool ID:** RC-042 · **Bucket:** Boot/Services · **Phase:** 2 (Deep diagnostic)
+
+## What It Does
+
+Detects service startup timeout issues that cause slow boot or service failures. Checks the ServicesPipeTimeout registry value, identifies auto-start services that failed, counts Service Control Manager errors, detects Event ID 7011 (service timeout) events, and validates critical services are running. Important for VMs that boot slowly or have services stuck in "Starting" state.
+
+| Check area | What is validated |
+|---|---|
+| ServicesPipeTimeout | Registry timeout value for service startup |
+| Failed auto-start | Auto-start services that failed to start |
+| SCM errors | Service Control Manager error events (7 days) |
+| Timeout events | Event ID 7011 (service timeout) count |
+| Critical services | Essential services running |
+
+## Run Command Constraints Met
+
+- ✅ PowerShell 5.1 only
+- ✅ No Az module required
+- ✅ No internet access needed
+- ✅ Output < 4 KB
+- ✅ No interactive prompts
+- ✅ Read-only (diagnostic only)
+
+## How to Run
+
+### Azure Run Command (recommended)
+Navigate to VM → Operations → Run Command → RunPowerShellScript → paste script.
+
+### Azure CLI
+```bash
+az vm run-command invoke -g <rg> -n <vm> --command-id RunPowerShellScript \
+  --scripts @Windows_ServiceStartupTimeout_Check/Windows_ServiceStartupTimeout_Check.ps1
+```
+
+### Mock test
+```powershell
+.\Windows_ServiceStartupTimeout_Check.ps1 -MockConfig .\mock_config_sample.json -MockProfile broken
+```
+
+## Sample Output (Issues Detected)
+
+```
+=== Windows Service Startup Timeout Check ===
+Check                                        Status
+-------------------------------------------- ------
+ServicesPipeTimeout value                    WARN
+Auto-start services failed                   FAIL
+Service Control Manager errors (7d)          FAIL
+Service timeout events (7011)                FAIL
+Critical services running                    FAIL
+-- Decision --
+Likely cause severity                        FAIL   Hard configuration/service break
+Next action                                  OK     Follow README interpretation and remediate FAIL rows first
+-- More Info --
+Remediation references available             OK     See paired README Learn References
+
+=== RESULT: 0 OK / 4 FAIL / 1 WARN ===
+```
+
+## Interpretation Guide
+
+| FAIL/WARN condition | Likely cause | Quick fix | Learn link |
+|---|---|---|---|
+| **ServicesPipeTimeout value** WARN | Default timeout (30 sec) may be insufficient for heavy VMs with many services. Value is 0 or not set. | Increase: `Set-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Control" -Name ServicesPipeTimeout -Value 120000 -Type DWord` (120 sec in ms) then reboot | [Slow VM start troubleshooting](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/slow-vm-start-extensions-troubleshooting) |
+| **Auto-start services failed** FAIL | One or more Automatic services didn't start. May indicate dependency failures, corrupted binaries, or permission issues. | `Get-Service \| Where-Object { $_.StartType -eq 'Automatic' -and $_.Status -ne 'Running' }` to identify. Fix dependencies or reinstall service. | [Troubleshoot service startup](https://learn.microsoft.com/troubleshoot/windows-server/system-management-components/troubleshoot-service-startup) |
+| **Service Control Manager errors (7d)** WARN | SCM logged errors (Event ID 7000-7009, 7023-7034). Indicates service start/stop failures. | `Get-WinEvent -FilterHashtable @{LogName='System'; ProviderName='Service Control Manager'; Level=2; StartTime=(Get-Date).AddDays(-7)}` | [SCM error reference](https://learn.microsoft.com/troubleshoot/windows-server/system-management-components/troubleshoot-service-startup) |
+| **Service timeout events (7011)** FAIL | Event ID 7011 — services exceeded the startup timeout. Common on VMs with slow storage or many services competing at boot. | Increase ServicesPipeTimeout (see above). Identify slow services from 7011 event details. Consider setting delayed start: `sc config <svc> start= delayed-auto` | [Slow boot troubleshooting](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/slow-vm-start-extensions-troubleshooting) |
+| **Critical services running** FAIL | One or more critical services (RpcSs, Netlogon, W32Time, LanmanServer, etc.) not running. May cascade into other failures. | `Get-Service RpcSs,Netlogon,W32Time,LanmanWorkstation -ErrorAction SilentlyContinue \| Format-Table Name,Status`. Start stopped services. | [Understand VM reboot](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/understand-vm-reboot) |
+
+## Related Articles
+
+| Article | Link |
+|---|---|
+| Slow VM start and extension troubleshooting | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/slow-vm-start-extensions-troubleshooting) |
+| Troubleshoot service startup | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/windows-server/system-management-components/troubleshoot-service-startup) |
+| Understand Azure VM reboot | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/understand-vm-reboot) |

--- a/RunCommand/Windows/Windows_ServiceStartupTimeout_Check/Windows_ServiceStartupTimeout_Check.ps1
+++ b/RunCommand/Windows/Windows_ServiceStartupTimeout_Check/Windows_ServiceStartupTimeout_Check.ps1
@@ -1,0 +1,67 @@
+#Requires -Version 5.1
+[CmdletBinding()]
+param(
+  [string]$MockConfig,
+  [ValidateSet('healthy','degraded','broken')]
+  [string]$MockProfile = 'degraded'
+)
+$ErrorActionPreference='Continue'
+function Pad($s,$n){$s="$s";if($s.Length -ge $n){$s.Substring(0,$n)}else{$s.PadRight($n)}}
+$W=44
+$rows=New-Object System.Collections.Generic.List[object]
+function Add-Row($c,$s,$d=''){ $rows.Add([PSCustomObject]@{Check=$c;Status=$s;Detail=$d}); Write-Output ('{0} {1}' -f (Pad $c $W), $s) }
+
+Write-Output '=== Windows Service Startup Timeout Check ==='
+Write-Output ('{0} {1}' -f (Pad 'Check' $W), 'Status')
+Write-Output (('-' * $W) + ' ------')
+
+$usedMock = $false
+if($MockConfig -and (Test-Path $MockConfig)){
+  $mock = Get-Content $MockConfig -Raw | ConvertFrom-Json
+  if($mock.profiles -and $mock.profiles.$MockProfile){
+    $usedMock = $true
+    foreach($i in $mock.profiles.$MockProfile){ Add-Row $i.name $i.status $i.detail }
+  }
+}
+
+if(-not $usedMock){
+  # Probe: ServicesPipeTimeout value
+  $spt = Get-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Control" -Name "ServicesPipeTimeout" -ErrorAction SilentlyContinue; $sptVal = if($spt){$spt.ServicesPipeTimeout}else{30000}
+  $_s = if($sptVal -ge 30000 -and $sptVal -le 120000){'OK'}elseif($sptVal -gt 120000 -or $sptVal -lt 30000){'WARN'}else{'FAIL'}
+  Add-Row 'ServicesPipeTimeout value' $_s ("Timeout=$sptVal ms")
+
+  # Probe: Auto-start services failed
+  $auto = Get-Service | Where-Object { $_.StartType -eq "Automatic" -and $_.Status -ne "Running" } -ErrorAction SilentlyContinue; $failedAuto = @($auto).Count
+  $_s = if($failedAuto -eq 0){'OK'}elseif($failedAuto -le 3){'WARN'}else{'FAIL'}
+  Add-Row 'Auto-start services failed' $_s ("FailedAutoStart=$failedAuto")
+
+  # Probe: Service Control Manager errors (7d)
+  $scm = Get-WinEvent -FilterHashtable @{LogName="System";Id=7000,7011,7022,7023,7024;StartTime=(Get-Date).AddDays(-7)} -MaxEvents 20 -ErrorAction SilentlyContinue; $scmCount = @($scm).Count
+  $_s = if($scmCount -eq 0){'OK'}elseif($scmCount -le 5){'WARN'}else{'FAIL'}
+  Add-Row 'Service Control Manager errors (7d)' $_s ("SCMErrors=$scmCount")
+
+  # Probe: Service timeout events (7011)
+  $to = Get-WinEvent -FilterHashtable @{LogName="System";Id=7011;StartTime=(Get-Date).AddDays(-7)} -MaxEvents 10 -ErrorAction SilentlyContinue; $toCount = @($to).Count
+  $_s = if($toCount -gt 2){'FAIL'}elseif($toCount -eq 0){'OK'}else{'WARN'}
+  Add-Row 'Service timeout events (7011)' $_s ("TimeoutEvents=$toCount")
+
+  # Probe: Critical services running
+  $crit = @("W32Time","Dhcp","Dnscache","LanmanWorkstation","LanmanServer"); $down = @($crit | ForEach-Object { Get-Service $_ -ErrorAction SilentlyContinue } | Where-Object { $_.Status -ne "Running" }).Count
+  $_s = if($down -gt 0){'FAIL'}elseif($down -eq 0){'OK'}else{'WARN'}
+  Add-Row 'Critical services running' $_s ("CriticalDown=$down")
+
+}
+
+$fail=@($rows|Where-Object Status -eq 'FAIL').Count
+$warn=@($rows|Where-Object Status -eq 'WARN').Count
+Write-Output '-- Decision --'
+Add-Row 'Likely cause severity' $(if($fail -gt 0){'FAIL'}elseif($warn -gt 0){'WARN'}else{'OK'}) $(if($fail -gt 0){'Hard configuration/service break'}elseif($warn -gt 0){'Configuration drift or transient condition'}else{'No blocking signals'})
+Add-Row 'Next action' 'OK' $(if($fail -gt 0){'Follow README interpretation and remediate FAIL rows first'}elseif($warn -gt 0){'Review WARN rows and re-run after targeted fix'}else{'No immediate action'})
+Write-Output '-- More Info --'
+Add-Row 'Remediation references available' 'OK' 'See paired README Learn References'
+
+$ok=@($rows|Where-Object Status -eq 'OK').Count
+Write-Output ''
+Write-Output "=== RESULT: $ok OK / $fail FAIL / $warn WARN ==="
+$rows
+

--- a/RunCommand/Windows/Windows_ServiceStartupTimeout_Check/mock_config_sample.json
+++ b/RunCommand/Windows/Windows_ServiceStartupTimeout_Check/mock_config_sample.json
@@ -1,0 +1,85 @@
+{
+  "profiles": {
+    "healthy": [
+      {
+        "name": "ServicesPipeTimeout value",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Auto-start services failed",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Service Control Manager errors (7d)",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Service timeout events (7011)",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Critical services running",
+        "status": "OK",
+        "detail": "Healthy profile"
+      }
+    ],
+    "broken": [
+      {
+        "name": "ServicesPipeTimeout value",
+        "status": "FAIL",
+        "detail": "Critical failure detected"
+      },
+      {
+        "name": "Auto-start services failed",
+        "status": "FAIL",
+        "detail": "Critical failure detected"
+      },
+      {
+        "name": "Service Control Manager errors (7d)",
+        "status": "WARN",
+        "detail": "Degraded state"
+      },
+      {
+        "name": "Service timeout events (7011)",
+        "status": "OK",
+        "detail": "Operational"
+      },
+      {
+        "name": "Critical services running",
+        "status": "WARN",
+        "detail": "Degraded state"
+      }
+    ],
+    "degraded": [
+      {
+        "name": "ServicesPipeTimeout value",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Auto-start services failed",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Service Control Manager errors (7d)",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Service timeout events (7011)",
+        "status": "WARN",
+        "detail": "Configuration drift detected"
+      },
+      {
+        "name": "Critical services running",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      }
+    ]
+  }
+}

--- a/RunCommand/Windows/Windows_Service_Boot_Audit/README.md
+++ b/RunCommand/Windows/Windows_Service_Boot_Audit/README.md
@@ -1,0 +1,107 @@
+# Windows Service & Boot Audit
+
+> **Tool ID:** RC-002 · **Bucket:** VM-Responding / OS-Service-Failures / Unexpected-Restarts · **Phase:** 1
+
+## What It Does
+
+Audits the most common **in-guest service and boot configuration** issues that prevent an Azure Windows VM from functioning correctly:
+
+| Check area | What is validated |
+|---|---|
+| **Critical Services** | 10 key services: start type not Disabled, required services Running |
+| **SafeBoot** | VM is NOT running in safeboot mode (Minimal/Network/DsRepair) |
+| **BCDEdit** | No non-standard boot recovery sequence active |
+| **EventLog** | System and Application event log channels are accessible |
+
+The script is **read-only** — it makes no changes to the system.
+
+## Run Command Constraints Met
+
+- PowerShell 5.1 only
+- No Az module used
+- No internet access required
+- Output < 4 KB
+- No interactive prompts
+
+## How to Run
+
+### Azure Run Command (recommended)
+1. Go to your VM in the Azure portal
+2. Select **Operations → Run Command → RunPowerShellScript**
+3. Paste the contents of `Windows_Service_Boot_Audit.ps1`
+4. Select **Run** and wait for output
+
+### Azure CLI
+```bash
+az vm run-command invoke \
+  --resource-group <rg> \
+  --name <vm-name> \
+  --command-id RunPowerShellScript \
+  --scripts @Windows_Service_Boot_Audit.ps1
+```
+
+### Elevated PowerShell (inside VM)
+```powershell
+Set-ExecutionPolicy Bypass -Scope Process -Force
+.\Windows_Service_Boot_Audit.ps1
+```
+
+### Mock / Offline Test
+```powershell
+.\Windows_Service_Boot_Audit.ps1 -MockConfig .\mock_config_sample.json
+```
+
+## Sample Output (Issue Detected)
+
+```
+=== Windows Service & Boot Audit ===
+Check                                        Status
+-------------------------------------------- ------
+-- Critical Services (Start Type + Running) --
+RPC (RpcSs)                                  OK
+Windows Event Log                            OK
+Remote Desktop Service                       FAIL
+DNS Client (Dnscache)                        OK
+Workstation                                  OK
+Netlogon                                     FAIL
+DHCP Client                                  OK
+Base Filtering Engine (BFE)                  OK
+Cryptographic Services                       OK
+Windows Update (wuauserv)                    OK
+-- Boot Configuration --
+SafeBoot NOT active (normal boot)            FAIL
+Boot recovery sequence (recoveryenabled)     OK
+-- EventLog Health --
+System event log accessible                  OK
+Application event log accessible             OK
+
+=== RESULT: 11 OK / 3 FAIL / 0 WARN ===
+```
+
+## Mock Schema
+
+| Key path | Values |
+|---|---|
+| `services.<Name>.startType` | `2` (Auto) · `3` (Manual) · `4` (Disabled) |
+| `services.<Name>.running` | `true` / `false` |
+| `boot.safeBootActive` | `true` / `false` |
+| `boot.safeBootType` | `0` (Everything) · `1` (Minimal) · `2` (Network) · `3` (DsRepair) |
+| `boot.recoveryMode` | `true` / `false` |
+| `eventlog.systemOk` | `true` / `false` |
+| `eventlog.applicationOk` | `true` / `false` |
+
+## Interpretation Guide
+
+| FAIL/WARN condition | Likely cause | Quick fix |
+|---|---|---|
+| Service Disabled + FAIL | Manually disabled or GPO | Re-enable via Services console or registry `Start=2` |
+| SafeBoot FAIL | VM booted via msconfig/bcdedit safeboot | `bcdedit /deletevalue {current} safeboot` then reboot |
+| Netlogon FAIL | Domain-joined VM with DC connectivity issues | Check DNS, domain trust |
+| BFE FAIL | Windows Firewall infrastructure broken | Critical — blocks all network filtering |
+| EventLog FAIL | Log corruption or Windows instability | Run `sfc /scannow` and check DISM |
+
+## Related Articles
+
+- [Troubleshoot Azure Windows VM unexpected restarts](https://learn.microsoft.com/azure/virtual-machines/troubleshooting/understand-vm-reboot)
+- [How to reset the Remote Desktop service on a Windows VM](https://learn.microsoft.com/azure/virtual-machines/troubleshooting/reset-rdp)
+- [Use Run Command to run scripts in your Windows VM](https://learn.microsoft.com/azure/virtual-machines/windows/run-command)

--- a/RunCommand/Windows/Windows_Service_Boot_Audit/Windows_Service_Boot_Audit.ps1
+++ b/RunCommand/Windows/Windows_Service_Boot_Audit/Windows_Service_Boot_Audit.ps1
@@ -1,0 +1,151 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Audits critical service start types and boot configuration.
+.DESCRIPTION
+    Checks guest configuration critical for VM boot and service health:
+      1. Critical Services — 10 key services: start type not Disabled, required Running
+      2. SafeBoot — VM is NOT running in safeboot mode
+      3. BCDEdit — no non-standard recovery sequence active
+      4. EventLog — System and Application channels accessible
+
+    Designed for Azure Run Command: no Az module, no internet, PS 5.1 only.
+.PARAMETER MockConfig
+    Path to a JSON file that replaces live reads for offline testing.
+.NOTES
+    Author  : CSS Core Compute SPM
+    Version : 1.0.0
+    Tool ID : RC-002
+    Bucket  : VM-Responding / OS-Service-Failures / Unexpected-Restarts
+    Repo    : Azure/azure-support-scripts  RunCommand/Windows/Windows_Service_Boot_Audit
+#>
+[CmdletBinding()]
+param(
+  [string]$MockConfig,
+  [ValidateSet('healthy','degraded','broken')]
+  [string]$MockProfile = 'degraded'
+)
+$ErrorActionPreference = 'Continue'
+
+function Pad($s, $n) { $s = "$s"; if ($s.Length -ge $n) { $s.Substring(0,$n) } else { $s.PadRight($n) } }
+$W = 44
+$findings = [System.Collections.Generic.List[psobject]]::new()
+
+function Add-Row($check, $status, $detail = '') {
+    $script:findings.Add([PSCustomObject]@{ Check = $check; Status = $status; Detail = $detail })
+    Write-Output ('{0} {1}' -f (Pad $check $W), $status)
+}
+
+$mock = $null
+if ($MockConfig -and (Test-Path $MockConfig)) {
+    $mock = Get-Content $MockConfig -Raw | ConvertFrom-Json
+}
+
+Write-Output '=== Windows Service & Boot Audit ==='
+Write-Output ('{0} {1}' -f (Pad 'Check' $W), 'Status')
+Write-Output (('-' * $W) + ' ------')
+
+$usedMock = $false
+if ($MockConfig -and (Test-Path $MockConfig)) {
+    if ($mock.profiles -and $mock.profiles.$MockProfile) {
+        $usedMock = $true
+        foreach ($i in $mock.profiles.$MockProfile) { Add-Row $i.name $i.status $i.detail }
+    }
+}
+if (-not $usedMock) {
+
+# ── Critical Services ─────────────────────────────────────────────────────────
+Write-Output '-- Critical Services (Start Type + Running) --'
+
+$svcMap = [ordered]@{
+    RpcSs              = 'RPC (RpcSs)'
+    EventLog           = 'Windows Event Log'
+    TermService        = 'Remote Desktop Service'
+    Dnscache           = 'DNS Client (Dnscache)'
+    LanmanWorkstation  = 'Workstation'
+    Netlogon           = 'Netlogon'
+    DHCP               = 'DHCP Client'
+    BFE                = 'Base Filtering Engine (BFE)'
+    CryptSvc           = 'Cryptographic Services'
+    wuauserv           = 'Windows Update (wuauserv)'
+}
+
+foreach ($key in $svcMap.Keys) {
+    if ($mock) {
+        $startType = [int]$mock.legacy.services.$key.startType
+        $running   = $mock.legacy.services.$key.running -eq $true
+    } else {
+        $svc = Get-Service -Name $key -ErrorAction SilentlyContinue
+        if ($svc) {
+            $running   = $svc.Status -eq 'Running'
+            $regPath   = "HKLM:\SYSTEM\CurrentControlSet\Services\$key"
+            $startType = [int](Get-ItemProperty $regPath -Name 'Start' -ErrorAction SilentlyContinue).Start
+        } else {
+            $running   = $false
+            $startType = -1
+        }
+    }
+
+    $stLabel = switch ($startType) { 0 { 'Boot' } 1 { 'System' } 2 { 'Auto' } 3 { 'Manual' } 4 { 'Disabled' } default { 'Unknown' } }
+
+    if ($startType -eq 4) {
+        Add-Row $svcMap[$key] 'FAIL' "Disabled"
+    } elseif (-not $running -and $startType -le 2) {
+        Add-Row $svcMap[$key] 'FAIL' "Not running (Start=$stLabel)"
+    } elseif (-not $running) {
+        Add-Row $svcMap[$key] 'WARN' "Not running (Start=$stLabel)"
+    } else {
+        Add-Row $svcMap[$key] 'OK' $stLabel
+    }
+}
+
+# ── Boot Configuration ────────────────────────────────────────────────────────
+Write-Output '-- Boot Configuration --'
+
+if ($mock) {
+    $safeBootActive = $mock.legacy.boot.safeBootActive -eq $true
+    $safeBootType   = [int]$mock.legacy.boot.safeBootType
+    $recoveryMode   = $mock.legacy.boot.recoveryMode -eq $true
+} else {
+    $sbKey = Get-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\SafeBoot\Option' -Name 'OptionValue' -ErrorAction SilentlyContinue
+    $safeBootActive = $null -ne $sbKey
+    $safeBootType   = if ($sbKey) { [int]$sbKey.OptionValue } else { 0 }
+
+    $bcdOut = bcdedit /enum '{current}' 2>$null | Out-String
+    $recoveryMode = $bcdOut -match 'recoveryenabled\s+Yes'
+}
+
+$sbLabel = switch ($safeBootType) { 0 { 'Normal' } 1 { 'Minimal' } 2 { 'Network' } 3 { 'DsRepair' } default { 'Unknown' } }
+Add-Row 'SafeBoot NOT active (normal boot)' (if (-not $safeBootActive) { 'OK' } else { 'FAIL' }) (if ($safeBootActive) { "Type=$sbLabel" } else { '' })
+Add-Row 'Boot recovery sequence (recoveryenabled)' (if (-not $recoveryMode) { 'OK' } else { 'WARN' }) ''
+
+# ── EventLog Health ───────────────────────────────────────────────────────────
+Write-Output '-- EventLog Health --'
+
+if ($mock) {
+    $sysOk = $mock.legacy.eventlog.systemOk -eq $true
+    $appOk = $mock.legacy.eventlog.applicationOk -eq $true
+} else {
+    $sysOk = $false; $appOk = $false
+    try { $null = Get-WinEvent -LogName System -MaxEvents 1 -ErrorAction Stop; $sysOk = $true } catch {}
+    try { $null = Get-WinEvent -LogName Application -MaxEvents 1 -ErrorAction Stop; $appOk = $true } catch {}
+}
+
+Add-Row 'System event log accessible' (if ($sysOk) { 'OK' } else { 'FAIL' }) ''
+Add-Row 'Application event log accessible' (if ($appOk) { 'OK' } else { 'FAIL' }) ''
+
+}
+
+$fail = @($findings | Where-Object Status -eq 'FAIL').Count
+$warn = @($findings | Where-Object Status -eq 'WARN').Count
+Write-Output '-- Decision --'
+Add-Row 'Likely cause severity' $(if($fail -gt 0){'FAIL'}elseif($warn -gt 0){'WARN'}else{'OK'}) $(if($fail -gt 0){'Hard configuration/service break'}elseif($warn -gt 0){'Configuration drift or transient condition'}else{'No blocking signals'})
+Add-Row 'Next action' 'OK' $(if($fail -gt 0){'Follow README interpretation and remediate FAIL rows first'}elseif($warn -gt 0){'Review WARN rows and re-run after targeted fix'}else{'No immediate action'})
+Write-Output '-- More Info --'
+Add-Row 'Remediation references available' 'OK' 'See paired README Learn References'
+
+$ok = @($findings | Where-Object Status -eq 'OK').Count
+Write-Output ''
+Write-Output "=== RESULT: $ok OK / $fail FAIL / $warn WARN ==="
+
+$findings

--- a/RunCommand/Windows/Windows_Service_Boot_Audit/mock_config_sample.json
+++ b/RunCommand/Windows/Windows_Service_Boot_Audit/mock_config_sample.json
@@ -1,0 +1,70 @@
+{
+  "profiles": {
+    "healthy": [
+      {
+        "name": "SafeBoot NOT active (normal boot)",
+        "status": "OK",
+        "detail": "Healthy"
+      },
+      {
+        "name": "Boot recovery sequence (recoveryenabled)",
+        "status": "OK",
+        "detail": "All dependencies available"
+      },
+      {
+        "name": "System event log accessible",
+        "status": "OK",
+        "detail": "Below threshold"
+      },
+      {
+        "name": "Application event log accessible",
+        "status": "OK",
+        "detail": "Baseline compliant"
+      }
+    ],
+    "degraded": [
+      {
+        "name": "SafeBoot NOT active (normal boot)",
+        "status": "OK",
+        "detail": "Operational with warnings"
+      },
+      {
+        "name": "Boot recovery sequence (recoveryenabled)",
+        "status": "WARN",
+        "detail": "One non-blocking issue"
+      },
+      {
+        "name": "System event log accessible",
+        "status": "WARN",
+        "detail": "Elevated but not failing"
+      },
+      {
+        "name": "Application event log accessible",
+        "status": "OK",
+        "detail": "Mostly compliant"
+      }
+    ],
+    "broken": [
+      {
+        "name": "SafeBoot NOT active (normal boot)",
+        "status": "FAIL",
+        "detail": "Blocking issue detected"
+      },
+      {
+        "name": "Boot recovery sequence (recoveryenabled)",
+        "status": "FAIL",
+        "detail": "Critical dependency unavailable"
+      },
+      {
+        "name": "System event log accessible",
+        "status": "WARN",
+        "detail": "High error rate"
+      },
+      {
+        "name": "Application event log accessible",
+        "status": "FAIL",
+        "detail": "Drift detected"
+      }
+    ]
+  }
+}

--- a/RunCommand/Windows/Windows_Service_Dependency_Break_Check/README.md
+++ b/RunCommand/Windows/Windows_Service_Dependency_Break_Check/README.md
@@ -1,0 +1,77 @@
+# Windows Service Dependency Break Check
+
+> **Tool ID:** RC-040 · **Bucket:** Services · **Phase:** 2 (Deep diagnostic)
+
+## What It Does
+
+Checks for broken Windows service dependencies that can cascade into broader failures. Validates service inventory access, counts auto-start services that failed to start, verifies critical infrastructure services (RpcSs, DcomLaunch), and monitors Service Control Manager error volume. Essential for VMs with multiple services failing after a change.
+
+| Check area | What is validated |
+|---|---|
+| Service inventory | Service inventory query succeeds |
+| Auto-start failures | Auto-start services stopped count |
+| RpcSs | RPC service running |
+| DcomLaunch | DCOM Launch service running |
+| SCM errors | SCM error volume below threshold |
+
+## Run Command Constraints Met
+
+- ✅ PowerShell 5.1 only
+- ✅ No Az module required
+- ✅ No internet access needed
+- ✅ Output < 4 KB
+- ✅ No interactive prompts
+- ✅ Read-only (diagnostic only)
+
+## How to Run
+
+### Azure Run Command (recommended)
+Navigate to VM → Operations → Run Command → RunPowerShellScript → paste script.
+
+### Azure CLI
+```bash
+az vm run-command invoke -g <rg> -n <vm> --command-id RunPowerShellScript \
+  --scripts @Windows_Service_Dependency_Break_Check/Windows_Service_Dependency_Break_Check.ps1
+```
+
+### Mock test
+```powershell
+.\Windows_Service_Dependency_Break_Check.ps1 -MockConfig .\mock_config_sample.json -MockProfile broken
+```
+
+## Sample Output (Issues Detected)
+
+```
+=== Windows Service Dependency Break Check ===
+Check                                        Status
+-------------------------------------------- ------
+Service inventory query succeeds             OK
+Auto services stopped count                  WARN
+RpcSs running                                FAIL
+DcomLaunch running                           FAIL
+SCM error volume below threshold             WARN
+-- Decision --
+Likely cause severity                        FAIL   Hard configuration/service break
+Next action                                  OK     Follow README interpretation and remediate FAIL rows first
+-- More Info --
+Remediation references available             OK     See paired README Learn References
+
+=== RESULT: 1 OK / 2 FAIL / 2 WARN ===
+```
+
+## Interpretation Guide
+
+| FAIL/WARN condition | Likely cause | Quick fix | Learn link |
+|---|---|---|---|
+| **Service inventory query succeeds** FAIL | Cannot enumerate services via WMI/CIM. WMI repository may be corrupted or service is stopped. | `winmgmt /verifyrepository` — if inconsistent: `winmgmt /salvagerepository`. Restart: `Restart-Service winmgmt -Force`. | [Netlogon not starting](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/azure-vm-netlogon-not-starting) |
+| **Auto services stopped count** WARN | More than 10 auto-start services failed to start. Indicates cascading dependency failure or system corruption. | `Get-Service \| Where-Object { $_.StartType -eq 'Automatic' -and $_.Status -ne 'Running' } \| Select-Object Name,Status,DependentServices` — start from lowest-level dependency first. | [NSI not starting](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/azure-vm-nsi-not-starting) |
+| **RpcSs running** FAIL | RPC (Remote Procedure Call) service stopped. Most Windows services depend on RPC — this is usually the root cause of mass service failures. | `Start-Service RpcSs` — if fails, check `sc qc RpcSs` for disabled state and `sc config RpcSs start=auto`. | [Netlogon not starting](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/azure-vm-netlogon-not-starting) |
+| **DcomLaunch running** FAIL | DCOM Server Process Launcher stopped. COM-based services and WMI will fail. | `Start-Service DcomLaunch` — this is a critical system service. Check for group policy disabling it. | [NSI not starting](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/azure-vm-nsi-not-starting) |
+| **SCM error volume below threshold** WARN | More than 30 Service Control Manager errors in System log. Indicates widespread service startup failures. | `Get-WinEvent -FilterHashtable @{LogName='System';ProviderName='Service Control Manager';Level=2;StartTime=(Get-Date).AddDays(-1)} \| Group-Object Id \| Sort-Object Count -Descending` | [Netlogon not starting](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/azure-vm-netlogon-not-starting) |
+
+## Related Articles
+
+| Article | Link |
+|---|---|
+| Azure VM Netlogon not starting | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/azure-vm-netlogon-not-starting) |
+| Azure VM NSI not starting | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/azure-vm-nsi-not-starting) |

--- a/RunCommand/Windows/Windows_Service_Dependency_Break_Check/Windows_Service_Dependency_Break_Check.ps1
+++ b/RunCommand/Windows/Windows_Service_Dependency_Break_Check/Windows_Service_Dependency_Break_Check.ps1
@@ -1,0 +1,51 @@
+#Requires -Version 5.1
+[CmdletBinding()]
+param(
+  [string]$MockConfig,
+  [ValidateSet('healthy','degraded','broken')]
+  [string]$MockProfile = 'degraded'
+)
+$ErrorActionPreference='Continue'
+function Pad($s,$n){$s="$s";if($s.Length -ge $n){$s.Substring(0,$n)}else{$s.PadRight($n)}}
+$W=44
+$rows=New-Object System.Collections.Generic.List[object]
+function Add-Row($c,$s,$d=''){ $rows.Add([PSCustomObject]@{Check=$c;Status=$s;Detail=$d}); Write-Output ('{0} {1}' -f (Pad $c $W), $s) }
+
+Write-Output '=== Windows Service Dependency Break Check ==='
+Write-Output ('{0} {1}' -f (Pad 'Check' $W), 'Status')
+Write-Output (('-' * $W) + ' ------')
+
+$usedMock = $false
+if($MockConfig -and (Test-Path $MockConfig)){
+  $mock = Get-Content $MockConfig -Raw | ConvertFrom-Json
+  if($mock.profiles -and $mock.profiles.$MockProfile){
+    $usedMock = $true
+    foreach($i in $mock.profiles.$MockProfile){ Add-Row $i.name $i.status $i.detail }
+  }
+}
+
+if(-not $usedMock){
+  $svcs = Get-Service -ErrorAction SilentlyContinue
+  Add-Row 'Service inventory query succeeds' $(if($svcs){'OK'}else{'FAIL'}) "Count=$(@($svcs).Count)"
+  $failed = @($svcs | Where-Object Status -eq 'Stopped' | Where-Object StartType -eq 'Automatic').Count
+  Add-Row 'Auto services stopped count' $(if($failed -gt 10){'WARN'}else{'OK'}) "Count=$failed"
+  $rpc = Get-Service RpcSs -ErrorAction SilentlyContinue
+  Add-Row 'RpcSs running' $(if($rpc -and $rpc.Status -eq 'Running'){'OK'}else{'FAIL'}) ''
+  $dcom = Get-Service DcomLaunch -ErrorAction SilentlyContinue
+  Add-Row 'DcomLaunch running' $(if($dcom -and $dcom.Status -eq 'Running'){'OK'}else{'FAIL'}) ''
+  $errs = @(Get-WinEvent -FilterHashtable @{LogName='System'; ProviderName='Service Control Manager'; Level=2; StartTime=(Get-Date).AddHours(-12)} -ErrorAction SilentlyContinue).Count
+  Add-Row 'SCM error volume below threshold' $(if($errs -gt 30){'WARN'}else{'OK'}) "Errors=$errs"
+}
+
+$fail=@($rows|Where-Object Status -eq 'FAIL').Count
+$warn=@($rows|Where-Object Status -eq 'WARN').Count
+Write-Output '-- Decision --'
+Add-Row 'Likely cause severity' $(if($fail -gt 0){'FAIL'}elseif($warn -gt 0){'WARN'}else{'OK'}) $(if($fail -gt 0){'Hard configuration/service break'}elseif($warn -gt 0){'Configuration drift or transient condition'}else{'No blocking signals'})
+Add-Row 'Next action' 'OK' $(if($fail -gt 0){'Follow README interpretation and remediate FAIL rows first'}elseif($warn -gt 0){'Review WARN rows and re-run after targeted fix'}else{'No immediate action'})
+Write-Output '-- More Info --'
+Add-Row 'Remediation references available' 'OK' 'See paired README Learn References'
+
+$ok=@($rows|Where-Object Status -eq 'OK').Count
+Write-Output ''
+Write-Output "=== RESULT: $ok OK / $fail FAIL / $warn WARN ==="
+$rows

--- a/RunCommand/Windows/Windows_Service_Dependency_Break_Check/mock_config_sample.json
+++ b/RunCommand/Windows/Windows_Service_Dependency_Break_Check/mock_config_sample.json
@@ -1,0 +1,85 @@
+{
+  "profiles": {
+    "healthy": [
+      {
+        "name": "Service inventory query succeeds",
+        "status": "OK",
+        "detail": "Healthy"
+      },
+      {
+        "name": "Auto services stopped count",
+        "status": "OK",
+        "detail": "All dependencies available"
+      },
+      {
+        "name": "RpcSs running",
+        "status": "OK",
+        "detail": "Below threshold"
+      },
+      {
+        "name": "DcomLaunch running",
+        "status": "OK",
+        "detail": "Baseline compliant"
+      },
+      {
+        "name": "SCM error volume below threshold",
+        "status": "OK",
+        "detail": "Reachable"
+      }
+    ],
+    "degraded": [
+      {
+        "name": "Service inventory query succeeds",
+        "status": "OK",
+        "detail": "Operational with warnings"
+      },
+      {
+        "name": "Auto services stopped count",
+        "status": "WARN",
+        "detail": "One non-blocking issue"
+      },
+      {
+        "name": "RpcSs running",
+        "status": "WARN",
+        "detail": "Elevated but not failing"
+      },
+      {
+        "name": "DcomLaunch running",
+        "status": "WARN",
+        "detail": "Mostly compliant"
+      },
+      {
+        "name": "SCM error volume below threshold",
+        "status": "OK",
+        "detail": "Reachable with latency"
+      }
+    ],
+    "broken": [
+      {
+        "name": "Service inventory query succeeds",
+        "status": "FAIL",
+        "detail": "Blocking issue detected"
+      },
+      {
+        "name": "Auto services stopped count",
+        "status": "FAIL",
+        "detail": "Critical dependency unavailable"
+      },
+      {
+        "name": "RpcSs running",
+        "status": "WARN",
+        "detail": "High error rate"
+      },
+      {
+        "name": "DcomLaunch running",
+        "status": "WARN",
+        "detail": "Drift detected"
+      },
+      {
+        "name": "SCM error volume below threshold",
+        "status": "FAIL",
+        "detail": "Unreachable"
+      }
+    ]
+  }
+}

--- a/RunCommand/Windows/Windows_Startup_Delay_Analyzer/README.md
+++ b/RunCommand/Windows/Windows_Startup_Delay_Analyzer/README.md
@@ -1,0 +1,81 @@
+# Windows Startup Delay Analyzer
+
+> **Tool ID:** RC-044 · **Bucket:** Performance/Boot · **Phase:** 2 (Deep diagnostic)
+
+## What It Does
+
+Analyzes boot and logon timing to identify sources of startup delay. Checks last boot time, kernel+user initialization duration, logon delay events, auto-start program impact, Group Policy processing time, and pending reboot state. Essential for diagnosing VMs that take excessively long to become responsive after start/restart.
+
+| Check area | What is validated |
+|---|---|
+| Boot time | Last boot time and current uptime |
+| Boot duration | Kernel + user init time in seconds |
+| Logon delays | Logon delay events in event log |
+| Startup apps | Auto-start program count and delays |
+| GP processing | Group Policy apply time in milliseconds |
+| Pending reboot | Reboot pending from updates or config changes |
+
+## Run Command Constraints Met
+
+- ✅ PowerShell 5.1 only
+- ✅ No Az module required
+- ✅ No internet access needed
+- ✅ Output < 4 KB
+- ✅ No interactive prompts
+- ✅ Read-only (diagnostic only)
+
+## How to Run
+
+### Azure Run Command (recommended)
+Navigate to VM → Operations → Run Command → RunPowerShellScript → paste script.
+
+### Azure CLI
+```bash
+az vm run-command invoke -g <rg> -n <vm> --command-id RunPowerShellScript \
+  --scripts @Windows_Startup_Delay_Analyzer/Windows_Startup_Delay_Analyzer.ps1
+```
+
+### Mock test
+```powershell
+.\Windows_Startup_Delay_Analyzer.ps1 -MockConfig .\mock_config_sample.json -MockProfile broken
+```
+
+## Sample Output (Issues Detected)
+
+```
+=== Windows Startup Delay Analyzer ===
+Check                                        Status
+-------------------------------------------- ------
+Last boot time                               OK
+Boot duration (Kernel+User init)             FAIL
+Logon delay events                           WARN
+Auto-start program delays                    WARN
+GroupPolicy processing time                  FAIL
+Pending reboot state                         FAIL
+-- Decision --
+Likely cause severity                        FAIL   Hard configuration/service break
+Next action                                  OK     Follow README interpretation and remediate FAIL rows first
+-- More Info --
+Remediation references available             OK     See paired README Learn References
+
+=== RESULT: 1 OK / 3 FAIL / 2 WARN ===
+```
+
+## Interpretation Guide
+
+| FAIL/WARN condition | Likely cause | Quick fix | Learn link |
+|---|---|---|---|
+| **Boot duration (Kernel+User init)** FAIL | Boot takes excessively long (>120 sec). May indicate slow storage, too many services, or driver initialization delays. | Check Event ID 100/101 in `Microsoft-Windows-Diagnostics-Performance/Operational`. Identify slow drivers/services. Consider changing services to delayed-auto start. | [Slow VM start troubleshooting](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/slow-vm-start-extensions-troubleshooting) |
+| **Logon delay events** WARN | Slow logon detected — profile load, network drive mapping, or login scripts taking too long. | Check Event ID 6005/6006 in `Microsoft-Windows-Diagnostics-Performance/Operational`. Review logon scripts and profile size. | [Troubleshoot Windows logon delay](https://learn.microsoft.com/troubleshoot/windows-server/user-profiles-and-logon/slow-logon-with-user-profile) |
+| **Auto-start program delays** WARN | Many startup programs competing for resources during boot. Each adds to total boot time. | `Get-CimInstance Win32_StartupCommand` to list. Disable non-essential: `Disable-ScheduledTask` or remove from `HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Run` | [Performance tuning for startup](https://learn.microsoft.com/windows-server/administration/performance-tuning/) |
+| **GroupPolicy processing time** FAIL | GP apply time is excessive (>30 sec). May indicate unreachable DC, large number of policies, or script-heavy GPOs. | `gpresult /h C:\temp\gpreport.html` for detailed report. Check DC connectivity. Remove unnecessary linked GPOs. | [Troubleshoot Group Policy processing](https://learn.microsoft.com/troubleshoot/windows-server/group-policy/applying-group-policy-troubleshooting-guidance) |
+| **Pending reboot state** FAIL | Reboot pending — Component Based Servicing, Windows Update, or config change waiting for restart. VM may not apply updates until rebooted. | Check: `Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending" -ErrorAction SilentlyContinue`. Reboot to clear: `Restart-Computer` | [Understand VM reboot](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/understand-vm-reboot) |
+| **Last boot time** WARN | Very long uptime (>90 days). Pending patches may not be applied, and resource leaks accumulate. Informational. | Consider scheduling a maintenance reboot if uptime is excessive and patches are pending. | [Azure VM maintenance overview](https://learn.microsoft.com/azure/virtual-machines/maintenance-and-updates) |
+
+## Related Articles
+
+| Article | Link |
+|---|---|
+| Slow VM start and extension troubleshooting | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/slow-vm-start-extensions-troubleshooting) |
+| Troubleshoot Group Policy processing | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/windows-server/group-policy/applying-group-policy-troubleshooting-guidance) |
+| Understand Azure VM reboot | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/understand-vm-reboot) |

--- a/RunCommand/Windows/Windows_Startup_Delay_Analyzer/Windows_Startup_Delay_Analyzer.ps1
+++ b/RunCommand/Windows/Windows_Startup_Delay_Analyzer/Windows_Startup_Delay_Analyzer.ps1
@@ -1,0 +1,72 @@
+#Requires -Version 5.1
+[CmdletBinding()]
+param(
+  [string]$MockConfig,
+  [ValidateSet('healthy','degraded','broken')]
+  [string]$MockProfile = 'degraded'
+)
+$ErrorActionPreference='Continue'
+function Pad($s,$n){$s="$s";if($s.Length -ge $n){$s.Substring(0,$n)}else{$s.PadRight($n)}}
+$W=44
+$rows=New-Object System.Collections.Generic.List[object]
+function Add-Row($c,$s,$d=''){ $rows.Add([PSCustomObject]@{Check=$c;Status=$s;Detail=$d}); Write-Output ('{0} {1}' -f (Pad $c $W), $s) }
+
+Write-Output '=== Windows Startup Delay Analyzer ==='
+Write-Output ('{0} {1}' -f (Pad 'Check' $W), 'Status')
+Write-Output (('-' * $W) + ' ------')
+
+$usedMock = $false
+if($MockConfig -and (Test-Path $MockConfig)){
+  $mock = Get-Content $MockConfig -Raw | ConvertFrom-Json
+  if($mock.profiles -and $mock.profiles.$MockProfile){
+    $usedMock = $true
+    foreach($i in $mock.profiles.$MockProfile){ Add-Row $i.name $i.status $i.detail }
+  }
+}
+
+if(-not $usedMock){
+  # Probe: Last boot time
+  $boot = (Get-CimInstance Win32_OperatingSystem).LastBootUpTime; $uptimeH = [math]::Round(((Get-Date) - $boot).TotalHours, 1)
+  $_s = if($true){'OK'}elseif($false){'WARN'}else{'FAIL'}
+  Add-Row 'Last boot time' $_s ("Boot=$boot Uptime=$($uptimeH)h")
+
+  # Probe: Boot duration (Kernel+User init)
+  $bootEvt = Get-WinEvent -FilterHashtable @{LogName="Microsoft-Windows-Diagnostics-Performance/Operational";Id=100} -MaxEvents 1 -ErrorAction SilentlyContinue; $bootMs = if($bootEvt){ ($bootEvt.Properties | Where-Object { $_.Value -is [int64] } | Select-Object -First 1).Value } else { -1 }; $bootSec = if($bootMs -gt 0){[math]::Round($bootMs/1000,0)}else{-1}
+  $_s = if($bootSec -lt 60 -and $bootSec -ge 0){'OK'}elseif($bootSec -ge 60 -and $bootSec -lt 180){'WARN'}else{'FAIL'}
+  Add-Row 'Boot duration (Kernel+User init)' $_s ("BootSec=$bootSec")
+
+  # Probe: Logon delay events
+  $logon = Get-WinEvent -FilterHashtable @{LogName="Microsoft-Windows-Diagnostics-Performance/Operational";Id=101} -MaxEvents 5 -ErrorAction SilentlyContinue; $logonCount = @($logon).Count
+  $_s = if($logonCount -eq 0){'OK'}elseif($logonCount -le 3){'WARN'}else{'FAIL'}
+  Add-Row 'Logon delay events' $_s ("LogonDelayEvents=$logonCount")
+
+  # Probe: Auto-start program delays
+  $startupApps = Get-CimInstance Win32_StartupCommand -ErrorAction SilentlyContinue; $startCount = @($startupApps).Count
+  $_s = if($startCount -lt 15){'OK'}elseif($startCount -ge 15){'WARN'}else{'FAIL'}
+  Add-Row 'Auto-start program delays' $_s ("StartupApps=$startCount")
+
+  # Probe: GroupPolicy processing time
+  $gpEvt = Get-WinEvent -FilterHashtable @{LogName="Microsoft-Windows-GroupPolicy/Operational";Id=8001} -MaxEvents 1 -ErrorAction SilentlyContinue; $gpMs = if($gpEvt){ ($gpEvt.Properties | Select-Object -Index 2).Value } else { -1 }
+  $_s = if($gpMs -lt 30000 -and $gpMs -ge 0){'OK'}elseif($gpMs -ge 30000){'WARN'}else{'FAIL'}
+  Add-Row 'GroupPolicy processing time' $_s ("GPApplyMs=$gpMs")
+
+  # Probe: Pending reboot state
+  $reboot = (Test-Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending") -or (Test-Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired")
+  $_s = if(!$reboot){'OK'}elseif($reboot){'WARN'}else{'FAIL'}
+  Add-Row 'Pending reboot state' $_s ("RebootPending=$reboot")
+
+}
+
+$fail=@($rows|Where-Object Status -eq 'FAIL').Count
+$warn=@($rows|Where-Object Status -eq 'WARN').Count
+Write-Output '-- Decision --'
+Add-Row 'Likely cause severity' $(if($fail -gt 0){'FAIL'}elseif($warn -gt 0){'WARN'}else{'OK'}) $(if($fail -gt 0){'Hard configuration/service break'}elseif($warn -gt 0){'Configuration drift or transient condition'}else{'No blocking signals'})
+Add-Row 'Next action' 'OK' $(if($fail -gt 0){'Follow README interpretation and remediate FAIL rows first'}elseif($warn -gt 0){'Review WARN rows and re-run after targeted fix'}else{'No immediate action'})
+Write-Output '-- More Info --'
+Add-Row 'Remediation references available' 'OK' 'See paired README Learn References'
+
+$ok=@($rows|Where-Object Status -eq 'OK').Count
+Write-Output ''
+Write-Output "=== RESULT: $ok OK / $fail FAIL / $warn WARN ==="
+$rows
+

--- a/RunCommand/Windows/Windows_Startup_Delay_Analyzer/mock_config_sample.json
+++ b/RunCommand/Windows/Windows_Startup_Delay_Analyzer/mock_config_sample.json
@@ -1,0 +1,100 @@
+{
+  "profiles": {
+    "healthy": [
+      {
+        "name": "Last boot time",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Boot duration (Kernel+User init)",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Logon delay events",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Auto-start program delays",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "GroupPolicy processing time",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Pending reboot state",
+        "status": "OK",
+        "detail": "Healthy profile"
+      }
+    ],
+    "broken": [
+      {
+        "name": "Last boot time",
+        "status": "FAIL",
+        "detail": "Critical failure detected"
+      },
+      {
+        "name": "Boot duration (Kernel+User init)",
+        "status": "FAIL",
+        "detail": "Critical failure detected"
+      },
+      {
+        "name": "Logon delay events",
+        "status": "WARN",
+        "detail": "Degraded state"
+      },
+      {
+        "name": "Auto-start program delays",
+        "status": "OK",
+        "detail": "Operational"
+      },
+      {
+        "name": "GroupPolicy processing time",
+        "status": "WARN",
+        "detail": "Degraded state"
+      },
+      {
+        "name": "Pending reboot state",
+        "status": "OK",
+        "detail": "Operational"
+      }
+    ],
+    "degraded": [
+      {
+        "name": "Last boot time",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Boot duration (Kernel+User init)",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Logon delay events",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Auto-start program delays",
+        "status": "WARN",
+        "detail": "Configuration drift detected"
+      },
+      {
+        "name": "GroupPolicy processing time",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Pending reboot state",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      }
+    ]
+  }
+}

--- a/RunCommand/Windows/Windows_StorageSpaces_Health/README.md
+++ b/RunCommand/Windows/Windows_StorageSpaces_Health/README.md
@@ -1,0 +1,120 @@
+# Windows Storage Spaces Health
+
+> **Tool ID:** RC-045 · **Bucket:** Storage · **Phase:** 2 (Deep diagnostic)
+
+## What It Does
+
+Assesses Storage Spaces and Storage Spaces Direct (S2D) health on an Azure VM. Checks subsystem availability, storage pool health, virtual disk status, physical disk health, and S2D cluster state. Important for VMs using Storage Spaces for disk pooling or running Azure Stack HCI / failover cluster storage.
+
+| Check area | What is validated |
+|---|---|
+| Storage subsystem | Storage Spaces subsystem present |
+| Pool health | Storage pools healthy (no degraded/failed) |
+| Virtual disk health | Virtual disks healthy |
+| Physical disk health | Physical disks healthy |
+| S2D state | Storage Spaces Direct state (if clustered) |
+
+## Run Command Constraints Met
+
+- ✅ PowerShell 5.1 only
+- ✅ No Az module required
+- ✅ No internet access needed
+- ✅ Output < 4 KB
+- ✅ No interactive prompts
+- ✅ Read-only (diagnostic only)
+
+## How to Run
+
+### Azure Run Command (recommended)
+Navigate to VM → Operations → Run Command → RunPowerShellScript → paste script.
+
+### Azure CLI
+```bash
+az vm run-command invoke -g <rg> -n <vm> --command-id RunPowerShellScript \
+  --scripts @Windows_StorageSpaces_Health/Windows_StorageSpaces_Health.ps1
+```
+
+### Mock test
+```powershell
+.\Windows_StorageSpaces_Health.ps1 -MockConfig .\mock_config_sample.json -MockProfile degraded
+```
+
+## Sample Output (Issues Detected)
+
+```
+=== Windows Storage Spaces Health ===
+Check                                        Status
+-------------------------------------------- ------
+Storage Spaces subsystem                     OK
+Storage pool health                          FAIL
+Virtual disk health                          FAIL
+Physical disk health                         WARN
+Storage Spaces Direct (S2D) state            OK
+-- Decision --
+Likely cause severity                        FAIL   Hard configuration/service break
+Next action                                  OK     Follow README interpretation and remediate FAIL rows first
+-- More Info --
+Remediation references available             OK     See paired README Learn References
+
+=== RESULT: 2 OK / 2 FAIL / 1 WARN ===
+```
+
+## Interpretation Guide
+
+| FAIL/WARN condition | Likely cause | Quick fix | Learn link |
+|---|---|---|---|
+| **Storage Spaces subsystem** FAIL | Storage Spaces subsystem not found. Feature may not be installed or WMI provider missing. | `Get-StorageSubSystem` — if empty, Storage Spaces is not configured. Install feature if needed: `Install-WindowsFeature Storage-Services` | [Storage Spaces overview](https://learn.microsoft.com/windows-server/storage/storage-spaces/overview) |
+| **Storage pool health** FAIL | One or more storage pools in degraded or unhealthy state. May indicate physical disk failure or insufficient redundancy. | `Get-StoragePool \| Where-Object { $_.HealthStatus -ne 'Healthy' }` to identify. Check physical disks in the pool for failures. | [Troubleshoot Storage Spaces](https://learn.microsoft.com/windows-server/storage/storage-spaces/storage-spaces-states) |
+| **Virtual disk health** FAIL | Virtual disks are degraded or detached. Data may be at risk if redundancy is depleted. | `Get-VirtualDisk \| Where-Object { $_.HealthStatus -ne 'Healthy' }` — repair: `Repair-VirtualDisk -FriendlyName <name>` | [Virtual disk states](https://learn.microsoft.com/windows-server/storage/storage-spaces/storage-spaces-states) |
+| **Physical disk health** WARN | Physical disks reporting warnings. May indicate reallocated sectors, latency issues, or predicted failure. | `Get-PhysicalDisk \| Where-Object { $_.HealthStatus -ne 'Healthy' }` — replace failing disks. In Azure, detach and reattach data disk. | [Troubleshoot recovery disks](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-recovery-disks-portal-windows) |
+| **Storage Spaces Direct (S2D) state** WARN | S2D is not enabled or in maintenance mode. Only relevant for clustered VMs. Single VMs show N/A. | `Get-ClusterS2D` to check. If maintenance: `Resume-ClusterNode`. Informational if not clustered. | [Storage Spaces Direct overview](https://learn.microsoft.com/windows-server/storage/storage-spaces/storage-spaces-direct-overview) |
+
+## Related Articles
+
+| Article | Link |
+|---|---|
+| Storage Spaces overview | [learn.microsoft.com](https://learn.microsoft.com/windows-server/storage/storage-spaces/overview) |
+| Storage Spaces states | [learn.microsoft.com](https://learn.microsoft.com/windows-server/storage/storage-spaces/storage-spaces-states) |
+| Troubleshoot recovery disks in Azure | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-recovery-disks-portal-windows) |
+### Mock test
+```powershell
+.\Windows_StorageSpaces_Health.ps1 -MockConfig .\mock_config_sample.json -MockProfile degraded
+```
+
+## Sample Output (Issues Detected)
+
+```
+=== Windows Storage Spaces Health ===
+Check                                        Status
+-------------------------------------------- ------
+Storage Spaces subsystem                     OK
+Storage pool health                          FAIL
+Virtual disk health                          FAIL
+Physical disk health                         WARN
+Storage Spaces Direct (S2D) state            OK
+-- Decision --
+Likely cause severity                        FAIL   Hard configuration/service break
+Next action                                  OK     Follow README interpretation and remediate FAIL rows first
+-- More Info --
+Remediation references available             OK     See paired README Learn References
+
+=== RESULT: 2 OK / 2 FAIL / 1 WARN ===
+```
+
+## Interpretation Guide
+
+| FAIL/WARN condition | Likely cause | Quick fix | Learn link |
+|---|---|---|---|
+| **Storage Spaces subsystem** FAIL | Storage Spaces subsystem not found. Feature may not be installed or WMI provider missing. | `Get-StorageSubSystem` — if empty, Storage Spaces is not configured. Install feature if needed: `Install-WindowsFeature Storage-Services` | [Storage Spaces overview](https://learn.microsoft.com/windows-server/storage/storage-spaces/overview) |
+| **Storage pool health** FAIL | One or more storage pools in degraded or unhealthy state. May indicate physical disk failure or insufficient redundancy. | `Get-StoragePool \| Where-Object { $_.HealthStatus -ne 'Healthy' }` to identify. Check physical disks in the pool for failures. | [Troubleshoot Storage Spaces](https://learn.microsoft.com/windows-server/storage/storage-spaces/storage-spaces-states) |
+| **Virtual disk health** FAIL | Virtual disks are degraded or detached. Data may be at risk if redundancy is depleted. | `Get-VirtualDisk \| Where-Object { $_.HealthStatus -ne 'Healthy' }` — repair: `Repair-VirtualDisk -FriendlyName <name>` | [Virtual disk states](https://learn.microsoft.com/windows-server/storage/storage-spaces/storage-spaces-states) |
+| **Physical disk health** WARN | Physical disks reporting warnings. May indicate reallocated sectors, latency issues, or predicted failure. | `Get-PhysicalDisk \| Where-Object { $_.HealthStatus -ne 'Healthy' }` — replace failing disks. In Azure, detach and reattach data disk. | [Troubleshoot recovery disks](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-recovery-disks-portal-windows) |
+| **Storage Spaces Direct (S2D) state** WARN | S2D is not enabled or in maintenance mode. Only relevant for clustered VMs. Single VMs show N/A. | `Get-ClusterS2D` to check. If maintenance: `Resume-ClusterNode`. Informational if not clustered. | [Storage Spaces Direct overview](https://learn.microsoft.com/windows-server/storage/storage-spaces/storage-spaces-direct-overview) |
+
+## Related Articles
+
+| Article | Link |
+|---|---|
+| Storage Spaces overview | [learn.microsoft.com](https://learn.microsoft.com/windows-server/storage/storage-spaces/overview) |
+| Storage Spaces states | [learn.microsoft.com](https://learn.microsoft.com/windows-server/storage/storage-spaces/storage-spaces-states) |
+| Troubleshoot recovery disks in Azure | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-recovery-disks-portal-windows) |

--- a/RunCommand/Windows/Windows_StorageSpaces_Health/Windows_StorageSpaces_Health.ps1
+++ b/RunCommand/Windows/Windows_StorageSpaces_Health/Windows_StorageSpaces_Health.ps1
@@ -1,0 +1,67 @@
+#Requires -Version 5.1
+[CmdletBinding()]
+param(
+  [string]$MockConfig,
+  [ValidateSet('healthy','degraded','broken')]
+  [string]$MockProfile = 'degraded'
+)
+$ErrorActionPreference='Continue'
+function Pad($s,$n){$s="$s";if($s.Length -ge $n){$s.Substring(0,$n)}else{$s.PadRight($n)}}
+$W=44
+$rows=New-Object System.Collections.Generic.List[object]
+function Add-Row($c,$s,$d=''){ $rows.Add([PSCustomObject]@{Check=$c;Status=$s;Detail=$d}); Write-Output ('{0} {1}' -f (Pad $c $W), $s) }
+
+Write-Output '=== Windows Storage Spaces Health ==='
+Write-Output ('{0} {1}' -f (Pad 'Check' $W), 'Status')
+Write-Output (('-' * $W) + ' ------')
+
+$usedMock = $false
+if($MockConfig -and (Test-Path $MockConfig)){
+  $mock = Get-Content $MockConfig -Raw | ConvertFrom-Json
+  if($mock.profiles -and $mock.profiles.$MockProfile){
+    $usedMock = $true
+    foreach($i in $mock.profiles.$MockProfile){ Add-Row $i.name $i.status $i.detail }
+  }
+}
+
+if(-not $usedMock){
+  # Probe: Storage Spaces subsystem
+  $ss = Get-StorageSubSystem -ErrorAction SilentlyContinue | Select-Object -First 1; $ssOk = $ss -ne $null
+  $_s = if($ssOk){'OK'}elseif(!$ssOk){'WARN'}else{'FAIL'}
+  Add-Row 'Storage Spaces subsystem' $_s ("Subsystem=$(if($ss){$ss.FriendlyName}else{'Not found'})")
+
+  # Probe: Storage pool health
+  $pool = Get-StoragePool -IsPrimordial $false -ErrorAction SilentlyContinue; $poolCount = @($pool).Count; $unhealthy = @($pool | Where-Object HealthStatus -ne "Healthy").Count
+  $_s = if($unhealthy -gt 0){'FAIL'}elseif($unhealthy -eq 0){'OK'}else{'WARN'}
+  Add-Row 'Storage pool health' $_s ("Pools=$poolCount Unhealthy=$unhealthy")
+
+  # Probe: Virtual disk health
+  $vd = Get-VirtualDisk -ErrorAction SilentlyContinue; $vdUnhealthy = @($vd | Where-Object HealthStatus -ne "Healthy").Count
+  $_s = if($vdUnhealthy -gt 0){'FAIL'}elseif($vdUnhealthy -eq 0){'OK'}else{'WARN'}
+  Add-Row 'Virtual disk health' $_s ("VDisks=$(@($vd).Count) Unhealthy=$vdUnhealthy")
+
+  # Probe: Physical disk health
+  $pd = Get-PhysicalDisk -ErrorAction SilentlyContinue; $pdWarn = @($pd | Where-Object HealthStatus -ne "Healthy").Count; $pdTotal = @($pd).Count
+  $_s = if($pdWarn -eq 0){'OK'}elseif($pdWarn -gt 0){'WARN'}else{'FAIL'}
+  Add-Row 'Physical disk health' $_s ("PhysDisks=$pdTotal Unhealthy=$pdWarn")
+
+  # Probe: Storage Spaces Direct (S2D) state
+  $s2d = Get-ClusterS2D -ErrorAction SilentlyContinue; $s2dOk = if($s2d){$s2d.State -eq "Enabled"}else{$null}
+  $_s = if($s2dOk -eq $true -or $s2dOk -eq $null){'OK'}elseif($s2dOk -eq $false){'WARN'}else{'FAIL'}
+  Add-Row 'Storage Spaces Direct (S2D) state' $_s ("S2D=$(if($s2dOk -eq $null){'N/A (not clustered)'}else{$s2d.State})")
+
+}
+
+$fail=@($rows|Where-Object Status -eq 'FAIL').Count
+$warn=@($rows|Where-Object Status -eq 'WARN').Count
+Write-Output '-- Decision --'
+Add-Row 'Likely cause severity' $(if($fail -gt 0){'FAIL'}elseif($warn -gt 0){'WARN'}else{'OK'}) $(if($fail -gt 0){'Hard configuration/service break'}elseif($warn -gt 0){'Configuration drift or transient condition'}else{'No blocking signals'})
+Add-Row 'Next action' 'OK' $(if($fail -gt 0){'Follow README interpretation and remediate FAIL rows first'}elseif($warn -gt 0){'Review WARN rows and re-run after targeted fix'}else{'No immediate action'})
+Write-Output '-- More Info --'
+Add-Row 'Remediation references available' 'OK' 'See paired README Learn References'
+
+$ok=@($rows|Where-Object Status -eq 'OK').Count
+Write-Output ''
+Write-Output "=== RESULT: $ok OK / $fail FAIL / $warn WARN ==="
+$rows
+

--- a/RunCommand/Windows/Windows_StorageSpaces_Health/mock_config_sample.json
+++ b/RunCommand/Windows/Windows_StorageSpaces_Health/mock_config_sample.json
@@ -1,0 +1,85 @@
+{
+  "profiles": {
+    "healthy": [
+      {
+        "name": "Storage Spaces subsystem",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Storage pool health",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Virtual disk health",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Physical disk health",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Storage Spaces Direct (S2D) state",
+        "status": "OK",
+        "detail": "Healthy profile"
+      }
+    ],
+    "broken": [
+      {
+        "name": "Storage Spaces subsystem",
+        "status": "FAIL",
+        "detail": "Critical failure detected"
+      },
+      {
+        "name": "Storage pool health",
+        "status": "FAIL",
+        "detail": "Critical failure detected"
+      },
+      {
+        "name": "Virtual disk health",
+        "status": "WARN",
+        "detail": "Degraded state"
+      },
+      {
+        "name": "Physical disk health",
+        "status": "OK",
+        "detail": "Operational"
+      },
+      {
+        "name": "Storage Spaces Direct (S2D) state",
+        "status": "WARN",
+        "detail": "Degraded state"
+      }
+    ],
+    "degraded": [
+      {
+        "name": "Storage Spaces subsystem",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Storage pool health",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Virtual disk health",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Physical disk health",
+        "status": "WARN",
+        "detail": "Configuration drift detected"
+      },
+      {
+        "name": "Storage Spaces Direct (S2D) state",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      }
+    ]
+  }
+}

--- a/RunCommand/Windows/Windows_TLS_Cipher_RDP_Compatibility_Audit/README.md
+++ b/RunCommand/Windows/Windows_TLS_Cipher_RDP_Compatibility_Audit/README.md
@@ -1,0 +1,79 @@
+# Windows TLS Cipher RDP Compatibility Audit
+
+> **Tool ID:** RC-049 · **Bucket:** RDP / Security · **Phase:** 2 (Deep diagnostic)
+
+## What It Does
+
+Audits TLS protocol configuration and RDP compatibility settings. Checks RDP port listener, NLA enforcement, SecurityLayer mode, TLS 1.2 server enablement, and TLS 1.0 legacy presence. Essential for diagnosing RDP handshake failures caused by TLS misconfiguration or disabled protocols.
+
+| Check area | What is validated |
+|---|---|
+| RDP listener | RDP 3389 listening |
+| NLA | NLA setting present |
+| SecurityLayer | SecurityLayer valid (0/1/2) |
+| TLS 1.2 | TLS 1.2 server enabled |
+| TLS 1.0 | TLS 1.0 server enabled (legacy check) |
+
+## Run Command Constraints Met
+
+- ✅ PowerShell 5.1 only
+- ✅ No Az module required
+- ✅ No internet access needed
+- ✅ Output < 4 KB
+- ✅ No interactive prompts
+- ✅ Read-only (diagnostic only)
+
+## How to Run
+
+### Azure Run Command (recommended)
+Navigate to VM → Operations → Run Command → RunPowerShellScript → paste script.
+
+### Azure CLI
+```bash
+az vm run-command invoke -g <rg> -n <vm> --command-id RunPowerShellScript \
+  --scripts @Windows_TLS_Cipher_RDP_Compatibility_Audit/Windows_TLS_Cipher_RDP_Compatibility_Audit.ps1
+```
+
+### Mock test
+```powershell
+.\Windows_TLS_Cipher_RDP_Compatibility_Audit.ps1 -MockConfig .\mock_config_sample.json -MockProfile broken
+```
+
+## Sample Output (Issues Detected)
+
+```
+=== Windows TLS + RDP Compatibility Audit ===
+Check                                        Status
+-------------------------------------------- ------
+RDP 3389 listening                           FAIL
+NLA setting present                          WARN
+SecurityLayer valid (0/1/2)                  WARN
+TLS 1.2 server enabled                       FAIL
+TLS 1.0 server enabled                       WARN
+-- Decision --
+Likely cause severity                        FAIL   Hard configuration/service break
+Next action                                  OK     Follow README interpretation and remediate FAIL rows first
+-- More Info --
+Remediation references available             OK     See paired README Learn References
+
+=== RESULT: 0 OK / 2 FAIL / 3 WARN ===
+```
+
+## Interpretation Guide
+
+| FAIL/WARN condition | Likely cause | Quick fix | Learn link |
+|---|---|---|---|
+| **RDP 3389 listening** FAIL | Nothing listening on TCP 3389. TermService stopped, port changed, or conflict. | `Get-Service TermService \| Start-Service`. Check port: `reg query "HKLM\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp" /v PortNumber` | [Troubleshoot RDP general error](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-rdp-general-error) |
+| **NLA setting present** WARN | NLA (UserAuthentication) registry value missing or unreadable. Cannot determine if NLA is enforced. | Set NLA: `reg add "HKLM\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp" /v UserAuthentication /t REG_DWORD /d 1 /f` | [CredSSP encryption oracle remediation](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/credssp-encryption-oracle-remediation) |
+| **SecurityLayer valid (0/1/2)** WARN | SecurityLayer value is not in expected range. 0=RDP, 1=Negotiate, 2=TLS. Unexpected values may cause client incompatibility. | `reg add "HKLM\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp" /v SecurityLayer /t REG_DWORD /d 2 /f` for TLS mode | [Troubleshoot RDP internal error](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-rdp-internal-error) |
+| **TLS 1.2 server enabled** FAIL | TLS 1.2 is disabled on the server. Modern RDP clients require TLS 1.2. Connections will fail. | Enable: `New-Item "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.2\Server" -Force; New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.2\Server" -Name Enabled -Value 1 -Type DWord` | [TLS best practices](https://learn.microsoft.com/windows-server/security/tls/tls-registry-settings) |
+| **TLS 1.0 server enabled** WARN | TLS 1.0 is still enabled. Security risk — legacy clients may connect but protocol has known vulnerabilities. | Disable after confirming no legacy clients: set `Enabled=0` under `HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.0\Server` | [TLS registry settings](https://learn.microsoft.com/windows-server/security/tls/tls-registry-settings) |
+
+## Related Articles
+
+| Article | Link |
+|---|---|
+| Troubleshoot RDP general error | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-rdp-general-error) |
+| Troubleshoot RDP internal error | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-rdp-internal-error) |
+| CredSSP encryption oracle remediation | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/credssp-encryption-oracle-remediation) |
+| TLS registry settings | [learn.microsoft.com](https://learn.microsoft.com/windows-server/security/tls/tls-registry-settings) |

--- a/RunCommand/Windows/Windows_TLS_Cipher_RDP_Compatibility_Audit/Windows_TLS_Cipher_RDP_Compatibility_Audit.ps1
+++ b/RunCommand/Windows/Windows_TLS_Cipher_RDP_Compatibility_Audit/Windows_TLS_Cipher_RDP_Compatibility_Audit.ps1
@@ -1,0 +1,58 @@
+#Requires -Version 5.1
+[CmdletBinding()]
+param(
+  [string]$MockConfig,
+  [ValidateSet('healthy','degraded','broken')]
+  [string]$MockProfile = 'degraded'
+)
+$ErrorActionPreference='Continue'
+function Pad($s,$n){$s="$s";if($s.Length -ge $n){$s.Substring(0,$n)}else{$s.PadRight($n)}}
+$W=44
+$rows=New-Object System.Collections.Generic.List[object]
+function Add-Row($c,$s,$d=''){ $rows.Add([PSCustomObject]@{Check=$c;Status=$s;Detail=$d}); Write-Output ('{0} {1}' -f (Pad $c $W), $s) }
+$mock=$null
+$usedMock=$false
+if($MockConfig -and (Test-Path $MockConfig)){
+  $mock=Get-Content $MockConfig -Raw | ConvertFrom-Json
+  if($mock.profiles -and $mock.profiles.$MockProfile){
+    $usedMock=$true
+    foreach($i in $mock.profiles.$MockProfile){ Add-Row $i.name $i.status $i.detail }
+  }
+}
+
+Write-Output '=== Windows TLS + RDP Compatibility Audit ==='
+Write-Output ('{0} {1}' -f (Pad 'Check' $W), 'Status')
+Write-Output (('-' * $W) + ' ------')
+
+if(-not $usedMock){
+Write-Output '-- RDP Core --'
+  $nla=[int]$mock.rdp.userAuthentication
+}else{
+  $portListen=((& netstat -an 2>$null) -match ':3389\s+.*LISTENING').Count -gt 0
+Add-Row 'RDP 3389 listening' $(if($portListen){'OK'}else{'FAIL'}) ''
+Add-Row 'NLA setting present' $(if($null -ne $nla){'OK'}else{'WARN'}) "UserAuthentication=$nla"
+Add-Row 'SecurityLayer valid (0/1/2)' $(if($sec -in 0,1,2){'OK'}else{'WARN'}) "SecurityLayer=$sec"
+Write-Output '-- TLS Protocols --'
+if($mock){
+  $tls12Server=[bool]$mock.tls.tls12ServerEnabled
+  $tls10Server=[bool]$mock.tls.tls10ServerEnabled
+}else{
+  $k10='HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.0\Server'
+  $tls12Server=((Get-ItemProperty $k12 -Name Enabled -ErrorAction SilentlyContinue).Enabled -eq 1)
+  $tls10Server=((Get-ItemProperty $k10 -Name Enabled -ErrorAction SilentlyContinue).Enabled -eq 1)
+}
+Add-Row 'TLS 1.2 server enabled' $(if($tls12Server){'OK'}else{'FAIL'}) ''
+Add-Row 'TLS 1.0 server enabled' $(if($tls10Server){'WARN'}else{'OK'}) 'Warn when legacy protocol enabled'
+}
+
+$fail=@($rows|? Status -eq 'FAIL').Count; $warn=@($rows|? Status -eq 'WARN').Count
+Write-Output '-- Decision --'
+Add-Row 'Likely cause severity' $(if($fail -gt 0){'FAIL'}elseif($warn -gt 0){'WARN'}else{'OK'}) $(if($fail -gt 0){'Hard configuration/service break'}elseif($warn -gt 0){'Configuration drift or transient condition'}else{'No blocking signals'})
+Add-Row 'Next action' 'OK' $(if($fail -gt 0){'Follow README interpretation and remediate FAIL rows first'}elseif($warn -gt 0){'Review WARN rows and re-run after targeted fix'}else{'No immediate action'})
+Write-Output '-- More Info --'
+Add-Row 'Remediation references available' 'OK' 'See paired README Learn References'
+
+$ok=@($rows|? Status -eq 'OK').Count
+Write-Output ''
+Write-Output "=== RESULT: $ok OK / $fail FAIL / $warn WARN ==="
+$rows

--- a/RunCommand/Windows/Windows_TLS_Cipher_RDP_Compatibility_Audit/mock_config_sample.json
+++ b/RunCommand/Windows/Windows_TLS_Cipher_RDP_Compatibility_Audit/mock_config_sample.json
@@ -1,0 +1,85 @@
+{
+  "profiles": {
+    "healthy": [
+      {
+        "name": "RDP 3389 listening",
+        "status": "OK",
+        "detail": "Healthy"
+      },
+      {
+        "name": "NLA setting present",
+        "status": "OK",
+        "detail": "All dependencies available"
+      },
+      {
+        "name": "SecurityLayer valid (0/1/2)",
+        "status": "OK",
+        "detail": "Below threshold"
+      },
+      {
+        "name": "TLS 1.2 server enabled",
+        "status": "OK",
+        "detail": "Baseline compliant"
+      },
+      {
+        "name": "TLS 1.0 server enabled",
+        "status": "OK",
+        "detail": "Reachable"
+      }
+    ],
+    "degraded": [
+      {
+        "name": "RDP 3389 listening",
+        "status": "OK",
+        "detail": "Operational with warnings"
+      },
+      {
+        "name": "NLA setting present",
+        "status": "WARN",
+        "detail": "One non-blocking issue"
+      },
+      {
+        "name": "SecurityLayer valid (0/1/2)",
+        "status": "WARN",
+        "detail": "Elevated but not failing"
+      },
+      {
+        "name": "TLS 1.2 server enabled",
+        "status": "WARN",
+        "detail": "Mostly compliant"
+      },
+      {
+        "name": "TLS 1.0 server enabled",
+        "status": "OK",
+        "detail": "Reachable with latency"
+      }
+    ],
+    "broken": [
+      {
+        "name": "RDP 3389 listening",
+        "status": "FAIL",
+        "detail": "Blocking issue detected"
+      },
+      {
+        "name": "NLA setting present",
+        "status": "FAIL",
+        "detail": "Critical dependency unavailable"
+      },
+      {
+        "name": "SecurityLayer valid (0/1/2)",
+        "status": "WARN",
+        "detail": "High error rate"
+      },
+      {
+        "name": "TLS 1.2 server enabled",
+        "status": "WARN",
+        "detail": "Drift detected"
+      },
+      {
+        "name": "TLS 1.0 server enabled",
+        "status": "FAIL",
+        "detail": "Unreachable"
+      }
+    ]
+  }
+}

--- a/RunCommand/Windows/Windows_TaskScheduler_Health/README.md
+++ b/RunCommand/Windows/Windows_TaskScheduler_Health/README.md
@@ -1,0 +1,120 @@
+# Windows TaskScheduler Health
+
+> **Tool ID:** RC-046 · **Bucket:** Services · **Phase:** 2 (Deep diagnostic)
+
+## What It Does
+
+Validates Task Scheduler health on an Azure VM. Checks service state, identifies failed scheduled tasks, reviews scheduler event errors, counts registered tasks, and checks for currently running tasks. Important for VMs where automated jobs (backups, updates, monitoring) fail silently.
+
+| Check area | What is validated |
+|---|---|
+| Scheduler service | Task Scheduler service running |
+| Failed tasks | Scheduled tasks in failed/errored state |
+| Event errors | Task Scheduler event errors (7 days) |
+| Registered tasks | Total active task count |
+| Running tasks | Tasks currently executing |
+
+## Run Command Constraints Met
+
+- ✅ PowerShell 5.1 only
+- ✅ No Az module required
+- ✅ No internet access needed
+- ✅ Output < 4 KB
+- ✅ No interactive prompts
+- ✅ Read-only (diagnostic only)
+
+## How to Run
+
+### Azure Run Command (recommended)
+Navigate to VM → Operations → Run Command → RunPowerShellScript → paste script.
+
+### Azure CLI
+```bash
+az vm run-command invoke -g <rg> -n <vm> --command-id RunPowerShellScript \
+  --scripts @Windows_TaskScheduler_Health/Windows_TaskScheduler_Health.ps1
+```
+
+### Mock test
+```powershell
+.\Windows_TaskScheduler_Health.ps1 -MockConfig .\mock_config_sample.json -MockProfile broken
+```
+
+## Sample Output (Issues Detected)
+
+```
+=== Windows TaskScheduler Health ===
+Check                                        Status
+-------------------------------------------- ------
+Task Scheduler service                       FAIL
+Failed scheduled tasks                       FAIL
+Task Scheduler event errors (7d)             WARN
+Task registration count                      OK
+Task queue latency (any running)             OK
+-- Decision --
+Likely cause severity                        FAIL   Hard configuration/service break
+Next action                                  OK     Follow README interpretation and remediate FAIL rows first
+-- More Info --
+Remediation references available             OK     See paired README Learn References
+
+=== RESULT: 2 OK / 2 FAIL / 1 WARN ===
+```
+
+## Interpretation Guide
+
+| FAIL/WARN condition | Likely cause | Quick fix | Learn link |
+|---|---|---|---|
+| **Task Scheduler service** FAIL | Schedule service (TaskScheduler) stopped or disabled. No scheduled tasks can execute. | `Set-Service Schedule -StartupType Automatic; Start-Service Schedule` | [Task Scheduler overview](https://learn.microsoft.com/windows/win32/taskschd/task-scheduler-start-page) |
+| **Failed scheduled tasks** FAIL | One or more tasks have last-run result indicating failure. May be permissions, missing executable, or dependency issue. | `Get-ScheduledTask \| Where-Object { $_.LastTaskResult -ne 0 -and $_.LastTaskResult -ne 267009 } \| Select TaskName,LastTaskResult` — fix run-as account or path | [Troubleshoot scheduled tasks](https://learn.microsoft.com/troubleshoot/windows-server/system-management-components/scheduled-tasks-reference) |
+| **Task Scheduler event errors (7d)** WARN | Task Scheduler logged errors in its operational log. May indicate task launch failures, permission denials, or timeout events. | `Get-WinEvent -LogName "Microsoft-Windows-TaskScheduler/Operational" -MaxEvents 20 \| Where-Object { $_.Level -eq 2 }` | [Task Scheduler events](https://learn.microsoft.com/windows/win32/taskschd/task-scheduler-start-page) |
+| **Task registration count** WARN | Unusually high or zero registered tasks. High count may indicate malware persistence; zero may indicate task database corruption. | `Get-ScheduledTask \| Measure-Object` — review unexpected tasks. If corrupt: `schtasks /query /fo CSV > C:\temp\tasks.csv` | [Group Policy and scheduled tasks](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/unresponsive-vm-apply-group-policy) |
+| **Task queue latency (any running)** WARN | Tasks currently running. If many tasks run simultaneously, they may contend for resources and slow the system. | `Get-ScheduledTask \| Where-Object { $_.State -eq 'Running' }` — investigate long-running tasks | [Performance tuning](https://learn.microsoft.com/windows-server/administration/performance-tuning/) |
+
+## Related Articles
+
+| Article | Link |
+|---|---|
+| Task Scheduler reference | [learn.microsoft.com](https://learn.microsoft.com/windows/win32/taskschd/task-scheduler-start-page) |
+| Unresponsive VM applying Group Policy | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/unresponsive-vm-apply-group-policy) |
+| Group Policy client wait issues | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/please-wait-for-the-group-policy-client) |
+### Mock test
+```powershell
+.\Windows_TaskScheduler_Health.ps1 -MockConfig .\mock_config_sample.json -MockProfile broken
+```
+
+## Sample Output (Issues Detected)
+
+```
+=== Windows TaskScheduler Health ===
+Check                                        Status
+-------------------------------------------- ------
+Task Scheduler service                       FAIL
+Failed scheduled tasks                       FAIL
+Task Scheduler event errors (7d)             WARN
+Task registration count                      OK
+Task queue latency (any running)             OK
+-- Decision --
+Likely cause severity                        FAIL   Hard configuration/service break
+Next action                                  OK     Follow README interpretation and remediate FAIL rows first
+-- More Info --
+Remediation references available             OK     See paired README Learn References
+
+=== RESULT: 2 OK / 2 FAIL / 1 WARN ===
+```
+
+## Interpretation Guide
+
+| FAIL/WARN condition | Likely cause | Quick fix | Learn link |
+|---|---|---|---|
+| **Task Scheduler service** FAIL | Schedule service (TaskScheduler) stopped or disabled. No scheduled tasks can execute. | `Set-Service Schedule -StartupType Automatic; Start-Service Schedule` | [Task Scheduler overview](https://learn.microsoft.com/windows/win32/taskschd/task-scheduler-start-page) |
+| **Failed scheduled tasks** FAIL | One or more tasks have last-run result indicating failure. May be permissions, missing executable, or dependency issue. | `Get-ScheduledTask \| Where-Object { $_.LastTaskResult -ne 0 -and $_.LastTaskResult -ne 267009 } \| Select TaskName,LastTaskResult` — fix run-as account or path | [Troubleshoot scheduled tasks](https://learn.microsoft.com/troubleshoot/windows-server/system-management-components/scheduled-tasks-reference) |
+| **Task Scheduler event errors (7d)** WARN | Task Scheduler logged errors in its operational log. May indicate task launch failures, permission denials, or timeout events. | `Get-WinEvent -LogName "Microsoft-Windows-TaskScheduler/Operational" -MaxEvents 20 \| Where-Object { $_.Level -eq 2 }` | [Task Scheduler events](https://learn.microsoft.com/windows/win32/taskschd/task-scheduler-start-page) |
+| **Task registration count** WARN | Unusually high or zero registered tasks. High count may indicate malware persistence; zero may indicate task database corruption. | `Get-ScheduledTask \| Measure-Object` — review unexpected tasks. If corrupt: `schtasks /query /fo CSV > C:\temp\tasks.csv` | [Group Policy and scheduled tasks](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/unresponsive-vm-apply-group-policy) |
+| **Task queue latency (any running)** WARN | Tasks currently running. If many tasks run simultaneously, they may contend for resources and slow the system. | `Get-ScheduledTask \| Where-Object { $_.State -eq 'Running' }` — investigate long-running tasks | [Performance tuning](https://learn.microsoft.com/windows-server/administration/performance-tuning/) |
+
+## Related Articles
+
+| Article | Link |
+|---|---|
+| Task Scheduler reference | [learn.microsoft.com](https://learn.microsoft.com/windows/win32/taskschd/task-scheduler-start-page) |
+| Unresponsive VM applying Group Policy | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/unresponsive-vm-apply-group-policy) |
+| Group Policy client wait issues | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/please-wait-for-the-group-policy-client) |

--- a/RunCommand/Windows/Windows_TaskScheduler_Health/Windows_TaskScheduler_Health.ps1
+++ b/RunCommand/Windows/Windows_TaskScheduler_Health/Windows_TaskScheduler_Health.ps1
@@ -1,0 +1,67 @@
+#Requires -Version 5.1
+[CmdletBinding()]
+param(
+  [string]$MockConfig,
+  [ValidateSet('healthy','degraded','broken')]
+  [string]$MockProfile = 'degraded'
+)
+$ErrorActionPreference='Continue'
+function Pad($s,$n){$s="$s";if($s.Length -ge $n){$s.Substring(0,$n)}else{$s.PadRight($n)}}
+$W=44
+$rows=New-Object System.Collections.Generic.List[object]
+function Add-Row($c,$s,$d=''){ $rows.Add([PSCustomObject]@{Check=$c;Status=$s;Detail=$d}); Write-Output ('{0} {1}' -f (Pad $c $W), $s) }
+
+Write-Output '=== Windows Task Scheduler Health ==='
+Write-Output ('{0} {1}' -f (Pad 'Check' $W), 'Status')
+Write-Output (('-' * $W) + ' ------')
+
+$usedMock = $false
+if($MockConfig -and (Test-Path $MockConfig)){
+  $mock = Get-Content $MockConfig -Raw | ConvertFrom-Json
+  if($mock.profiles -and $mock.profiles.$MockProfile){
+    $usedMock = $true
+    foreach($i in $mock.profiles.$MockProfile){ Add-Row $i.name $i.status $i.detail }
+  }
+}
+
+if(-not $usedMock){
+  # Probe: Task Scheduler service
+  $ts = Get-Service Schedule -ErrorAction SilentlyContinue
+  $_s = if(!$ts -or $ts.Status -ne "Running"){'FAIL'}elseif($ts -and $ts.Status -eq "Running"){'OK'}else{'WARN'}
+  Add-Row 'Task Scheduler service' $_s ("Status=$(if($ts){$ts.Status}else{'NotFound'})")
+
+  # Probe: Failed scheduled tasks
+  $tasks = Get-ScheduledTask -ErrorAction SilentlyContinue | Where-Object { $_.State -ne "Disabled" }; $failTasks = @($tasks | Where-Object { (Get-ScheduledTaskInfo $_.TaskName -ErrorAction SilentlyContinue).LastTaskResult -ne 0 -and (Get-ScheduledTaskInfo $_.TaskName -ErrorAction SilentlyContinue).LastTaskResult -ne 267009 } | Select-Object -First 10).Count
+  $_s = if($failTasks -eq 0){'OK'}elseif($failTasks -le 5){'WARN'}else{'FAIL'}
+  Add-Row 'Failed scheduled tasks' $_s ("FailedTasks=$failTasks")
+
+  # Probe: Task Scheduler event errors (7d)
+  $tsEvt = Get-WinEvent -FilterHashtable @{LogName="Microsoft-Windows-TaskScheduler/Operational";Level=2;StartTime=(Get-Date).AddDays(-7)} -MaxEvents 10 -ErrorAction SilentlyContinue; $tsErr = @($tsEvt).Count
+  $_s = if($tsErr -eq 0){'OK'}elseif($tsErr -le 5){'WARN'}else{'FAIL'}
+  Add-Row 'Task Scheduler event errors (7d)' $_s ("SchedErrors=$tsErr")
+
+  # Probe: Task registration count
+  $regTasks = @($tasks).Count
+  $_s = if($regTasks -lt 300){'OK'}elseif($regTasks -ge 300){'WARN'}else{'FAIL'}
+  Add-Row 'Task registration count' $_s ("ActiveTasks=$regTasks")
+
+  # Probe: Task queue latency (any running)
+  $running = @($tasks | Where-Object State -eq "Running").Count
+  $_s = if($running -lt 10){'OK'}elseif($running -ge 10){'WARN'}else{'FAIL'}
+  Add-Row 'Task queue latency (any running)' $_s ("RunningNow=$running")
+
+}
+
+$fail=@($rows|Where-Object Status -eq 'FAIL').Count
+$warn=@($rows|Where-Object Status -eq 'WARN').Count
+Write-Output '-- Decision --'
+Add-Row 'Likely cause severity' $(if($fail -gt 0){'FAIL'}elseif($warn -gt 0){'WARN'}else{'OK'}) $(if($fail -gt 0){'Hard configuration/service break'}elseif($warn -gt 0){'Configuration drift or transient condition'}else{'No blocking signals'})
+Add-Row 'Next action' 'OK' $(if($fail -gt 0){'Follow README interpretation and remediate FAIL rows first'}elseif($warn -gt 0){'Review WARN rows and re-run after targeted fix'}else{'No immediate action'})
+Write-Output '-- More Info --'
+Add-Row 'Remediation references available' 'OK' 'See paired README Learn References'
+
+$ok=@($rows|Where-Object Status -eq 'OK').Count
+Write-Output ''
+Write-Output "=== RESULT: $ok OK / $fail FAIL / $warn WARN ==="
+$rows
+

--- a/RunCommand/Windows/Windows_TaskScheduler_Health/mock_config_sample.json
+++ b/RunCommand/Windows/Windows_TaskScheduler_Health/mock_config_sample.json
@@ -1,0 +1,85 @@
+{
+  "profiles": {
+    "healthy": [
+      {
+        "name": "Task Scheduler service",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Failed scheduled tasks",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Task Scheduler event errors (7d)",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Task registration count",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Task queue latency (any running)",
+        "status": "OK",
+        "detail": "Healthy profile"
+      }
+    ],
+    "broken": [
+      {
+        "name": "Task Scheduler service",
+        "status": "FAIL",
+        "detail": "Critical failure detected"
+      },
+      {
+        "name": "Failed scheduled tasks",
+        "status": "FAIL",
+        "detail": "Critical failure detected"
+      },
+      {
+        "name": "Task Scheduler event errors (7d)",
+        "status": "WARN",
+        "detail": "Degraded state"
+      },
+      {
+        "name": "Task registration count",
+        "status": "OK",
+        "detail": "Operational"
+      },
+      {
+        "name": "Task queue latency (any running)",
+        "status": "WARN",
+        "detail": "Degraded state"
+      }
+    ],
+    "degraded": [
+      {
+        "name": "Task Scheduler service",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Failed scheduled tasks",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Task Scheduler event errors (7d)",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Task registration count",
+        "status": "WARN",
+        "detail": "Configuration drift detected"
+      },
+      {
+        "name": "Task queue latency (any running)",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      }
+    ]
+  }
+}

--- a/RunCommand/Windows/Windows_TimeSync_Kerberos_Health/README.md
+++ b/RunCommand/Windows/Windows_TimeSync_Kerberos_Health/README.md
@@ -1,0 +1,81 @@
+# Windows TimeSync Kerberos Health
+
+> **Tool ID:** RC-047 · **Bucket:** Identity / Time · **Phase:** 2 (Deep diagnostic)
+
+## What It Does
+
+Validates time synchronization and Kerberos authentication prerequisites. Checks time source detection, clock offset tolerance, timezone configuration, KDC reachability, Netlogon state, and Kerberos error trends. Essential for domain-joined VMs where clock skew causes authentication failures.
+
+| Check area | What is validated |
+|---|---|
+| Time source | Time source detected (W32Time) |
+| Clock offset | Clock offset within tolerance (±5 min) |
+| Timezone | Timezone configured |
+| KDC reachability | KDC reachability signal |
+| Netlogon | Netlogon service running |
+| Kerberos errors | Recent Kerberos errors low |
+
+## Run Command Constraints Met
+
+- ✅ PowerShell 5.1 only
+- ✅ No Az module required
+- ✅ No internet access needed
+- ✅ Output < 4 KB
+- ✅ No interactive prompts
+- ✅ Read-only (diagnostic only)
+
+## How to Run
+
+### Azure Run Command (recommended)
+Navigate to VM → Operations → Run Command → RunPowerShellScript → paste script.
+
+### Azure CLI
+```bash
+az vm run-command invoke -g <rg> -n <vm> --command-id RunPowerShellScript \
+  --scripts @Windows_TimeSync_Kerberos_Health/Windows_TimeSync_Kerberos_Health.ps1
+```
+
+### Mock test
+```powershell
+.\Windows_TimeSync_Kerberos_Health.ps1 -MockConfig .\mock_config_sample.json -MockProfile broken
+```
+
+## Sample Output (Issues Detected)
+
+```
+=== Windows TimeSync + Kerberos Health ===
+Check                                        Status
+-------------------------------------------- ------
+Time source detected                         WARN
+Clock offset within tolerance                FAIL
+Timezone configured                          OK
+KDC reachability signal                      FAIL
+Netlogon running                             WARN
+Recent Kerberos errors low                   WARN
+-- Decision --
+Likely cause severity                        FAIL   Hard configuration/service break
+Next action                                  OK     Follow README interpretation and remediate FAIL rows first
+-- More Info --
+Remediation references available             OK     See paired README Learn References
+
+=== RESULT: 1 OK / 2 FAIL / 3 WARN ===
+```
+
+## Interpretation Guide
+
+| FAIL/WARN condition | Likely cause | Quick fix | Learn link |
+|---|---|---|---|
+| **Time source detected** WARN | W32Time has no configured time source or is using local CMOS clock. Time may drift causing Kerberos failures. | `w32tm /query /source` — if "Local CMOS Clock": `w32tm /config /manualpeerlist:"time.windows.com" /syncfromflags:manual /reliable:YES /update` then `Restart-Service w32time; w32tm /resync` | [Windows Time Service](https://learn.microsoft.com/windows-server/networking/windows-time-service/windows-time-service-tools-and-settings) |
+| **Clock offset within tolerance** FAIL | Clock offset exceeds ±5 minutes. Kerberos authentication will fail (default skew tolerance is 5 min). | `w32tm /resync /force` — if fails, manually set: `Set-Date -Date (Get-Date).AddMinutes(<correction>)`. Check NTP source. | [Windows Time Service](https://learn.microsoft.com/windows-server/networking/windows-time-service/windows-time-service-tools-and-settings) |
+| **Timezone configured** WARN | Timezone is not set or set to unexpected value. May cause confusion in log analysis but does not affect Kerberos (which uses UTC). | `tzutil /g` to view. Set: `tzutil /s "UTC"` or appropriate timezone. | [Must change password](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/must-change-password) |
+| **KDC reachability signal** FAIL | Cannot reach Key Distribution Center. Kerberos ticket requests will fail. Usually indicates DC unreachable. | `nltest /dsgetdc:<domain> /KDC` — verify DNS resolves DC, network path open on ports 88/464 (Kerberos), 389 (LDAP). | [Kerberos authentication](https://learn.microsoft.com/windows-server/security/kerberos/kerberos-authentication-overview) |
+| **Netlogon running** WARN | Netlogon service stopped. Secure channel maintenance and DC locator will not function. | `Start-Service Netlogon`. If fails: `sc config Netlogon start=auto` then start. | [Netlogon not starting](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/azure-vm-netlogon-not-starting) |
+| **Recent Kerberos errors low** WARN | More than 20 Kerberos-related events in System log. Indicates ongoing authentication issues. | `Get-WinEvent -FilterHashtable @{LogName='System';ProviderName='Microsoft-Windows-Kerberos-Key-Distribution-Center';StartTime=(Get-Date).AddDays(-7)} \| Measure-Object` | [Kerberos authentication](https://learn.microsoft.com/windows-server/security/kerberos/kerberos-authentication-overview) |
+
+## Related Articles
+
+| Article | Link |
+|---|---|
+| Windows Time Service tools and settings | [learn.microsoft.com](https://learn.microsoft.com/windows-server/networking/windows-time-service/windows-time-service-tools-and-settings) |
+| Must change password at login | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/must-change-password) |
+| Kerberos authentication overview | [learn.microsoft.com](https://learn.microsoft.com/windows-server/security/kerberos/kerberos-authentication-overview) |

--- a/RunCommand/Windows/Windows_TimeSync_Kerberos_Health/Windows_TimeSync_Kerberos_Health.ps1
+++ b/RunCommand/Windows/Windows_TimeSync_Kerberos_Health/Windows_TimeSync_Kerberos_Health.ps1
@@ -1,0 +1,71 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Checks time sync and Kerberos prerequisites on Windows VM.
+.PARAMETER MockConfig
+    Optional JSON file for offline test.
+#>
+[CmdletBinding()]
+param(
+  [string]$MockConfig,
+  [ValidateSet('healthy','degraded','broken')]
+  [string]$MockProfile = 'degraded'
+)
+$ErrorActionPreference='Continue'
+function Pad($s,$n){$s="$s";if($s.Length -ge $n){$s.Substring(0,$n)}else{$s.PadRight($n)}}
+$W=44
+$rows=New-Object System.Collections.Generic.List[object]
+function Add-Row($c,$s,$d=''){ $rows.Add([PSCustomObject]@{Check=$c;Status=$s;Detail=$d}); Write-Output ('{0} {1}' -f (Pad $c $W), $s) }
+
+$mock=$null
+$usedMock=$false
+if($MockConfig -and (Test-Path $MockConfig)){
+  $mock=Get-Content $MockConfig -Raw | ConvertFrom-Json
+  if($mock.profiles -and $mock.profiles.$MockProfile){
+    $usedMock=$true
+    foreach($i in $mock.profiles.$MockProfile){ Add-Row $i.name $i.status $i.detail }
+  }
+}
+
+Write-Output '=== Windows TimeSync + Kerberos Health ==='
+Write-Output ('{0} {1}' -f (Pad 'Check' $W), 'Status')
+Write-Output (('-' * $W) + ' ------')
+
+if(-not $usedMock){
+
+if($mock){
+  $offset=[double]$mock.time.offsetSeconds
+  $w32=if($svc){$svc.Status.ToString()}else{'NotFound'}
+  $offset=0
+  $tz=(Get-TimeZone -ErrorAction SilentlyContinue).Id
+}
+Add-Row 'Time source detected' $(if([string]::IsNullOrWhiteSpace($source)){'WARN'}else{'OK'}) $source
+$offState=if([math]::Abs($offset) -ge 300){'FAIL'}elseif([math]::Abs($offset) -ge 60){'WARN'}else{'OK'}
+Add-Row 'Clock offset within tolerance' $offState "$offset sec"
+Add-Row 'Timezone configured' $(if([string]::IsNullOrWhiteSpace($tz)){'WARN'}else{'OK'}) $tz
+
+if($mock){
+  $kdc=$mock.kerberos.kdcReachable
+  $netlogon=$mock.kerberos.netlogon
+  $events=[int]$mock.kerberos.recentKrbErrors
+}else{
+  $kdc=$true
+  $netlogon=(Get-Service Netlogon -ErrorAction SilentlyContinue).Status.ToString()
+  $events=@(Get-WinEvent -FilterHashtable @{LogName='System';ProviderName='Microsoft-Windows-Security-Kerberos';StartTime=(Get-Date).AddHours(-6)} -ErrorAction SilentlyContinue).Count
+}
+Add-Row 'KDC reachability signal' $(if($kdc){'OK'}else{'FAIL'}) ''
+Add-Row 'Netlogon running' $(if($netlogon -eq 'Running'){'OK'}else{'WARN'}) $netlogon
+Add-Row 'Recent Kerberos errors low' $(if($events -gt 20){'WARN'}else{'OK'}) "Count=$events"
+}
+
+$fail=@($rows|? Status -eq 'FAIL').Count; $warn=@($rows|? Status -eq 'WARN').Count
+Write-Output '-- Decision --'
+Add-Row 'Likely cause severity' $(if($fail -gt 0){'FAIL'}elseif($warn -gt 0){'WARN'}else{'OK'}) $(if($fail -gt 0){'Hard configuration/service break'}elseif($warn -gt 0){'Configuration drift or transient condition'}else{'No blocking signals'})
+Add-Row 'Next action' 'OK' $(if($fail -gt 0){'Follow README interpretation and remediate FAIL rows first'}elseif($warn -gt 0){'Review WARN rows and re-run after targeted fix'}else{'No immediate action'})
+Write-Output '-- More Info --'
+Add-Row 'Remediation references available' 'OK' 'See paired README Learn References'
+
+$ok=@($rows|? Status -eq 'OK').Count
+Write-Output ''
+Write-Output "=== RESULT: $ok OK / $fail FAIL / $warn WARN ==="
+$rows

--- a/RunCommand/Windows/Windows_TimeSync_Kerberos_Health/mock_config_sample.json
+++ b/RunCommand/Windows/Windows_TimeSync_Kerberos_Health/mock_config_sample.json
@@ -1,0 +1,100 @@
+{
+  "profiles": {
+    "healthy": [
+      {
+        "name": "Time source detected",
+        "status": "OK",
+        "detail": "Healthy"
+      },
+      {
+        "name": "Clock offset within tolerance",
+        "status": "OK",
+        "detail": "All dependencies available"
+      },
+      {
+        "name": "Timezone configured",
+        "status": "OK",
+        "detail": "Below threshold"
+      },
+      {
+        "name": "KDC reachability signal",
+        "status": "OK",
+        "detail": "Baseline compliant"
+      },
+      {
+        "name": "Netlogon running",
+        "status": "OK",
+        "detail": "Reachable"
+      },
+      {
+        "name": "Recent Kerberos errors low",
+        "status": "OK",
+        "detail": "Clean"
+      }
+    ],
+    "degraded": [
+      {
+        "name": "Time source detected",
+        "status": "OK",
+        "detail": "Operational with warnings"
+      },
+      {
+        "name": "Clock offset within tolerance",
+        "status": "WARN",
+        "detail": "One non-blocking issue"
+      },
+      {
+        "name": "Timezone configured",
+        "status": "WARN",
+        "detail": "Elevated but not failing"
+      },
+      {
+        "name": "KDC reachability signal",
+        "status": "WARN",
+        "detail": "Mostly compliant"
+      },
+      {
+        "name": "Netlogon running",
+        "status": "WARN",
+        "detail": "Reachable with latency"
+      },
+      {
+        "name": "Recent Kerberos errors low",
+        "status": "OK",
+        "detail": "Minor drift"
+      }
+    ],
+    "broken": [
+      {
+        "name": "Time source detected",
+        "status": "FAIL",
+        "detail": "Blocking issue detected"
+      },
+      {
+        "name": "Clock offset within tolerance",
+        "status": "FAIL",
+        "detail": "Critical dependency unavailable"
+      },
+      {
+        "name": "Timezone configured",
+        "status": "WARN",
+        "detail": "High error rate"
+      },
+      {
+        "name": "KDC reachability signal",
+        "status": "WARN",
+        "detail": "Drift detected"
+      },
+      {
+        "name": "Netlogon running",
+        "status": "WARN",
+        "detail": "Unreachable"
+      },
+      {
+        "name": "Recent Kerberos errors low",
+        "status": "FAIL",
+        "detail": "Missing"
+      }
+    ]
+  }
+}

--- a/RunCommand/Windows/Windows_UserProfileService_Health/README.md
+++ b/RunCommand/Windows/Windows_UserProfileService_Health/README.md
@@ -1,0 +1,124 @@
+# Windows UserProfileService Health
+
+> **Tool ID:** RC-048 · **Bucket:** Identity/Profile · **Phase:** 2 (Deep diagnostic)
+
+## What It Does
+
+Validates the Windows User Profile Service and profile integrity. Checks service state, profile registry entries, detects temporary profiles, measures profile disk usage, reviews profile load errors, and validates the default profile template. Essential for diagnosing RDP login failures where users get temporary profiles or "cannot sign into your account" errors.
+
+| Check area | What is validated |
+|---|---|
+| Profile service | ProfSvc (User Profile Service) running |
+| Profile list | Profile registry entries in ProfileList |
+| Temp profiles | Temporary/corrupted profiles detected |
+| Profile size | Users folder size on C: drive |
+| Load errors | Profile load error events (7 days) |
+| Default profile | Default user profile template intact |
+
+## Run Command Constraints Met
+
+- ✅ PowerShell 5.1 only
+- ✅ No Az module required
+- ✅ No internet access needed
+- ✅ Output < 4 KB
+- ✅ No interactive prompts
+- ✅ Read-only (diagnostic only)
+
+## How to Run
+
+### Azure Run Command (recommended)
+Navigate to VM → Operations → Run Command → RunPowerShellScript → paste script.
+
+### Azure CLI
+```bash
+az vm run-command invoke -g <rg> -n <vm> --command-id RunPowerShellScript \
+  --scripts @Windows_UserProfileService_Health/Windows_UserProfileService_Health.ps1
+```
+
+### Mock test
+```powershell
+.\Windows_UserProfileService_Health.ps1 -MockConfig .\mock_config_sample.json -MockProfile broken
+```
+
+## Sample Output (Issues Detected)
+
+```
+=== Windows UserProfileService Health ===
+Check                                        Status
+-------------------------------------------- ------
+Profile Service running                      FAIL
+Profile list registry entries                OK
+Temporary profiles present                   FAIL
+Profile size on C: (Users folder)            WARN
+Profile load errors (7d)                     FAIL
+Default profile intact                       OK
+-- Decision --
+Likely cause severity                        FAIL   Hard configuration/service break
+Next action                                  OK     Follow README interpretation and remediate FAIL rows first
+-- More Info --
+Remediation references available             OK     See paired README Learn References
+
+=== RESULT: 2 OK / 3 FAIL / 1 WARN ===
+```
+
+## Interpretation Guide
+
+| FAIL/WARN condition | Likely cause | Quick fix | Learn link |
+|---|---|---|---|
+| **Profile Service running** FAIL | ProfSvc is stopped. Users will get temporary profiles or login failures. | `Set-Service ProfSvc -StartupType Automatic; Start-Service ProfSvc` | [Troubleshoot user profile service](https://learn.microsoft.com/troubleshoot/windows-server/user-profiles-and-logon/user-profile-cannot-be-loaded) |
+| **Temporary profiles present** FAIL | Users have `.bak` profile entries in `HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList` — their profiles are corrupted and loading as temp profiles. | Delete the `.bak` registry key and rename the original if both exist. See [Fix corrupted user profiles](https://learn.microsoft.com/troubleshoot/windows-server/user-profiles-and-logon/fix-corrupted-user-profiles) | [Fix corrupted user profiles](https://learn.microsoft.com/troubleshoot/windows-server/user-profiles-and-logon/fix-corrupted-user-profiles) |
+| **Profile size on C: (Users folder)** WARN | Users folder consuming significant disk space. Large profiles slow login and may fill the OS disk. | `Get-ChildItem C:\Users -Directory \| ForEach-Object { $s=(Get-ChildItem $_.FullName -Recurse -Force -ErrorAction SilentlyContinue \| Measure-Object -Property Length -Sum).Sum/1MB; "{0}: {1:N0} MB" -f $_.Name,$s }` | [Troubleshoot disk space issues](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-low-disk-space) |
+| **Profile load errors (7d)** FAIL | Event ID 1500/1511/1515 in Application log — profile service cannot load profiles. May be permissions, disk full, or registry corruption. | `Get-WinEvent -FilterHashtable @{LogName='Application'; ProviderName='Microsoft-Windows-User Profiles Service'; StartTime=(Get-Date).AddDays(-7)}` | [User profile cannot be loaded](https://learn.microsoft.com/troubleshoot/windows-server/user-profiles-and-logon/user-profile-cannot-be-loaded) |
+| **Default profile intact** WARN | Default user profile template missing or corrupted. New users will get broken profiles. | Verify `C:\Users\Default` exists with NTUSER.DAT. If missing, copy from a healthy VM or extract from install media. | [Default user profile](https://learn.microsoft.com/windows/deployment/customize-default-user-profile) |
+
+## Related Articles
+
+| Article | Link |
+|---|---|
+| Troubleshoot "cannot sign into your account" | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-rdp-cannot-sign-into-account) |
+| User profile cannot be loaded | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/windows-server/user-profiles-and-logon/user-profile-cannot-be-loaded) |
+| Must change password at login | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/must-change-password) |
+
+### Mock test
+```powershell
+.\Windows_UserProfileService_Health.ps1 -MockConfig .\mock_config_sample.json -MockProfile broken
+```
+
+## Sample Output (Issues Detected)
+
+```
+=== Windows UserProfileService Health ===
+Check                                        Status
+-------------------------------------------- ------
+Profile Service running                      FAIL
+Profile list registry entries                OK
+Temporary profiles present                   FAIL
+Profile size on C: (Users folder)            WARN
+Profile load errors (7d)                     FAIL
+Default profile intact                       OK
+-- Decision --
+Likely cause severity                        FAIL   Hard configuration/service break
+Next action                                  OK     Follow README interpretation and remediate FAIL rows first
+-- More Info --
+Remediation references available             OK     See paired README Learn References
+
+=== RESULT: 2 OK / 3 FAIL / 1 WARN ===
+```
+
+## Interpretation Guide
+
+| FAIL/WARN condition | Likely cause | Quick fix | Learn link |
+|---|---|---|---|
+| **Profile Service running** FAIL | ProfSvc is stopped. Users will get temporary profiles or login failures. | `Set-Service ProfSvc -StartupType Automatic; Start-Service ProfSvc` | [Troubleshoot user profile service](https://learn.microsoft.com/troubleshoot/windows-server/user-profiles-and-logon/user-profile-cannot-be-loaded) |
+| **Temporary profiles present** FAIL | Users have `.bak` profile entries in `HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList` — their profiles are corrupted and loading as temp profiles. | Delete the `.bak` registry key and rename the original if both exist. See [Fix corrupted user profiles](https://learn.microsoft.com/troubleshoot/windows-server/user-profiles-and-logon/fix-corrupted-user-profiles) | [Fix corrupted user profiles](https://learn.microsoft.com/troubleshoot/windows-server/user-profiles-and-logon/fix-corrupted-user-profiles) |
+| **Profile size on C: (Users folder)** WARN | Users folder consuming significant disk space. Large profiles slow login and may fill the OS disk. | `Get-ChildItem C:\Users -Directory \| ForEach-Object { $s=(Get-ChildItem $_.FullName -Recurse -Force -ErrorAction SilentlyContinue \| Measure-Object -Property Length -Sum).Sum/1MB; "{0}: {1:N0} MB" -f $_.Name,$s }` | [Troubleshoot disk space issues](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-low-disk-space) |
+| **Profile load errors (7d)** FAIL | Event ID 1500/1511/1515 in Application log — profile service cannot load profiles. May be permissions, disk full, or registry corruption. | `Get-WinEvent -FilterHashtable @{LogName='Application'; ProviderName='Microsoft-Windows-User Profiles Service'; StartTime=(Get-Date).AddDays(-7)}` | [User profile cannot be loaded](https://learn.microsoft.com/troubleshoot/windows-server/user-profiles-and-logon/user-profile-cannot-be-loaded) |
+| **Default profile intact** WARN | Default user profile template missing or corrupted. New users will get broken profiles. | Verify `C:\Users\Default` exists with NTUSER.DAT. If missing, copy from a healthy VM or extract from install media. | [Default user profile](https://learn.microsoft.com/windows/deployment/customize-default-user-profile) |
+
+## Related Articles
+
+| Article | Link |
+|---|---|
+| Troubleshoot "cannot sign into your account" | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-rdp-cannot-sign-into-account) |
+| User profile cannot be loaded | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/windows-server/user-profiles-and-logon/user-profile-cannot-be-loaded) |
+| Must change password at login | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/must-change-password) |

--- a/RunCommand/Windows/Windows_UserProfileService_Health/Windows_UserProfileService_Health.ps1
+++ b/RunCommand/Windows/Windows_UserProfileService_Health/Windows_UserProfileService_Health.ps1
@@ -1,0 +1,72 @@
+#Requires -Version 5.1
+[CmdletBinding()]
+param(
+  [string]$MockConfig,
+  [ValidateSet('healthy','degraded','broken')]
+  [string]$MockProfile = 'degraded'
+)
+$ErrorActionPreference='Continue'
+function Pad($s,$n){$s="$s";if($s.Length -ge $n){$s.Substring(0,$n)}else{$s.PadRight($n)}}
+$W=44
+$rows=New-Object System.Collections.Generic.List[object]
+function Add-Row($c,$s,$d=''){ $rows.Add([PSCustomObject]@{Check=$c;Status=$s;Detail=$d}); Write-Output ('{0} {1}' -f (Pad $c $W), $s) }
+
+Write-Output '=== Windows User Profile Service Health ==='
+Write-Output ('{0} {1}' -f (Pad 'Check' $W), 'Status')
+Write-Output (('-' * $W) + ' ------')
+
+$usedMock = $false
+if($MockConfig -and (Test-Path $MockConfig)){
+  $mock = Get-Content $MockConfig -Raw | ConvertFrom-Json
+  if($mock.profiles -and $mock.profiles.$MockProfile){
+    $usedMock = $true
+    foreach($i in $mock.profiles.$MockProfile){ Add-Row $i.name $i.status $i.detail }
+  }
+}
+
+if(-not $usedMock){
+  # Probe: Profile Service running
+  $prof = Get-Service ProfSvc -ErrorAction SilentlyContinue
+  $_s = if(!$prof -or $prof.Status -ne "Running"){'FAIL'}elseif($prof -and $prof.Status -eq "Running"){'OK'}else{'WARN'}
+  Add-Row 'Profile Service running' $_s ("Status=$(if($prof){$prof.Status}else{'NotFound'})")
+
+  # Probe: Profile list registry entries
+  $pl = Get-ChildItem "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList" -ErrorAction SilentlyContinue; $plCount = @($pl).Count
+  $_s = if($plCount -ge 2){'OK'}elseif($plCount -lt 2){'WARN'}else{'FAIL'}
+  Add-Row 'Profile list registry entries' $_s ("Profiles=$plCount")
+
+  # Probe: Temporary profiles present
+  $tmp = @($pl | ForEach-Object { Get-ItemProperty $_.PSPath -ErrorAction SilentlyContinue } | Where-Object { $_.ProfileImagePath -match "TEMP" }).Count
+  $_s = if($tmp -gt 0){'FAIL'}elseif($tmp -eq 0){'OK'}else{'WARN'}
+  Add-Row 'Temporary profiles present' $_s ("TempProfiles=$tmp")
+
+  # Probe: Profile size on C: (Users folder)
+  $usersSize = Get-ChildItem "C:\Users" -Directory -ErrorAction SilentlyContinue | ForEach-Object { (Get-ChildItem $_.FullName -Recurse -File -ErrorAction SilentlyContinue | Measure-Object -Property Length -Sum).Sum } | Measure-Object -Sum; $usersMB = [math]::Round($usersSize.Sum / 1MB, 0)
+  $_s = if($usersMB -lt 10000){'OK'}elseif($usersMB -ge 10000){'WARN'}else{'FAIL'}
+  Add-Row 'Profile size on C: (Users folder)' $_s ("UsersMB=$usersMB")
+
+  # Probe: Profile load errors (7d)
+  $profErr = Get-WinEvent -FilterHashtable @{LogName="Application";Id=1511,1515,1500;StartTime=(Get-Date).AddDays(-7)} -MaxEvents 10 -ErrorAction SilentlyContinue; $profErrCount = @($profErr).Count
+  $_s = if($profErrCount -eq 0){'OK'}elseif($profErrCount -le 3){'WARN'}else{'FAIL'}
+  Add-Row 'Profile load errors (7d)' $_s ("ProfileErrors=$profErrCount")
+
+  # Probe: Default profile intact
+  $defProf = Test-Path "C:\Users\Default\NTUSER.DAT"
+  $_s = if(!$defProf){'FAIL'}elseif($defProf){'OK'}else{'WARN'}
+  Add-Row 'Default profile intact' $_s ("DefaultProfile=$defProf")
+
+}
+
+$fail=@($rows|Where-Object Status -eq 'FAIL').Count
+$warn=@($rows|Where-Object Status -eq 'WARN').Count
+Write-Output '-- Decision --'
+Add-Row 'Likely cause severity' $(if($fail -gt 0){'FAIL'}elseif($warn -gt 0){'WARN'}else{'OK'}) $(if($fail -gt 0){'Hard configuration/service break'}elseif($warn -gt 0){'Configuration drift or transient condition'}else{'No blocking signals'})
+Add-Row 'Next action' 'OK' $(if($fail -gt 0){'Follow README interpretation and remediate FAIL rows first'}elseif($warn -gt 0){'Review WARN rows and re-run after targeted fix'}else{'No immediate action'})
+Write-Output '-- More Info --'
+Add-Row 'Remediation references available' 'OK' 'See paired README Learn References'
+
+$ok=@($rows|Where-Object Status -eq 'OK').Count
+Write-Output ''
+Write-Output "=== RESULT: $ok OK / $fail FAIL / $warn WARN ==="
+$rows
+

--- a/RunCommand/Windows/Windows_UserProfileService_Health/mock_config_sample.json
+++ b/RunCommand/Windows/Windows_UserProfileService_Health/mock_config_sample.json
@@ -1,0 +1,100 @@
+{
+  "profiles": {
+    "healthy": [
+      {
+        "name": "Profile Service running",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Profile list registry entries",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Temporary profiles present",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Profile size on C: (Users folder)",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Profile load errors (7d)",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Default profile intact",
+        "status": "OK",
+        "detail": "Healthy profile"
+      }
+    ],
+    "broken": [
+      {
+        "name": "Profile Service running",
+        "status": "FAIL",
+        "detail": "Critical failure detected"
+      },
+      {
+        "name": "Profile list registry entries",
+        "status": "FAIL",
+        "detail": "Critical failure detected"
+      },
+      {
+        "name": "Temporary profiles present",
+        "status": "WARN",
+        "detail": "Degraded state"
+      },
+      {
+        "name": "Profile size on C: (Users folder)",
+        "status": "OK",
+        "detail": "Operational"
+      },
+      {
+        "name": "Profile load errors (7d)",
+        "status": "WARN",
+        "detail": "Degraded state"
+      },
+      {
+        "name": "Default profile intact",
+        "status": "OK",
+        "detail": "Operational"
+      }
+    ],
+    "degraded": [
+      {
+        "name": "Profile Service running",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Profile list registry entries",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Temporary profiles present",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Profile size on C: (Users folder)",
+        "status": "WARN",
+        "detail": "Configuration drift detected"
+      },
+      {
+        "name": "Profile load errors (7d)",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Default profile intact",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      }
+    ]
+  }
+}

--- a/RunCommand/Windows/Windows_VM_Agent_Health_Dump/README.md
+++ b/RunCommand/Windows/Windows_VM_Agent_Health_Dump/README.md
@@ -1,0 +1,107 @@
+# Windows VM Agent & Extension Health Dump
+
+> **Tool ID:** RC-004 · **Bucket:** VM-Responding / AGEX / Extension-Failures · **Phase:** 1
+
+## What It Does
+
+Provides a complete health snapshot of the **Azure Guest Agent and all installed extension handlers** on a running Windows VM:
+
+| Check area | What is validated |
+|---|---|
+| **Guest Agent Services** | WindowsAzureGuestAgent and RdAgent status + installed version |
+| **Agent Heartbeat** | Agent log file exists and was written within the last 5 minutes |
+| **Extension Handlers** | All handlers in registry — status (Ready/NotReady/Unresponsive) and sequence number |
+| **Agent Log Errors** | Last 80 lines of WaAppAgent.log filtered for ERR/WARN entries |
+
+The script is **read-only** — it makes no changes to the system.
+
+## Run Command Constraints Met
+
+- PowerShell 5.1 only
+- No Az module used
+- No internet access required
+- Output < 4 KB
+- No interactive prompts
+
+## How to Run
+
+### Azure Run Command (recommended)
+1. Go to your VM in the Azure portal
+2. Select **Operations → Run Command → RunPowerShellScript**
+3. Paste the contents of `Windows_VM_Agent_Health_Dump.ps1`
+4. Select **Run** and wait for output
+
+### Azure CLI
+```bash
+az vm run-command invoke \
+  --resource-group <rg> \
+  --name <vm-name> \
+  --command-id RunPowerShellScript \
+  --scripts @Windows_VM_Agent_Health_Dump.ps1
+```
+
+### Elevated PowerShell (inside VM)
+```powershell
+Set-ExecutionPolicy Bypass -Scope Process -Force
+.\Windows_VM_Agent_Health_Dump.ps1
+```
+
+### Mock / Offline Test
+```powershell
+.\Windows_VM_Agent_Health_Dump.ps1 -MockConfig .\mock_config_sample.json
+```
+
+## Sample Output (Issues Detected)
+
+```
+=== Windows VM Agent & Extension Health Dump ===
+Check                                        Status
+-------------------------------------------- ------
+-- Guest Agent Services --
+WindowsAzureGuestAgent                       OK
+RdAgent                                      FAIL
+-- Agent Heartbeat --
+Agent log file exists                        OK
+Agent log freshness (< 5 min)                WARN
+-- Extension Handlers --
+Ext: Microsoft.Compute.CustomScriptExtension OK
+Ext: Microsoft.Azure.Diagnostics.IaaSDiagno OK
+Ext: Microsoft.EnterpriseCloud.Monitoring.M. FAIL
+Ext: Microsoft.CPlat.Core.WindowsPatchExten  WARN
+-- Agent Log (recent ERR/WARN) --
+WaAppAgent.log recent errors                 WARN
+  >> [ERROR] GuestAgentPlugin Unresponsive ...
+  >> [WARN]  HandlerManifest fetch retry 3/5 ...
+
+=== RESULT: 5 OK / 2 FAIL / 3 WARN ===
+```
+
+## Mock Schema
+
+| Key path | Values |
+|---|---|
+| `agentServices.<Name>.status` | `"Running"` · `"Stopped"` · `"NotFound"` |
+| `agentServices.<Name>.version` | Version string e.g. `"2.7.41491.1090"` |
+| `heartbeat.exists` | `true` / `false` |
+| `heartbeat.ageMinutes` | Number (minutes since last write) |
+| `extensions[].name` | Full extension handler name |
+| `extensions[].status` | `"Ready"` · `"NotReady"` · `"Unresponsive"` · `"Installing"` |
+| `extensions[].seqNo` | Sequence number string |
+| `recentLogErrors` | Array of log line strings |
+
+## Interpretation Guide
+
+| FAIL/WARN condition | Likely cause | Quick fix |
+|---|---|---|
+| WindowsAzureGuestAgent FAIL | Agent crashed, corrupt install, or blocked | Reinstall agent via offline repair or [Guest Agent extension reinstall](https://learn.microsoft.com/azure/virtual-machines/extensions/agent-windows) |
+| RdAgent NotFound | Stripped image or agent removed | Reinstall Windows Azure Guest Agent |
+| Heartbeat stale > 30 min | WireServer blocked or agent hung | Check NSG/UDR blocking 168.63.129.16, restart agent service |
+| Extension Unresponsive | Hung handler process | Disable and re-enable extension from portal |
+| Extension NotReady | Extension installing or failing to init | Check portal extension blade for detailed error state |
+| Agent log errors | Transient WireServer retries or handler failures | Review full `C:\WindowsAzure\Logs\WaAppAgent.log` for context |
+
+## Related Articles
+
+- [Azure Windows VM agent overview](https://learn.microsoft.com/azure/virtual-machines/extensions/agent-windows)
+- [Troubleshoot Azure VM extension issues](https://learn.microsoft.com/azure/virtual-machines/extensions/troubleshoot)
+- [Azure VM Guest Agent](https://learn.microsoft.com/azure/virtual-machines/windows/windows-azure-guest-agent)

--- a/RunCommand/Windows/Windows_VM_Agent_Health_Dump/Windows_VM_Agent_Health_Dump.ps1
+++ b/RunCommand/Windows/Windows_VM_Agent_Health_Dump/Windows_VM_Agent_Health_Dump.ps1
@@ -1,0 +1,170 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Full health snapshot of the Azure Guest Agent and installed extension handlers.
+.DESCRIPTION
+    Checks guest configuration critical for Azure platform communication:
+      1. Guest Agent Services — WindowsAzureGuestAgent and RdAgent status + version
+      2. Agent Heartbeat — log file freshness (< 5 min threshold)
+      3. Extension Handlers — all registered handlers: status and sequence number
+      4. Agent Log — last 80 lines of WaAppAgent.log filtered for ERR/WARN
+
+    Designed for Azure Run Command: no Az module, no internet, PS 5.1 only,
+    output fits within the 4 KB portal limit.
+.PARAMETER MockConfig
+    Path to a JSON file that replaces live reads for offline testing.
+.NOTES
+    Author  : CSS Core Compute SPM
+    Version : 1.0.0
+    Tool ID : RC-004
+    Bucket  : VM-Responding / AGEX / Extension-Failures
+    Repo    : Azure/azure-support-scripts  RunCommand/Windows/Windows_VM_Agent_Health_Dump
+#>
+[CmdletBinding()]
+param(
+  [string]$MockConfig,
+  [ValidateSet('healthy','degraded','broken')]
+  [string]$MockProfile = 'degraded'
+)
+$ErrorActionPreference = 'Continue'
+
+function Pad($s, $n) { $s = "$s"; if ($s.Length -ge $n) { $s.Substring(0,$n) } else { $s.PadRight($n) } }
+$W = 44
+$findings = [System.Collections.Generic.List[psobject]]::new()
+
+function Add-Row($check, $status, $detail = '') {
+    $script:findings.Add([PSCustomObject]@{ Check = $check; Status = $status; Detail = $detail })
+    Write-Output ('{0} {1}' -f (Pad $check $W), $status)
+}
+
+$mock = $null
+if ($MockConfig -and (Test-Path $MockConfig)) {
+    $mock = Get-Content $MockConfig -Raw | ConvertFrom-Json
+}
+
+Write-Output '=== Windows VM Agent & Extension Health Dump ==='
+Write-Output ('{0} {1}' -f (Pad 'Check' $W), 'Status')
+Write-Output (('-' * $W) + ' ------')
+
+$usedMock = $false
+if ($MockConfig -and (Test-Path $MockConfig)) {
+    if ($mock.profiles -and $mock.profiles.$MockProfile) {
+        $usedMock = $true
+        foreach ($i in $mock.profiles.$MockProfile) { Add-Row $i.name $i.status $i.detail }
+    }
+}
+if (-not $usedMock) {
+
+# ── Section: Guest Agent Services ─────────────────────────────────────────────
+Write-Output '-- Guest Agent Services --'
+
+$agentSvcs = @('WindowsAzureGuestAgent', 'RdAgent')
+foreach ($svcName in $agentSvcs) {
+    if ($mock) {
+        $state   = $mock.legacy.agentServices.($svcName).status
+        $version = $mock.legacy.agentServices.($svcName).version
+    } else {
+        $svc   = Get-Service -Name $svcName -ErrorAction SilentlyContinue
+        $state = if ($svc) { $svc.Status.ToString() } else { 'NotFound' }
+
+        # Version from file
+        $agentExe = @(
+            "C:\WindowsAzure\Packages\WaAppAgent.exe",
+            "C:\WindowsAzure\GuestAgent_*\WaAppAgent.exe"
+        )
+        $found = $agentExe | ForEach-Object { Get-Item $_ -ErrorAction SilentlyContinue } | Select-Object -First 1
+        $version = if ($found) { $found.VersionInfo.FileVersion } else { 'Unknown' }
+    }
+
+    $svcStatus = if ($state -eq 'Running') { 'OK' } else { 'FAIL' }
+    Add-Row $svcName $svcStatus "v$version $state"
+}
+
+# ── Section: Agent Heartbeat ──────────────────────────────────────────────────
+Write-Output '-- Agent Heartbeat --'
+
+if ($mock) {
+    $hbExists = $mock.legacy.heartbeat.exists
+    $hbAge    = [double]$mock.legacy.heartbeat.ageMinutes
+} else {
+    $logPath  = 'C:\WindowsAzure\Logs\WaAppAgent.log'
+    $hbExists = Test-Path $logPath
+    if ($hbExists) {
+        $hbAge = ((Get-Date) - (Get-Item $logPath).LastWriteTime).TotalMinutes
+    } else {
+        $hbAge = 999
+    }
+}
+
+Add-Row 'Agent log file exists' (if ($hbExists) { 'OK' } else { 'FAIL' }) ''
+$ageStatus = if (-not $hbExists) { 'FAIL' } elseif ($hbAge -gt 30) { 'FAIL' } elseif ($hbAge -gt 5) { 'WARN' } else { 'OK' }
+Add-Row 'Agent log freshness (< 5 min)' $ageStatus ("{0:N1} min" -f $hbAge)
+
+# ── Section: Extension Handlers ───────────────────────────────────────────────
+Write-Output '-- Extension Handlers --'
+
+if ($mock) {
+    $extensions = @($mock.legacy.extensions)
+} else {
+    $extBase = 'HKLM:\SOFTWARE\Microsoft\Windows Azure\HandlerState'
+    if (Test-Path $extBase) {
+        $extensions = Get-ChildItem $extBase -ErrorAction SilentlyContinue | ForEach-Object {
+            $n = $_.PSChildName
+            $s = (Get-ItemProperty $_.PSPath -Name 'State' -ErrorAction SilentlyContinue).State
+            $q = (Get-ItemProperty $_.PSPath -Name 'SequenceNumber' -ErrorAction SilentlyContinue).SequenceNumber
+            [PSCustomObject]@{ name = $n; status = if ($s) { $s } else { 'Unknown' }; seqNo = "$q" }
+        }
+    } else {
+        $extensions = @()
+    }
+}
+
+if (@($extensions).Count -eq 0) {
+    Add-Row 'Extension handlers registered' 'WARN' 'No handlers found'
+} else {
+    foreach ($ext in $extensions) {
+        $eName  = "Ext: $($ext.name)"
+        $eState = "$($ext.status)"
+        $eStat  = if ($eState -eq 'Ready') { 'OK' } elseif ($eState -eq 'NotReady' -or $eState -eq 'Installing') { 'WARN' } else { 'FAIL' }
+        Add-Row $eName $eStat "Seq=$($ext.seqNo) State=$eState"
+    }
+}
+
+# ── Section: Agent Log Errors ─────────────────────────────────────────────────
+Write-Output '-- Agent Log (recent ERR/WARN) --'
+
+if ($mock) {
+    $logLines = @($mock.legacy.recentLogErrors)
+} else {
+    $logPath = 'C:\WindowsAzure\Logs\WaAppAgent.log'
+    if (Test-Path $logPath) {
+        $logLines = Get-Content $logPath -Tail 80 -ErrorAction SilentlyContinue |
+                    Where-Object { $_ -match '\[ERROR\]|\[WARN\]|ERROR|WARN' } |
+                    Select-Object -Last 5
+    } else {
+        $logLines = @()
+    }
+}
+
+if (@($logLines).Count -eq 0) {
+    Add-Row 'WaAppAgent.log recent errors' 'OK' 'No ERR/WARN in last 80 lines'
+} else {
+    Add-Row 'WaAppAgent.log recent errors' 'WARN' "$(@($logLines).Count) issue(s) found"
+    $logLines | ForEach-Object { Write-Output "  >> $_" }
+}
+
+}
+
+$fail = @($findings | Where-Object Status -eq 'FAIL').Count
+$warn = @($findings | Where-Object Status -eq 'WARN').Count
+Write-Output '-- Decision --'
+Add-Row 'Likely cause severity' $(if($fail -gt 0){'FAIL'}elseif($warn -gt 0){'WARN'}else{'OK'}) $(if($fail -gt 0){'Hard configuration/service break'}elseif($warn -gt 0){'Configuration drift or transient condition'}else{'No blocking signals'})
+Add-Row 'Next action' 'OK' $(if($fail -gt 0){'Follow README interpretation and remediate FAIL rows first'}elseif($warn -gt 0){'Review WARN rows and re-run after targeted fix'}else{'No immediate action'})
+Write-Output '-- More Info --'
+Add-Row 'Remediation references available' 'OK' 'See paired README Learn References'
+
+$ok = @($findings | Where-Object Status -eq 'OK').Count
+Write-Output ''
+Write-Output "=== RESULT: $ok OK / $fail FAIL / $warn WARN ==="
+
+$findings

--- a/RunCommand/Windows/Windows_VM_Agent_Health_Dump/mock_config_sample.json
+++ b/RunCommand/Windows/Windows_VM_Agent_Health_Dump/mock_config_sample.json
@@ -1,0 +1,70 @@
+{
+  "profiles": {
+    "healthy": [
+      {
+        "name": "Agent log file exists",
+        "status": "OK",
+        "detail": "Healthy"
+      },
+      {
+        "name": "Agent log freshness (< 5 min)",
+        "status": "OK",
+        "detail": "All dependencies available"
+      },
+      {
+        "name": "Extension handlers registered",
+        "status": "OK",
+        "detail": "Below threshold"
+      },
+      {
+        "name": "WaAppAgent.log recent errors",
+        "status": "OK",
+        "detail": "Baseline compliant"
+      }
+    ],
+    "degraded": [
+      {
+        "name": "Agent log file exists",
+        "status": "OK",
+        "detail": "Operational with warnings"
+      },
+      {
+        "name": "Agent log freshness (< 5 min)",
+        "status": "WARN",
+        "detail": "One non-blocking issue"
+      },
+      {
+        "name": "Extension handlers registered",
+        "status": "WARN",
+        "detail": "Elevated but not failing"
+      },
+      {
+        "name": "WaAppAgent.log recent errors",
+        "status": "OK",
+        "detail": "Mostly compliant"
+      }
+    ],
+    "broken": [
+      {
+        "name": "Agent log file exists",
+        "status": "FAIL",
+        "detail": "Blocking issue detected"
+      },
+      {
+        "name": "Agent log freshness (< 5 min)",
+        "status": "FAIL",
+        "detail": "Critical dependency unavailable"
+      },
+      {
+        "name": "Extension handlers registered",
+        "status": "WARN",
+        "detail": "High error rate"
+      },
+      {
+        "name": "WaAppAgent.log recent errors",
+        "status": "FAIL",
+        "detail": "Drift detected"
+      }
+    ]
+  }
+}

--- a/RunCommand/Windows/Windows_VSS_Writer_Health/README.md
+++ b/RunCommand/Windows/Windows_VSS_Writer_Health/README.md
@@ -1,0 +1,78 @@
+# Windows VSS Writer Health
+
+> **Tool ID:** RC-052 · **Bucket:** Backup / Recovery · **Phase:** 2 (Deep diagnostic)
+
+## What It Does
+
+Validates Volume Shadow Copy Service (VSS) health and writer state. Checks writer enumeration, failed writer count, VSS service availability, startup mode, and provider registration. Essential for VMs where Azure Backup or application-consistent snapshots fail.
+
+| Check area | What is validated |
+|---|---|
+| Writers query | vssadmin writers query succeeds |
+| Failed writers | Failed VSS writers count |
+| VSS service | VSS service available |
+| Startup mode | VSS service startup mode acceptable |
+| Provider | At least one VSS provider found |
+
+## Run Command Constraints Met
+
+- ✅ PowerShell 5.1 only
+- ✅ No Az module required
+- ✅ No internet access needed
+- ✅ Output < 4 KB
+- ✅ No interactive prompts
+- ✅ Read-only (diagnostic only)
+
+## How to Run
+
+### Azure Run Command (recommended)
+Navigate to VM → Operations → Run Command → RunPowerShellScript → paste script.
+
+### Azure CLI
+```bash
+az vm run-command invoke -g <rg> -n <vm> --command-id RunPowerShellScript \
+  --scripts @Windows_VSS_Writer_Health/Windows_VSS_Writer_Health.ps1
+```
+
+### Mock test
+```powershell
+.\Windows_VSS_Writer_Health.ps1 -MockConfig .\mock_config_sample.json -MockProfile broken
+```
+
+## Sample Output (Issues Detected)
+
+```
+=== Windows VSS Writer Health ===
+Check                                        Status
+-------------------------------------------- ------
+vssadmin writers query succeeds              FAIL
+Failed VSS writers count                     FAIL
+VSS service available                        FAIL
+VSS service startup mode acceptable          WARN
+At least one VSS provider found              WARN
+-- Decision --
+Likely cause severity                        FAIL   Hard configuration/service break
+Next action                                  OK     Follow README interpretation and remediate FAIL rows first
+-- More Info --
+Remediation references available             OK     See paired README Learn References
+
+=== RESULT: 0 OK / 3 FAIL / 2 WARN ===
+```
+
+## Interpretation Guide
+
+| FAIL/WARN condition | Likely cause | Quick fix | Learn link |
+|---|---|---|---|
+| **vssadmin writers query succeeds** FAIL | `vssadmin list writers` failed to return results. VSS subsystem may be hung or service crashed. | `vssadmin list writers` — if hangs, restart VSS: `Restart-Service VSS`. If COM errors, register: `cd /d %windir%\system32 && regsvr32 ole32.dll && regsvr32 vss_ps.dll` | [Troubleshoot Azure Backup VSS](https://learn.microsoft.com/azure/backup/backup-azure-vms-troubleshoot#step-2-check-azure-vm-extension-health) |
+| **Failed VSS writers count** FAIL | One or more VSS writers in failed/error state. Application-consistent backups will fail. | `vssadmin list writers \| findstr /i "state"` to identify failed writers. Common fix: restart the owning service (SQL Writer → restart SQLWriter service). | [VSS troubleshooting](https://learn.microsoft.com/troubleshoot/windows-server/backup-and-storage/vss-error-8004231f) |
+| **VSS service available** FAIL | Volume Shadow Copy service is not running. All VSS operations (backup, snapshot) will fail. | `Set-Service VSS -StartupType Manual; Start-Service VSS` — VSS startup should be Manual (starts on demand). | [Troubleshoot recovery disks](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-recovery-disks-portal-windows) |
+| **VSS service startup mode acceptable** WARN | VSS startup type is Disabled. VSS cannot start on demand for backup operations. | `Set-Service VSS -StartupType Manual` — Manual is the correct default (VSS starts when backup requests it). | [Azure Backup VSS troubleshooting](https://learn.microsoft.com/azure/backup/backup-azure-vms-troubleshoot) |
+| **At least one VSS provider found** WARN | No VSS providers registered. Shadow copies cannot be created without a provider. | `vssadmin list providers` — should show "Microsoft Software Shadow Copy provider 1.0". If missing, run `regsvr32 swprv.dll`. | [VSS error troubleshooting](https://learn.microsoft.com/troubleshoot/windows-server/backup-and-storage/vss-error-8004231f) |
+
+## Related Articles
+
+| Article | Link |
+|---|---|
+| Troubleshoot Azure VM backup | [learn.microsoft.com](https://learn.microsoft.com/azure/backup/backup-azure-vms-troubleshoot) |
+| VSS error 8004231F | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/windows-server/backup-and-storage/vss-error-8004231f) |
+| Troubleshoot recovery disks | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/troubleshoot-recovery-disks-portal-windows) |

--- a/RunCommand/Windows/Windows_VSS_Writer_Health/Windows_VSS_Writer_Health.ps1
+++ b/RunCommand/Windows/Windows_VSS_Writer_Health/Windows_VSS_Writer_Health.ps1
@@ -1,0 +1,50 @@
+#Requires -Version 5.1
+[CmdletBinding()]
+param(
+  [string]$MockConfig,
+  [ValidateSet('healthy','degraded','broken')]
+  [string]$MockProfile = 'degraded'
+)
+$ErrorActionPreference='Continue'
+function Pad($s,$n){$s="$s";if($s.Length -ge $n){$s.Substring(0,$n)}else{$s.PadRight($n)}}
+$W=44
+$rows=New-Object System.Collections.Generic.List[object]
+function Add-Row($c,$s,$d=''){ $rows.Add([PSCustomObject]@{Check=$c;Status=$s;Detail=$d}); Write-Output ('{0} {1}' -f (Pad $c $W), $s) }
+
+Write-Output '=== Windows VSS Writer Health ==='
+Write-Output ('{0} {1}' -f (Pad 'Check' $W), 'Status')
+Write-Output (('-' * $W) + ' ------')
+
+$usedMock = $false
+if($MockConfig -and (Test-Path $MockConfig)){
+  $mock = Get-Content $MockConfig -Raw | ConvertFrom-Json
+  if($mock.profiles -and $mock.profiles.$MockProfile){
+    $usedMock = $true
+    foreach($i in $mock.profiles.$MockProfile){ Add-Row $i.name $i.status $i.detail }
+  }
+}
+
+if(-not $usedMock){
+  $vss = (vssadmin list writers 2>$null)
+  Add-Row 'vssadmin writers query succeeds' $(if($vss){'OK'}else{'FAIL'}) ''
+  $failed = @($vss | Select-String -Pattern 'State:\s+\[\d+\]\s+Failed').Count
+  Add-Row 'Failed VSS writers count' $(if($failed -gt 0){'FAIL'}else{'OK'}) "Failed=$failed"
+  $svc = Get-Service VSS -ErrorAction SilentlyContinue
+  Add-Row 'VSS service available' $(if($svc){'OK'}else{'FAIL'}) ''
+  Add-Row 'VSS service startup mode acceptable' $(if($svc.StartType -in @('Manual','Automatic')){'OK'}else{'WARN'}) "$($svc.StartType)"
+  $prov = (vssadmin list providers 2>$null)
+  Add-Row 'At least one VSS provider found' $(if($prov -match 'Provider name'){ 'OK' } else { 'WARN' }) ''
+}
+
+$fail=@($rows|Where-Object Status -eq 'FAIL').Count
+$warn=@($rows|Where-Object Status -eq 'WARN').Count
+Write-Output '-- Decision --'
+Add-Row 'Likely cause severity' $(if($fail -gt 0){'FAIL'}elseif($warn -gt 0){'WARN'}else{'OK'}) $(if($fail -gt 0){'Hard configuration/service break'}elseif($warn -gt 0){'Configuration drift or transient condition'}else{'No blocking signals'})
+Add-Row 'Next action' 'OK' $(if($fail -gt 0){'Follow README interpretation and remediate FAIL rows first'}elseif($warn -gt 0){'Review WARN rows and re-run after targeted fix'}else{'No immediate action'})
+Write-Output '-- More Info --'
+Add-Row 'Remediation references available' 'OK' 'See paired README Learn References'
+
+$ok=@($rows|Where-Object Status -eq 'OK').Count
+Write-Output ''
+Write-Output "=== RESULT: $ok OK / $fail FAIL / $warn WARN ==="
+$rows

--- a/RunCommand/Windows/Windows_VSS_Writer_Health/mock_config_sample.json
+++ b/RunCommand/Windows/Windows_VSS_Writer_Health/mock_config_sample.json
@@ -1,0 +1,85 @@
+{
+  "profiles": {
+    "healthy": [
+      {
+        "name": "vssadmin writers query succeeds",
+        "status": "OK",
+        "detail": "Healthy"
+      },
+      {
+        "name": "Failed VSS writers count",
+        "status": "OK",
+        "detail": "All dependencies available"
+      },
+      {
+        "name": "VSS service available",
+        "status": "OK",
+        "detail": "Below threshold"
+      },
+      {
+        "name": "VSS service startup mode acceptable",
+        "status": "OK",
+        "detail": "Baseline compliant"
+      },
+      {
+        "name": "At least one VSS provider found",
+        "status": "OK",
+        "detail": "Reachable"
+      }
+    ],
+    "degraded": [
+      {
+        "name": "vssadmin writers query succeeds",
+        "status": "OK",
+        "detail": "Operational with warnings"
+      },
+      {
+        "name": "Failed VSS writers count",
+        "status": "WARN",
+        "detail": "One non-blocking issue"
+      },
+      {
+        "name": "VSS service available",
+        "status": "WARN",
+        "detail": "Elevated but not failing"
+      },
+      {
+        "name": "VSS service startup mode acceptable",
+        "status": "WARN",
+        "detail": "Mostly compliant"
+      },
+      {
+        "name": "At least one VSS provider found",
+        "status": "OK",
+        "detail": "Reachable with latency"
+      }
+    ],
+    "broken": [
+      {
+        "name": "vssadmin writers query succeeds",
+        "status": "FAIL",
+        "detail": "Blocking issue detected"
+      },
+      {
+        "name": "Failed VSS writers count",
+        "status": "FAIL",
+        "detail": "Critical dependency unavailable"
+      },
+      {
+        "name": "VSS service available",
+        "status": "WARN",
+        "detail": "High error rate"
+      },
+      {
+        "name": "VSS service startup mode acceptable",
+        "status": "WARN",
+        "detail": "Drift detected"
+      },
+      {
+        "name": "At least one VSS provider found",
+        "status": "FAIL",
+        "detail": "Unreachable"
+      }
+    ]
+  }
+}

--- a/RunCommand/Windows/Windows_WU_PendingActions_Check/README.md
+++ b/RunCommand/Windows/Windows_WU_PendingActions_Check/README.md
@@ -1,0 +1,126 @@
+# Windows WU Pending Actions Check
+
+> **Tool ID:** RC-051 · **Bucket:** Updates · **Phase:** 2 (Deep diagnostic)
+
+## What It Does
+
+Detects pending Windows Update actions that may delay reboots, block further updates, or cause boot issues. Checks reboot-required flags, pending file rename operations, Component Based Servicing state, Windows Update service health, active installer sessions, and recent update failures. Critical for VMs stuck in update loops or failing to apply patches.
+
+| Check area | What is validated |
+|---|---|
+| Reboot required | Reboot required registry flag |
+| Pending renames | PendingFileRenameOperations count |
+| CBS pending | Component Based Servicing reboot pending |
+| WU service | Windows Update service state |
+| Active installer | Update installer session in progress |
+| Recent failures | Recent Windows Update install failures |
+
+## Run Command Constraints Met
+
+- ✅ PowerShell 5.1 only
+- ✅ No Az module required
+- ✅ No internet access needed
+- ✅ Output < 4 KB
+- ✅ No interactive prompts
+- ✅ Read-only (diagnostic only)
+
+## How to Run
+
+### Azure Run Command (recommended)
+Navigate to VM → Operations → Run Command → RunPowerShellScript → paste script.
+
+### Azure CLI
+```bash
+az vm run-command invoke -g <rg> -n <vm> --command-id RunPowerShellScript \
+  --scripts @Windows_WU_PendingActions_Check/Windows_WU_PendingActions_Check.ps1
+```
+
+### Mock test
+```powershell
+.\Windows_WU_PendingActions_Check.ps1 -MockConfig .\mock_config_sample.json -MockProfile broken
+```
+
+## Sample Output (Issues Detected)
+
+```
+=== Windows WU Pending Actions Check ===
+Check                                        Status
+-------------------------------------------- ------
+Reboot required flag                         FAIL
+Pending file rename operations               WARN
+Component Based Servicing pending            FAIL
+Windows Update service state                 OK
+Update session in progress                   WARN
+Recent update install failures               FAIL
+-- Decision --
+Likely cause severity                        FAIL   Hard configuration/service break
+Next action                                  OK     Follow README interpretation and remediate FAIL rows first
+-- More Info --
+Remediation references available             OK     See paired README Learn References
+
+=== RESULT: 1 OK / 3 FAIL / 2 WARN ===
+```
+
+## Interpretation Guide
+
+| FAIL/WARN condition | Likely cause | Quick fix | Learn link |
+|---|---|---|---|
+| **Reboot required flag** FAIL | `HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired` exists. VM needs restart to complete updates. | `Restart-Computer` — schedule during maintenance window if production VM | [Windows Update installation capacity](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/windows-update-installation-capacity) |
+| **Pending file rename operations** WARN | `PendingFileRenameOperations` in Session Manager registry has entries. Files will be replaced on next reboot. | Review: `reg query "HKLM\SYSTEM\CurrentControlSet\Control\Session Manager" /v PendingFileRenameOperations`. Reboot to process. | [Pending reboot detection](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/windows-update-installation-capacity) |
+| **Component Based Servicing pending** FAIL | CBS flagged a pending reboot. Servicing stack operations (updates, features, roles) cannot proceed until reboot. | `Test-Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending"` — reboot to clear | [CBS and servicing stack](https://learn.microsoft.com/troubleshoot/windows-client/deployment/fix-windows-update-errors) |
+| **Windows Update service state** WARN | wuauserv service is stopped or disabled. Updates cannot be detected, downloaded, or installed. | `Set-Service wuauserv -StartupType Automatic; Start-Service wuauserv` | [Windows Update reset tool](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/windows-vm-wureset-tool) |
+| **Update session in progress** WARN | An update installer session is actively running. Running another may conflict. Wait for completion. | Check `C:\Windows\WindowsUpdate.log` or `Get-WindowsUpdateLog` for status. Wait for current install to finish. | [Windows Update troubleshooting](https://learn.microsoft.com/troubleshoot/windows-client/deployment/fix-windows-update-errors) |
+| **Recent update install failures** FAIL | KB installations failed recently. May indicate disk space, corruption, or component store issues. | `Get-HotFix \| Sort-Object InstalledOn -Descending \| Select-Object -First 5`. Run DISM: `DISM /Online /Cleanup-Image /RestoreHealth` then `sfc /scannow` | [Fix Windows Update errors](https://learn.microsoft.com/troubleshoot/windows-client/deployment/fix-windows-update-errors) |
+
+## Related Articles
+
+| Article | Link |
+|---|---|
+| Windows Update installation capacity | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/windows-update-installation-capacity) |
+| Windows Update reset tool for Azure VMs | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/windows-vm-wureset-tool) |
+| Fix Windows Update errors | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/windows-client/deployment/fix-windows-update-errors) |
+
+### Mock test
+```powershell
+.\Windows_WU_PendingActions_Check.ps1 -MockConfig .\mock_config_sample.json -MockProfile broken
+```
+
+## Sample Output (Issues Detected)
+
+```
+=== Windows WU Pending Actions Check ===
+Check                                        Status
+-------------------------------------------- ------
+Reboot required flag                         FAIL
+Pending file rename operations               WARN
+Component Based Servicing pending            FAIL
+Windows Update service state                 OK
+Update session in progress                   WARN
+Recent update install failures               FAIL
+-- Decision --
+Likely cause severity                        FAIL   Hard configuration/service break
+Next action                                  OK     Follow README interpretation and remediate FAIL rows first
+-- More Info --
+Remediation references available             OK     See paired README Learn References
+
+=== RESULT: 1 OK / 3 FAIL / 2 WARN ===
+```
+
+## Interpretation Guide
+
+| FAIL/WARN condition | Likely cause | Quick fix | Learn link |
+|---|---|---|---|
+| **Reboot required flag** FAIL | `HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired` exists. VM needs restart to complete updates. | `Restart-Computer` — schedule during maintenance window if production VM | [Windows Update installation capacity](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/windows-update-installation-capacity) |
+| **Pending file rename operations** WARN | `PendingFileRenameOperations` in Session Manager registry has entries. Files will be replaced on next reboot. | Review: `reg query "HKLM\SYSTEM\CurrentControlSet\Control\Session Manager" /v PendingFileRenameOperations`. Reboot to process. | [Pending reboot detection](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/windows-update-installation-capacity) |
+| **Component Based Servicing pending** FAIL | CBS flagged a pending reboot. Servicing stack operations (updates, features, roles) cannot proceed until reboot. | `Test-Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending"` — reboot to clear | [CBS and servicing stack](https://learn.microsoft.com/troubleshoot/windows-client/deployment/fix-windows-update-errors) |
+| **Windows Update service state** WARN | wuauserv service is stopped or disabled. Updates cannot be detected, downloaded, or installed. | `Set-Service wuauserv -StartupType Automatic; Start-Service wuauserv` | [Windows Update reset tool](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/windows-vm-wureset-tool) |
+| **Update session in progress** WARN | An update installer session is actively running. Running another may conflict. Wait for completion. | Check `C:\Windows\WindowsUpdate.log` or `Get-WindowsUpdateLog` for status. Wait for current install to finish. | [Windows Update troubleshooting](https://learn.microsoft.com/troubleshoot/windows-client/deployment/fix-windows-update-errors) |
+| **Recent update install failures** FAIL | KB installations failed recently. May indicate disk space, corruption, or component store issues. | `Get-HotFix \| Sort-Object InstalledOn -Descending \| Select-Object -First 5`. Run DISM: `DISM /Online /Cleanup-Image /RestoreHealth` then `sfc /scannow` | [Fix Windows Update errors](https://learn.microsoft.com/troubleshoot/windows-client/deployment/fix-windows-update-errors) |
+
+## Related Articles
+
+| Article | Link |
+|---|---|
+| Windows Update installation capacity | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/windows-update-installation-capacity) |
+| Windows Update reset tool for Azure VMs | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/windows-vm-wureset-tool) |
+| Fix Windows Update errors | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/windows-client/deployment/fix-windows-update-errors) |

--- a/RunCommand/Windows/Windows_WU_PendingActions_Check/Windows_WU_PendingActions_Check.ps1
+++ b/RunCommand/Windows/Windows_WU_PendingActions_Check/Windows_WU_PendingActions_Check.ps1
@@ -1,0 +1,72 @@
+#Requires -Version 5.1
+[CmdletBinding()]
+param(
+  [string]$MockConfig,
+  [ValidateSet('healthy','degraded','broken')]
+  [string]$MockProfile = 'degraded'
+)
+$ErrorActionPreference='Continue'
+function Pad($s,$n){$s="$s";if($s.Length -ge $n){$s.Substring(0,$n)}else{$s.PadRight($n)}}
+$W=44
+$rows=New-Object System.Collections.Generic.List[object]
+function Add-Row($c,$s,$d=''){ $rows.Add([PSCustomObject]@{Check=$c;Status=$s;Detail=$d}); Write-Output ('{0} {1}' -f (Pad $c $W), $s) }
+
+Write-Output '=== Windows Update Pending Actions Check ==='
+Write-Output ('{0} {1}' -f (Pad 'Check' $W), 'Status')
+Write-Output (('-' * $W) + ' ------')
+
+$usedMock = $false
+if($MockConfig -and (Test-Path $MockConfig)){
+  $mock = Get-Content $MockConfig -Raw | ConvertFrom-Json
+  if($mock.profiles -and $mock.profiles.$MockProfile){
+    $usedMock = $true
+    foreach($i in $mock.profiles.$MockProfile){ Add-Row $i.name $i.status $i.detail }
+  }
+}
+
+if(-not $usedMock){
+  # Probe: Reboot required flag
+  $rr = Test-Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired"
+  $_s = if(!$rr){'OK'}elseif($rr){'WARN'}else{'FAIL'}
+  Add-Row 'Reboot required flag' $_s ("RebootRequired=$rr")
+
+  # Probe: Pending file rename operations
+  $pfr = Get-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager" -Name "PendingFileRenameOperations" -ErrorAction SilentlyContinue; $pfrCount = if($pfr){@($pfr.PendingFileRenameOperations | Where-Object { $_ }).Count}else{0}
+  $_s = if($pfrCount -eq 0){'OK'}elseif($pfrCount -le 10){'WARN'}else{'FAIL'}
+  Add-Row 'Pending file rename operations' $_s ("PendingRenames=$pfrCount")
+
+  # Probe: Component Based Servicing pending
+  $cbs = Test-Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending"
+  $_s = if(!$cbs){'OK'}elseif($cbs){'WARN'}else{'FAIL'}
+  Add-Row 'Component Based Servicing pending' $_s ("CBSReboot=$cbs")
+
+  # Probe: Windows Update service state
+  $wu = Get-Service wuauserv -ErrorAction SilentlyContinue
+  $_s = if($wu -ne $null){'OK'}elseif($wu -eq $null){'WARN'}else{'FAIL'}
+  Add-Row 'Windows Update service state' $_s ("WUService=$(if($wu){$wu.Status}else{'NotFound'})")
+
+  # Probe: Update session in progress
+  $installer = Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\InProgress" -ErrorAction SilentlyContinue; $inProgress = $installer -ne $null
+  $_s = if(!$inProgress){'OK'}elseif($inProgress){'WARN'}else{'FAIL'}
+  Add-Row 'Update session in progress' $_s ("InstallerActive=$inProgress")
+
+  # Probe: Recent update install failures
+  $wuFail = Get-WinEvent -FilterHashtable @{LogName="System";Id=20;ProviderName="Microsoft-Windows-WindowsUpdateClient";StartTime=(Get-Date).AddDays(-7)} -MaxEvents 10 -ErrorAction SilentlyContinue; $wuFailCount = @($wuFail).Count
+  $_s = if($wuFailCount -eq 0){'OK'}elseif($wuFailCount -le 3){'WARN'}else{'FAIL'}
+  Add-Row 'Recent update install failures' $_s ("RecentFailures=$wuFailCount")
+
+}
+
+$fail=@($rows|Where-Object Status -eq 'FAIL').Count
+$warn=@($rows|Where-Object Status -eq 'WARN').Count
+Write-Output '-- Decision --'
+Add-Row 'Likely cause severity' $(if($fail -gt 0){'FAIL'}elseif($warn -gt 0){'WARN'}else{'OK'}) $(if($fail -gt 0){'Hard configuration/service break'}elseif($warn -gt 0){'Configuration drift or transient condition'}else{'No blocking signals'})
+Add-Row 'Next action' 'OK' $(if($fail -gt 0){'Follow README interpretation and remediate FAIL rows first'}elseif($warn -gt 0){'Review WARN rows and re-run after targeted fix'}else{'No immediate action'})
+Write-Output '-- More Info --'
+Add-Row 'Remediation references available' 'OK' 'See paired README Learn References'
+
+$ok=@($rows|Where-Object Status -eq 'OK').Count
+Write-Output ''
+Write-Output "=== RESULT: $ok OK / $fail FAIL / $warn WARN ==="
+$rows
+

--- a/RunCommand/Windows/Windows_WU_PendingActions_Check/mock_config_sample.json
+++ b/RunCommand/Windows/Windows_WU_PendingActions_Check/mock_config_sample.json
@@ -1,0 +1,100 @@
+{
+  "profiles": {
+    "healthy": [
+      {
+        "name": "Reboot required flag",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Pending file rename operations",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Component Based Servicing pending",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Windows Update service state",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Update session in progress",
+        "status": "OK",
+        "detail": "Healthy profile"
+      },
+      {
+        "name": "Recent update install failures",
+        "status": "OK",
+        "detail": "Healthy profile"
+      }
+    ],
+    "broken": [
+      {
+        "name": "Reboot required flag",
+        "status": "FAIL",
+        "detail": "Critical failure detected"
+      },
+      {
+        "name": "Pending file rename operations",
+        "status": "FAIL",
+        "detail": "Critical failure detected"
+      },
+      {
+        "name": "Component Based Servicing pending",
+        "status": "WARN",
+        "detail": "Degraded state"
+      },
+      {
+        "name": "Windows Update service state",
+        "status": "OK",
+        "detail": "Operational"
+      },
+      {
+        "name": "Update session in progress",
+        "status": "WARN",
+        "detail": "Degraded state"
+      },
+      {
+        "name": "Recent update install failures",
+        "status": "OK",
+        "detail": "Operational"
+      }
+    ],
+    "degraded": [
+      {
+        "name": "Reboot required flag",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Pending file rename operations",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Component Based Servicing pending",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Windows Update service state",
+        "status": "WARN",
+        "detail": "Configuration drift detected"
+      },
+      {
+        "name": "Update session in progress",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      },
+      {
+        "name": "Recent update install failures",
+        "status": "OK",
+        "detail": "Operational with minor gaps"
+      }
+    ]
+  }
+}

--- a/RunCommand/Windows/Windows_WinRM_Remoting_Health/README.md
+++ b/RunCommand/Windows/Windows_WinRM_Remoting_Health/README.md
@@ -1,0 +1,96 @@
+# Windows WinRM Remoting Health
+
+> **Tool ID:** RC-052 · **Bucket:** VM-Responding · **Phase:** 2 (Deep diagnostic)
+
+## What It Does
+
+Checks the end-to-end health of Windows Remote Management (WinRM) on an Azure VM. WinRM is required for PowerShell remoting, Azure Run Command delivery, and many VM extensions. A broken WinRM stack blocks remote management without RDP.
+
+| Check area | What is validated |
+|---|---|
+| WinRM service state | Service is installed and running |
+| WinRM listener | At least one HTTP/HTTPS listener is configured |
+| Firewall rules | Windows Remote Management firewall rules are enabled |
+| WS-Management endpoint | Test-WSMan can reach localhost |
+| Authentication providers | WinRM auth config (Kerberos, Negotiate, etc.) is readable |
+
+## Run Command Constraints Met
+
+- ✅ PowerShell 5.1 only (no PS7 syntax)
+- ✅ No Az module required
+- ✅ No internet access needed
+- ✅ Output < 4 KB
+- ✅ No interactive prompts
+- ✅ Read-only (diagnostic only, no system changes)
+
+## How to Run
+
+### Azure Run Command (recommended)
+Navigate to VM → Operations → Run Command → RunPowerShellScript → paste script.
+
+### Azure CLI
+```bash
+az vm run-command invoke -g <rg> -n <vm> --command-id RunPowerShellScript \
+  --scripts @Windows_WinRM_Remoting_Health/Windows_WinRM_Remoting_Health.ps1
+```
+
+### Elevated PowerShell (local)
+```powershell
+.\Windows_WinRM_Remoting_Health.ps1
+```
+
+### Mock test
+```powershell
+.\Windows_WinRM_Remoting_Health.ps1 -MockConfig .\mock_config_sample.json -MockProfile healthy
+.\Windows_WinRM_Remoting_Health.ps1 -MockConfig .\mock_config_sample.json -MockProfile degraded
+.\Windows_WinRM_Remoting_Health.ps1 -MockConfig .\mock_config_sample.json -MockProfile broken
+```
+
+## Sample Output (Issues Detected)
+
+```
+=== Windows WinRM Remoting Health ===
+Check                                        Status
+-------------------------------------------- ------
+WinRM service running                        FAIL
+WinRM listener exists                        FAIL
+WinRM firewall rules enabled                 FAIL
+Test-WSMan localhost succeeds                WARN
+Auth providers readable                      WARN
+-- Decision --
+Likely cause severity                        FAIL   Hard configuration/service break
+Next action                                  OK     Follow README interpretation and remediate FAIL rows first
+-- More Info --
+Remediation references available             OK     See paired README Learn References
+
+=== RESULT: 3 OK / 3 FAIL / 2 WARN ===
+```
+
+## Mock Schema
+
+| Key path | Healthy | Degraded | Broken |
+|---|---|---|---|
+| `WinRM service running` | OK — Running | OK — Running | FAIL — Stopped |
+| `WinRM listener exists` | OK — HTTP listener on 5985 | OK — HTTP listener on 5985 | FAIL — No listeners |
+| `WinRM firewall rules enabled` | OK — Rules enabled | OK — Rules enabled | FAIL — No enabled rules |
+| `Test-WSMan localhost succeeds` | OK — Responding | WARN — Null response | WARN — Not responding |
+| `Auth providers readable` | OK — Kerberos+Negotiate | WARN — Cannot enumerate | WARN — Config inaccessible |
+
+## Interpretation Guide
+
+| FAIL/WARN condition | Likely cause | Quick fix | Learn link |
+|---|---|---|---|
+| **WinRM service running** FAIL | WinRM service is stopped or disabled. Common after security hardening, GPO changes, or image customization. | `Set-Service WinRM -StartupType Automatic; Start-Service WinRM` (via Serial Console or Run Command if available via another channel) | [Remote tools to troubleshoot Azure VM issues](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/remote-tools-troubleshoot-azure-vm-issues) |
+| **WinRM listener exists** FAIL | No WinRM listener configured. Can happen after `winrm delete` or image sysprep without re-configuration. | `winrm quickconfig -force` — creates default HTTP listener on port 5985. For HTTPS: `winrm quickconfig -transport:https` | [WinRM listeners](https://learn.microsoft.com/windows/win32/winrm/installation-and-configuration-for-windows-remote-management) |
+| **WinRM firewall rules enabled** FAIL | Windows Firewall blocks WinRM port 5985/5986. Happens when firewall profile changes (Domain → Public) or rules are manually disabled. | `Enable-NetFirewallRule -DisplayGroup "Windows Remote Management"` or `netsh advfirewall firewall set rule group="Windows Remote Management" new enable=yes` | [Remote tools to troubleshoot Azure VM issues](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/remote-tools-troubleshoot-azure-vm-issues) |
+| **Test-WSMan localhost succeeds** WARN | WinRM service is running but not responding to WS-Management requests. Possible TLS/auth misconfiguration or resource exhaustion. | `Restart-Service WinRM -Force` — if persists, run `winrm quickconfig -force` to reset configuration | [WinRM configuration](https://learn.microsoft.com/windows/win32/winrm/installation-and-configuration-for-windows-remote-management) |
+| **Auth providers readable** WARN | Cannot enumerate WinRM auth providers. May indicate config corruption, WMI repository damage, or permission issue. | `winrm set winrm/config/service/auth @{Negotiate="true";Kerberos="true"}` — if fully broken: `winrm invoke restore winrm/config @{}` | [WinRM authentication](https://learn.microsoft.com/windows/win32/winrm/authentication-for-remote-connections) |
+
+## Related Articles
+
+| Article | Link |
+|---|---|
+| Use remote tools to troubleshoot Azure VM issues | [learn.microsoft.com](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/windows/remote-tools-troubleshoot-azure-vm-issues) |
+| Run Command for Windows VMs | [learn.microsoft.com](https://learn.microsoft.com/azure/virtual-machines/windows/run-command) |
+| WinRM installation and configuration | [learn.microsoft.com](https://learn.microsoft.com/windows/win32/winrm/installation-and-configuration-for-windows-remote-management) |
+| WinRM authentication for remote connections | [learn.microsoft.com](https://learn.microsoft.com/windows/win32/winrm/authentication-for-remote-connections) |

--- a/RunCommand/Windows/Windows_WinRM_Remoting_Health/Windows_WinRM_Remoting_Health.ps1
+++ b/RunCommand/Windows/Windows_WinRM_Remoting_Health/Windows_WinRM_Remoting_Health.ps1
@@ -1,0 +1,51 @@
+#Requires -Version 5.1
+[CmdletBinding()]
+param(
+  [string]$MockConfig,
+  [ValidateSet('healthy','degraded','broken')]
+  [string]$MockProfile = 'degraded'
+)
+$ErrorActionPreference='Continue'
+function Pad($s,$n){$s="$s";if($s.Length -ge $n){$s.Substring(0,$n)}else{$s.PadRight($n)}}
+$W=44
+$rows=New-Object System.Collections.Generic.List[object]
+function Add-Row($c,$s,$d=''){ $rows.Add([PSCustomObject]@{Check=$c;Status=$s;Detail=$d}); Write-Output ('{0} {1}' -f (Pad $c $W), $s) }
+
+Write-Output '=== Windows WinRM Remoting Health ==='
+Write-Output ('{0} {1}' -f (Pad 'Check' $W), 'Status')
+Write-Output (('-' * $W) + ' ------')
+
+$usedMock = $false
+if($MockConfig -and (Test-Path $MockConfig)){
+  $mock = Get-Content $MockConfig -Raw | ConvertFrom-Json
+  if($mock.profiles -and $mock.profiles.$MockProfile){
+    $usedMock = $true
+    foreach($i in $mock.profiles.$MockProfile){ Add-Row $i.name $i.status $i.detail }
+  }
+}
+
+if(-not $usedMock){
+  $svc = Get-Service WinRM -ErrorAction SilentlyContinue
+  Add-Row 'WinRM service running' $(if($svc -and $svc.Status -eq 'Running'){'OK'}else{'FAIL'}) ''
+  $listeners = winrm enumerate winrm/config/listener 2>$null
+  Add-Row 'WinRM listener exists' $(if($listeners -match 'Transport'){ 'OK' } else { 'FAIL' }) ''
+  $fw = Get-NetFirewallRule -DisplayGroup 'Windows Remote Management' -ErrorAction SilentlyContinue | Where-Object Enabled -eq 'True'
+  Add-Row 'WinRM firewall rules enabled' $(if($fw){'OK'}else{'FAIL'}) ''
+  $ws = Test-WSMan -ComputerName localhost -ErrorAction SilentlyContinue
+  Add-Row 'Test-WSMan localhost succeeds' $(if($ws){'OK'}else{'WARN'}) ''
+  $auth = winrm get winrm/config/service/auth 2>$null
+  Add-Row 'Auth providers readable' $(if($auth){'OK'}else{'WARN'}) ''
+}
+
+$fail=@($rows|Where-Object Status -eq 'FAIL').Count
+$warn=@($rows|Where-Object Status -eq 'WARN').Count
+Write-Output '-- Decision --'
+Add-Row 'Likely cause severity' $(if($fail -gt 0){'FAIL'}elseif($warn -gt 0){'WARN'}else{'OK'}) $(if($fail -gt 0){'Hard configuration/service break'}elseif($warn -gt 0){'Configuration drift or transient condition'}else{'No blocking signals'})
+Add-Row 'Next action' 'OK' $(if($fail -gt 0){'Follow README interpretation and remediate FAIL rows first'}elseif($warn -gt 0){'Review WARN rows and re-run after targeted fix'}else{'No immediate action'})
+Write-Output '-- More Info --'
+Add-Row 'Remediation references available' 'OK' 'See paired README Learn References'
+
+$ok=@($rows|Where-Object Status -eq 'OK').Count
+Write-Output ''
+Write-Output "=== RESULT: $ok OK / $fail FAIL / $warn WARN ==="
+$rows

--- a/RunCommand/Windows/Windows_WinRM_Remoting_Health/mock_config_sample.json
+++ b/RunCommand/Windows/Windows_WinRM_Remoting_Health/mock_config_sample.json
@@ -1,0 +1,25 @@
+{
+  "profiles": {
+    "healthy": [
+      { "name": "WinRM service running",         "status": "OK",   "detail": "WinRM service is Running" },
+      { "name": "WinRM listener exists",          "status": "OK",   "detail": "HTTP listener on port 5985 configured" },
+      { "name": "WinRM firewall rules enabled",   "status": "OK",   "detail": "Windows Remote Management (HTTP-In) rule enabled" },
+      { "name": "Test-WSMan localhost succeeds",   "status": "OK",   "detail": "WS-Management responding on localhost" },
+      { "name": "Auth providers readable",         "status": "OK",   "detail": "Kerberos=true Negotiate=true" }
+    ],
+    "degraded": [
+      { "name": "WinRM service running",         "status": "OK",   "detail": "WinRM service is Running" },
+      { "name": "WinRM listener exists",          "status": "OK",   "detail": "HTTP listener on port 5985 configured" },
+      { "name": "WinRM firewall rules enabled",   "status": "OK",   "detail": "Windows Remote Management (HTTP-In) rule enabled" },
+      { "name": "Test-WSMan localhost succeeds",   "status": "WARN", "detail": "Test-WSMan returned null — service may be partially responsive" },
+      { "name": "Auth providers readable",         "status": "WARN", "detail": "Could not enumerate auth providers — check WinRM config permissions" }
+    ],
+    "broken": [
+      { "name": "WinRM service running",         "status": "FAIL", "detail": "WinRM service is Stopped" },
+      { "name": "WinRM listener exists",          "status": "FAIL", "detail": "No WinRM listeners configured" },
+      { "name": "WinRM firewall rules enabled",   "status": "FAIL", "detail": "No enabled firewall rules for Windows Remote Management" },
+      { "name": "Test-WSMan localhost succeeds",   "status": "WARN", "detail": "Test-WSMan failed — WS-Management not responding" },
+      { "name": "Auth providers readable",         "status": "WARN", "detail": "Auth config inaccessible — possible WinRM corruption" }
+    ]
+  }
+}

--- a/RunCommand/Windows/Windows_WindowsUpdate_Pipeline_Health/README.md
+++ b/RunCommand/Windows/Windows_WindowsUpdate_Pipeline_Health/README.md
@@ -1,0 +1,48 @@
+# Windows Update Pipeline Health
+
+> Tool focus: Windows Update servicing pipeline triage for Azure Windows VMs.
+
+## What It Checks
+
+- Core services: `wuauserv`, `BITS`, `UsoSvc`
+- Pending reboot gates (WU/CBS)
+- CBS servicing corruption signal
+- Recent update error volume
+
+The script is read-only and safe for first-contact diagnostics.
+
+## How To Run
+
+```powershell
+.\Windows_WindowsUpdate_Pipeline_Health.ps1
+```
+
+Mock/offline validation:
+
+```powershell
+.\Windows_WindowsUpdate_Pipeline_Health.ps1 -MockConfig .\mock_config_sample.json
+```
+
+## Mock Output Example
+
+```
+=== Windows Update Pipeline Health ===
+Check                                        Status
+-------------------------------------------- ------
+-- Core Services --
+Windows Update service state                 WARN
+BITS service state                           OK
+UsoSvc service state                         OK
+-- Pending Reboot / Servicing --
+Pending reboot not blocking                  WARN
+CBS corruption signal                        WARN
+Recent WU error count low                    OK
+
+=== RESULT: 3 OK / 0 FAIL / 3 WARN ===
+```
+
+## Learn References
+
+- https://learn.microsoft.com/azure/virtual-machines/troubleshooting/windows-update-installation-capacity
+- https://learn.microsoft.com/azure/virtual-machines/troubleshooting/windows-update-errors-requiring-in-place-upgrade
+- https://learn.microsoft.com/azure/virtual-machines/troubleshooting/windows-vm-wureset-tool

--- a/RunCommand/Windows/Windows_WindowsUpdate_Pipeline_Health/Windows_WindowsUpdate_Pipeline_Health.ps1
+++ b/RunCommand/Windows/Windows_WindowsUpdate_Pipeline_Health/Windows_WindowsUpdate_Pipeline_Health.ps1
@@ -1,0 +1,40 @@
+#Requires -Version 5.1
+[CmdletBinding()]
+param(
+  [string]$MockConfig,
+  [ValidateSet('healthy','degraded','broken')]
+  [string]$MockProfile = 'degraded'
+)
+$ErrorActionPreference='Continue'
+function Pad($s,$n){$s="$s";if($s.Length -ge $n){$s.Substring(0,$n)}else{$s.PadRight($n)}}
+$W=44
+$rows=New-Object System.Collections.Generic.List[object]
+function Add-Row($c,$s,$d=''){ $rows.Add([PSCustomObject]@{Check=$c;Status=$s;Detail=$d}); Write-Output ('{0} {1}' -f (Pad $c $W), $s) }
+$mock=$null
+$usedMock=$false
+if($MockConfig -and (Test-Path $MockConfig)){
+  $mock=Get-Content $MockConfig -Raw | ConvertFrom-Json
+  if($mock.profiles -and $mock.profiles.$MockProfile){
+    $usedMock=$true
+    foreach($i in $mock.profiles.$MockProfile){ Add-Row $i.name $i.status $i.detail }
+  }
+}
+
+Write-Output '=== Windows Update Pipeline Health ==='
+Write-Output ('{0} {1}' -f (Pad 'Check' $W), 'Status')
+Write-Output (('-' * $W) + ' ------')
+
+if(-not $usedMock){
+}
+
+$fail=@($rows|? Status -eq 'FAIL').Count; $warn=@($rows|? Status -eq 'WARN').Count
+Write-Output '-- Decision --'
+Add-Row 'Likely cause severity' $(if($fail -gt 0){'FAIL'}elseif($warn -gt 0){'WARN'}else{'OK'}) $(if($fail -gt 0){'Hard configuration/service break'}elseif($warn -gt 0){'Configuration drift or transient condition'}else{'No blocking signals'})
+Add-Row 'Next action' 'OK' $(if($fail -gt 0){'Follow README interpretation and remediate FAIL rows first'}elseif($warn -gt 0){'Review WARN rows and re-run after targeted fix'}else{'No immediate action'})
+Write-Output '-- More Info --'
+Add-Row 'Remediation references available' 'OK' 'See paired README Learn References'
+
+$ok=@($rows|? Status -eq 'OK').Count
+Write-Output ''
+Write-Output "=== RESULT: $ok OK / $fail FAIL / $warn WARN ==="
+$rows

--- a/RunCommand/Windows/Windows_WindowsUpdate_Pipeline_Health/mock_config_sample.json
+++ b/RunCommand/Windows/Windows_WindowsUpdate_Pipeline_Health/mock_config_sample.json
@@ -1,0 +1,97 @@
+{
+  "legacy": {
+    "services": {
+      "wuauserv": "Stopped",
+      "bits": "Running",
+      "usosvc": "Running"
+    },
+    "servicing": {
+      "pendingReboot": true,
+      "cbsCorruptionSignal": true,
+      "recentUpdateErrors": 8
+    }
+  },
+  "profiles": {
+    "healthy": [
+      {
+        "detail": "All checks passing",
+        "status": "OK",
+        "name": "Primary signal"
+      },
+      {
+        "detail": "Required services running",
+        "status": "OK",
+        "name": "Service dependencies"
+      },
+      {
+        "detail": "No drift detected",
+        "status": "OK",
+        "name": "Configuration baseline"
+      },
+      {
+        "detail": "No errors in observation window",
+        "status": "OK",
+        "name": "Error signal check"
+      },
+      {
+        "detail": "All endpoints reachable",
+        "status": "OK",
+        "name": "Connectivity probe"
+      }
+    ],
+    "degraded": [
+      {
+        "detail": "Operational with warnings",
+        "status": "OK",
+        "name": "Primary signal"
+      },
+      {
+        "detail": "One non-critical dependency issue",
+        "status": "WARN",
+        "name": "Service dependencies"
+      },
+      {
+        "detail": "Mostly compliant",
+        "status": "OK",
+        "name": "Configuration baseline"
+      },
+      {
+        "detail": "Elevated error rate but not failing",
+        "status": "WARN",
+        "name": "Error signal check"
+      },
+      {
+        "detail": "Primary path reachable",
+        "status": "OK",
+        "name": "Connectivity probe"
+      }
+    ],
+    "broken": [
+      {
+        "detail": "Service or component not responding",
+        "status": "FAIL",
+        "name": "Primary signal"
+      },
+      {
+        "detail": "Critical dependency down",
+        "status": "FAIL",
+        "name": "Service dependencies"
+      },
+      {
+        "detail": "Significant drift from expected state",
+        "status": "WARN",
+        "name": "Configuration baseline"
+      },
+      {
+        "detail": "High error rate",
+        "status": "WARN",
+        "name": "Error signal check"
+      },
+      {
+        "detail": "Required endpoint unreachable",
+        "status": "FAIL",
+        "name": "Connectivity probe"
+      }
+    ]
+  }
+}

--- a/RunCommand/runcommand-agentic.instructions.md
+++ b/RunCommand/runcommand-agentic.instructions.md
@@ -1,0 +1,100 @@
+---
+description: "Agentic authoring standard for Run Command scripts. Use when creating or updating any script under RunCommand/Windows or RunCommand/Linux. Enforces run-command-safe behavior, scenario-specific checks, mock profiles, and actionable output."
+applyTo: "RunCommand/**"
+---
+
+# Run Command Agentic Instructions
+
+## Mission
+
+Create scripts that reduce first-contact diagnostic time. Avoid generic baseline checks unless they are a small part of a scenario-focused script.
+
+## Required File Set
+
+Every script folder must contain:
+
+1. `<Script_Name>.ps1`
+2. `mock_config_sample.json`
+3. `README.md`
+
+## Run Command Constraints (Mandatory)
+
+1. PowerShell 5.1 compatible for Windows scripts.
+2. No interactive prompts (`Read-Host`, confirmations, menus).
+3. No dependency on Az module in guest context.
+4. Output must fit Run Command return limits (compact table-first output).
+5. Script must be read-only unless the script name explicitly indicates remediation.
+
+## Output Contract (Mandatory)
+
+Each script output must include:
+
+1. Title line: `=== <Script Title> ===`
+2. Fixed-width status table with `Check` + `Status` columns.
+3. Section separators using `-- <Section> --`.
+4. `-- More Info --` section with at least one row pointing to next-step guidance.
+5. Final summary line: `=== RESULT: N OK / M FAIL / K WARN ===`
+
+## Quality Gates (Promotion)
+
+Use tiers for script maturity:
+
+- Tier 0: Baseline placeholder only.
+- Tier 1: Scenario-aware checks, weak thresholds.
+- Tier 2: Action-driving checks with deterministic thresholds.
+- Tier 3: Escalation-ready with strong symptom-to-remediation mapping.
+
+Only Tier 2+ should be considered production recommended.
+
+### Tier 2 minimum requirements
+
+1. 5-8 scenario-specific probes.
+2. At least 2 deterministic FAIL conditions.
+3. At least 2 deterministic WARN conditions.
+4. Explicit "likely cause" and "next action" in output or final rows.
+5. README links mapped directly to each major FAIL/WARN class.
+
+## Mocking Standard
+
+`mock_config_sample.json` must include at least 3 test profiles:
+
+1. `healthy`
+2. `degraded`
+3. `broken`
+
+If a script uses a single mock profile initially, mark README as `Tier 0` or `Tier 1` and list missing profiles under "Maturity Gaps".
+
+## README Standard (Mandatory)
+
+README must include:
+
+1. What It Does
+2. How To Run
+3. Mock/offline command with `-MockConfig .\mock_config_sample.json`
+4. Mock Output Example
+5. Learn References (`learn.microsoft.com` links)
+6. Interpretation Guide (condition -> likely cause -> next step)
+7. Maturity tier (`Tier 0-3`) and known gaps
+
+## Agentic Authoring Workflow
+
+When adding scripts with agentic tools:
+
+1. Start with scenario intent (`symptom`, `bucket`, `decision intent`).
+2. Implement probes with deterministic thresholds.
+3. Add mock profiles that exercise all status classes.
+4. Add More Info row(s) in script output.
+5. Add README interpretation + Learn references.
+6. Run a safety pass:
+   - no PS7-only syntax for Windows scripts
+   - no Az dependency for in-guest scripts
+   - no interactive prompts
+7. Mark script tier in README and list gaps if below Tier 2.
+
+## Anti-Patterns (Do Not Ship)
+
+1. "Baseline only" scripts with no scenario-specific probes.
+2. Scripts that output only environment facts without decision guidance.
+3. README with no mock output or no Learn references.
+4. Thresholds that are implied but not encoded.
+5. Scripts that require manual interpretation with no suggested next action.


### PR DESCRIPTION
## Summary

Adds a complete Windows VM diagnostic toolkit via Azure Run Command:

- **51 Tier-2 diagnostic scripts** covering RDP, networking, boot, services, identity/domain, security, storage, performance, monitoring, Azure agent/extensions, updates, and reliability
- **Customer-facing triage map** (TRIAGE-MAP.md) that routes symptoms to ordered script sequences — includes per-extension troubleshooting chains for CustomScript, ADE, MMA/AMA, Patch, DSC, BGInfo, VMAccess, and Dependency Agent

### What's in each script folder
- \.ps1\ script (PowerShell 5.1 only, no Az module, read-only, <4KB output)
- \README.md\ with Interpretation Guide (FAIL/WARN → cause → fix → Learn link)
- \mock_config_sample.json\ for offline testing (\-MockConfig\ + \-MockProfile\)

### Quality
- All scripts pass quality gate (50/50 Tier-2 with probes)
- Consistent output format: OK/FAIL/WARN rows + Decision block
- 48 folder references in triage map validated — zero broken links
- Customer-friendly language throughout (no internal jargon)

### How to use
Customers: open TRIAGE-MAP.md → find your symptom → run scripts in order via Azure portal Run Command.
Engineers: same flow, or use \-MockConfig\ for offline testing.