### PR TITLE
Clarify TSS Offline Log Collector run location (rescue VM / Hyper-V host)

### DIFF
--- a/RunCommand/Windows/TSSOfflineLogCollector/README_tssofflinelogcollector.md
+++ b/RunCommand/Windows/TSSOfflineLogCollector/README_tssofflinelogcollector.md
@@ -38,9 +38,12 @@ PowerShell script for rescue-VM scenarios that collects Windows troubleshooting 
 
 - PowerShell 5.1 or higher
 - **Run from an elevated (Run as administrator) PowerShell console**
-- The broken VM OS disk must already be attached to the rescue VM
+- **Run from a *working* machine — an Azure rescue VM or a Hyper-V host — not from the broken VM itself**
+- The broken VM's OS disk must already be attached to that working machine as an **offline data disk**
 
 ## Usage
+
+> **Where to run this:** Execute the script on a working host that has the broken disk attached — an Azure **rescue VM** or a **Hyper-V host** with the broken VM's OS disk mounted as an offline data disk. The script reads the broken disk offline; it is **not** run on the broken VM.
 
 From an elevated PowerShell console:
 

--- a/RunCommand/Windows/TSSOfflineLogCollector/tssofflinelogcollector.ps1
+++ b/RunCommand/Windows/TSSOfflineLogCollector/tssofflinelogcollector.ps1
@@ -1,3 +1,4 @@
+# Run from a WORKING machine (Azure rescue VM or Hyper-V host) that has the broken VM's OS disk attached as an offline data disk. Do NOT run on the broken VM.
 [CmdletBinding(SupportsShouldProcess)]
 param(
     [Parameter(Mandatory = $false)]


### PR DESCRIPTION
## Summary
Clarifies **where** the TSS Offline Log Collector must run, addressing confusion that it might run on the broken VM.

The tool runs on a **working** machine that has the broken VM's OS disk attached as an **offline data disk** \u2014 an Azure **rescue VM** or a **Hyper-V host** \u2014 not on the broken VM itself.

## Changes
- **README**: added an explicit run-location bullet under Prerequisites and a callout at the top of Usage.
- **Script**: added a one-line comment above `[CmdletBinding()]` stating the same requirement.

## Notes
Stacked on `feature/tssofflinelogcollector` (base of PR #138). Docs/comment only \u2014 no functional change.